### PR TITLE
feat: system health monitoring service (#109)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,15 @@ S3_REGION=us-east-1
 # JWT
 JWT_SECRET=dev-secret-change-in-production
 JWT_EXPIRY=24h
+
+# System health monitoring (issue #109)
+# Per-probe timeout in milliseconds; one slow component cannot stall the report.
+HEALTH_PROBE_TIMEOUT_MS=2000
+# Queue depth that flips the queues component to "degraded".
+HEALTH_QUEUE_WARN_DEPTH=10000
+# Failed-job count that flips the queues component to "degraded".
+HEALTH_QUEUE_WARN_FAILED=100
+# Postgres connection-pool usage percent that flips the database component to "degraded".
+HEALTH_DB_CONNECTION_WARN_PCT=80
+# Background monitor interval in milliseconds; default 30s.
+HEALTH_MONITOR_INTERVAL_MS=30000

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -140,3 +140,34 @@ MinIO: localhost:9000/9001        # S3-compatible storage (minioadmin/minioadmin
 - Drizzle schema exports select/insert types via drizzle-zod
 - OpenAPI spec defines Agent API contract types
 - Zod schemas provide runtime validation + static types
+
+## Design Context
+
+Design context for the React frontend lives in `.impeccable.md` at the repo root. Read it before any UI/UX work. Summary:
+
+### Users
+HashHive serves three operator roles (admins, power-users, end users), all technical security/red-team personnel running the platform in a private lab on a closed network. 1–3 concurrent dashboard users, long sessions, often viewed on a second monitor or wall display while hashcat is running on 7–10+ GPU rigs. The job is "tell me at a glance that my rigs are running and surface the moment a hash cracks."
+
+### Brand Personality
+**Operator-grade, editorial, candid.** Direct technical voice ("Queue depth 12,340 exceeds warn threshold 10,000" beats "Something's not quite right!"). Treats the user as a peer, never condescends. The dashboard reads like a well-designed data magazine, not a SaaS template. Emotional register: **dramatic ops theater** — pit-wall HUD / NOC display, big numbers when earned, motion when *the system* moves, never when chrome moves.
+
+### Aesthetic Direction
+**Dark-only Catppuccin Macchiato** (locked via `<html class="dark">` and `color-scheme: dark`; no light mode exists). Peach `#f5a97f` is the brand primary. The full Catppuccin accent range is available for **editorial use** — per-attack-mode chunking, graph series in lavender → sapphire → sky → teal → green sequence, domain accents — not just status. Status colors (green/yellow/red) stay reserved for actual status. Typography: Space Grotesk + Space Mono. Motion: compositor-friendly, ease-out-exponential, reserved for operator moments.
+
+### Anti-References (explicit rejection list)
+The following aesthetic lanes are **rejected**:
+- NOT generic SaaS dashboard (no Linear/Vercel/Stripe reflex, no gradient hero metrics, no cards-on-cards)
+- NOT enterprise security tool (no navy + gold, no Splunk/Tenable density)
+- NOT hacker theater (no Matrix green-on-black, no skull icons, no fake-leet typography)
+- NOT neon crypto dashboard (no glassmorphism, no neon gradients, no Coinbase Pro vibe)
+
+If a design choice could be guessed from "password-cracking platform" alone, rework it.
+
+### Design Principles
+1. **Theater earns its place.** Motion is reserved for operator moments (crack, transition, completion), never for chrome.
+2. **Editorial color, never neon noise.** Catppuccin's full range is for chunking and series; semantic green/yellow/red is reserved for status.
+3. **Every signal pairs with a non-color cue.** Status = color + icon + label. Survives color-blind operators and grayscale screenshots.
+4. **Keyboard is a first-class peer of mouse.** Visible focus rings, logical tab order, kbd hints on frequent actions, reduced-motion respected.
+5. **No category reflexes.** SaaS-cream, enterprise-navy, hacker-green, crypto-neon are all explicit anti-references.
+
+For full context, principles, and locked tokens, read `.impeccable.md`.

--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,6 @@ CLAUDE.md
 .claude/
 .cursor/
 .codex/
-.impeccable.md
 .kiro/hooks/
 .kiro/specs/mern-migration/.config.kiro
 .augment/

--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,0 +1,94 @@
+# HashHive Design Context
+
+This file is the source of truth for design decisions on the HashHive frontend. It is read by `/impeccable:*` skills and any agent working on UI surfaces.
+
+## Design Context
+
+### Users
+
+HashHive serves three operator roles, all of them technical security/red-team personnel running the platform in a private lab on a closed network:
+
+- **Admins** — global system + user + project management. Power-tools posture, expects to see everything.
+- **Power-users** — project-level admins running campaigns across 7–10+ GPU rigs (~25× RTX 4090 capacity). Day-to-day operators. Comfortable with hashcat command surface, attack modes, mask languages, rule files. They do NOT need hand-holding.
+- **End users** — campaign creators and result reviewers. Less infrastructure-savvy than power-users, but still technical.
+
+**Operator context**: 1–3 concurrent dashboard users on the LAN. Long-running sessions (hours to days). Operators glance at the dashboard *while* hashcat is running on the rigs — the dashboard is a status surface and a control plane, not a destination. Often viewed on second monitors or a wall display.
+
+**The job to be done**: "Tell me, at a glance, that my rigs are running, my campaigns are progressing, and surface the moment a hash cracks." Plus: "When something is wrong (rig offline, queue backed up, MinIO slow), make it impossible to miss."
+
+### Brand Personality
+
+**Three words: operator-grade, editorial, candid.**
+
+- *Operator-grade* — built for people who know what they're doing. Dense by default, no condescending empty states, no marketing tone. Treats the user as a peer.
+- *Editorial* — typography-forward, intentional typography hierarchy (Space Grotesk display + Space Mono for hashes/IDs/output), editorial use of color rather than UI-kit reflex. The dashboard reads like a well-designed data magazine, not a SaaS template.
+- *Candid* — when things are broken, the UI says so. When a hash cracks, the UI celebrates. No fake-positive empty states, no aspirational charts, no marketing voice anywhere.
+
+**Voice**: Direct, technical, no jargon-cheating. "Queue depth 12,340 exceeds warn threshold 10,000" beats "Something's not quite right!" Operators read the message text and trust it.
+
+**Emotional goal**: **Dramatic ops theater** — the dashboard should feel like a pit-wall HUD or NOC display. Big numbers when they earn their size. Motion when *the system* moves, not when the chrome moves. The moment of a successful crack is acknowledged. The moment a rig goes offline is unmissable. Everything between is calm, dense, and trustworthy.
+
+### Aesthetic Direction
+
+**Theme**: Dark only. Locked via `<html class="dark">` and `color-scheme: dark`. There is no light mode. Operators run this in dim labs, on second monitors, often at 2 AM. Light mode would be wrong for the scene.
+
+**Palette**: Catppuccin Macchiato is the locked palette. Surface hierarchy crust → mantle → base → surface0/1/2 maps to depth. The full Catppuccin accent range (lavender, blue, sapphire, sky, teal, green, yellow, peach, maroon, red, mauve, pink, flamingo, rosewater) is **available for editorial use**, not just semantic status. Peach (`#f5a97f`) is the brand primary.
+
+**Color strategy**: **Editorial / data-rich** (Committed register on the impeccable color-strategy axis). The Catppuccin range is treated as an editorial palette: per-attack-mode colors for chunking, graph series in the lavender → sapphire → sky → teal → green sequence, domain accents. Semantic status (green/yellow/red) still uses the same tokens but in their semantic role. The default surface is tinted neutrals; color appears with intent.
+
+**Typography**: Space Grotesk (300–700) for everything except code, hashes, IDs, raw hashcat output, and probe detail dumps — those use Space Mono. Body line-height 1.6 (slightly looser for light-on-dark readability). Hierarchy via scale + weight contrast (≥1.25 ratio). Tabular numerals for stats.
+
+**Motion**: Compositor-friendly only (transform, opacity, clip-path). Ease-out exponential curves. **Reserved for operator moments**, not chrome:
+- A hash cracks → the result row arrives with a brief reveal.
+- A rig transitions online → the agent indicator pulses once.
+- A campaign completes → the campaign card acknowledges it.
+- Status dots pulse on degraded/unhealthy (already implemented, motion-reduce-aware).
+
+**No motion for**: page transitions, button presses, hover effects, loading skeletons (those use opacity-only fades).
+
+**Reference posture**: Imagine a Formula 1 pit-wall HUD redrawn by someone who cares about typography, with the discipline of Bloomberg Terminal and the warmth of Catppuccin. Or: hashtopolis if it had been designed by the team behind Linear and ported to a dark editorial palette.
+
+### Anti-References (explicit rejection list)
+
+The user has explicitly rejected ALL of these aesthetic lanes — they are reflex traps for password-cracking / security tooling:
+
+- **NOT generic SaaS dashboard** — no cards-on-cards, no gradient hero metric, no cream backgrounds, no "I cost $25/seat" Linear/Vercel/Stripe reflex, no illustrated empty states, no marketing voice anywhere.
+- **NOT enterprise security tool** — no navy + gold, no Splunk/Tenable/Cisco vibe, no compliance-software density, no '$80k/seat' aesthetic.
+- **NOT hacker theater** — no Matrix green-on-black, no scrolling terminal effects, no skull icons, no fake-leet typography, no "look I'm hacking" cosplay.
+- **NOT neon crypto dashboard** — no glassmorphism, no neon gradients on black, no Coinbase Pro / Binance reflex, no animated number tickers as decoration, no RGB underglow, no web3 anything.
+
+Whenever a design choice could be guessed from "password-cracking platform" alone (`green-on-black`, `skull-icon`, `hash-as-decoration`), reject it. The honest answer is editorial-warm dark with Catppuccin's peach/lavender/sapphire range — distinct from every saturated category lane.
+
+### Design Principles
+
+These five rules govern every design decision on HashHive. When a pattern conflicts with a principle, the principle wins.
+
+1. **Theater earns its place.** Motion and spectacle are reserved for genuine operator moments — a hash cracks, an agent transitions, a campaign completes. Never for chrome (page loads, hovers, button presses). If you're animating because the page felt empty, remove the animation, not the emptiness.
+
+2. **Editorial color, never neon noise.** Use Catppuccin's full range for chunking domains, encoding attack modes, and series in data viz. Reserve green/yellow/red for actual semantic status. A "gradient because it looks cool" is wrong; a "lavender header on the campaigns section because it's the campaign domain color" is right.
+
+3. **Every signal pairs with a non-color cue.** Status = color **plus** icon **plus** label, never color alone. A degraded queue is a yellow dot **and** a warning glyph **and** the message "queue depth 12,340 exceeds 10,000." Survives color-blind operators, grayscale screenshots, and prefers-contrast settings.
+
+4. **Keyboard is a first-class peer of mouse.** Visible focus rings (peach, 2px, offset 2px — already wired in `:focus-visible`). Logical tab order. Frequent operator actions surface a `kbd` hint inline (refresh, switch project, jump to agents). Reduced-motion users see no spinning loaders, no slide transitions, no auto-scroll.
+
+5. **No category reflexes.** SaaS-cream, enterprise-navy, hacker-green, crypto-neon are all explicit anti-references. When a design could be guessed from "security tool" or "GPU dashboard" alone, rework it until the answer isn't obvious from the category. The first reflex is wrong; usually the second one is too.
+
+---
+
+## Locked Stack & Tokens
+
+These are not design decisions to revisit — they're constraints already wired into the codebase.
+
+- **Theme**: dark-only Catppuccin Macchiato (`<html class="dark">`, `color-scheme: dark` in `index.html` and `index.css`).
+- **Tokens**: `packages/frontend/src/index.css` defines the full token system — surfaces, text hierarchy, semantic colors, full Catppuccin accent palette, typography vars. New design work uses these tokens, doesn't redefine them.
+- **Type**: Space Grotesk (`--font-sans`) + Space Mono (`--font-mono`), loaded from Google Fonts in `index.html`.
+- **Components**: shadcn/ui base in `src/components/ui/`, feature components in `src/components/features/`. Lucide React for icons.
+- **Logo**: `src/assets/logo.svg` — hexagonal honeycomb cluster with peach lock. Don't redesign without explicit ask.
+- **Existing surfaces**: Dashboard, agents (list + detail), campaigns (list + detail + create), templates, hash lists, results, resources, crackers, account, login, select-project. Plus `SystemHealthCard`, `ConnectionIndicator`, `StatCard`, `StatusBadge`, sidebar, layout.
+
+## How to use this file
+
+- Any `/impeccable:*` invocation reads this on startup. Don't rebuild context from the original prompt alone.
+- `/impeccable shape` and `/impeccable craft` use the Design Principles to constrain output.
+- `/impeccable critique` and `/impeccable audit` measure new work *against* this file.
+- If a design choice contradicts something here, surface the contradiction explicitly before proceeding — don't silently override.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ This file provides AI coding assistants with project context. All substantive do
 - **[Development Setup](./docs/development.md)** -- environment, commands, infrastructure services, environment variables
 - **[Testing](./docs/testing.md)** -- test strategy, bun:test patterns, mock patterns, frontend test utilities
 - **[Known Gotchas](./GOTCHAS.md)** -- hard-won lessons by domain (TypeScript strict mode, Hono, Drizzle, BetterAuth, bun:test, frontend JSX)
+- **[Frontend Design Context](./.impeccable.md)** -- users, brand personality, aesthetic direction, anti-references, and the five design principles every UI surface must follow. Read before any frontend visual work.
 
 ## API Surfaces
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,16 @@ Users issue and rotate Control API keys from the dashboard Account page (`/accou
 - Prefer mermaid diagrams for architectural or sequence diagrams in documentation.
 - Agents (hashcat workers) are the primary API consumer. Never break the agent API to improve the dashboard experience.
 
+## Validation Gates (MANDATORY)
+
+Two gates protect the codebase from drifting red. Both are non-negotiable; if either fails, fix the failures before proceeding -- do not commit a red tree, do not open a PR with failures, and do not ask the human for permission to skip the gate.
+
+- **After completing any change task, you MUST run `just check`.** This runs format, lint, type-check, and build. It is the fast quality gate (typically <30s) and catches the majority of drift before it lands. Run it after every meaningful change, not just at the end of a session.
+- **Before committing, you MUST run `just ci-check`.** This runs the full test suite on top of `just check` and is what CI runs. Local `just ci-check` green is the contract; if it fails locally it will fail in CI.
+- **If either command fails, you fix it and rerun until green.** This includes test failures you didn't expect, lint findings on adjacent code the formatter touched, and type errors surfaced by upstream dependency changes. The standard is "green at commit time", not "green on the change you intended to make".
+
+Recipes that wrap individual concerns (`just test-frontend`, `just type-check`, etc.) are useful for iterating on a specific failure but never substitute for the two gates above.
+
 ## Agent Rules <!-- tessl-managed -->
 
 @.tessl/RULES.md follow the [instructions](.tessl/RULES.md)

--- a/GOTCHAS.md
+++ b/GOTCHAS.md
@@ -29,6 +29,10 @@ Read the relevant section before working in that area. See also [ARCHITECTURE.md
 
 - **Never leak internal errors to clients**: The global `app.onError()` handler must NOT send `err.message` in any environment (including dev) — Drizzle errors include full SQL queries with table names and column names. Always return a generic message and log the full error server-side.
 
+- **Use `Context<AppEnv>` for handler/helper signatures, never `Parameters<typeof Hono.prototype.get>[1]`**: The `Parameters<...>` form fails under TS strict mode (`Property 'get' does not exist on type 'never'`). Import `Context` from `hono` directly: `function helper(c: Context<AppEnv>)`.
+
+- **Zod v3 vs v4 at the `@hono/zod-validator` hook boundary**: v0.7 emits `$ZodError` (zod v4 core) on validation failure, but local helpers like `mapZodError` are typed against `z.ZodError` from zod v3. Runtime `issues[]` shape matches; cast through `unknown` (`mapZodError(result.error as z.ZodError)`) at the hook boundary, not at every call site.
+
 ## Drizzle ORM
 
 - **`db.execute(sql`...`)` returns array-like result** — access rows as `result[0]`, not `result.rows[0]`
@@ -69,6 +73,7 @@ Read the relevant section before working in that area. See also [ARCHITECTURE.md
 - **Shared module cache gotcha**: `mock.module` **merges** mock exports into the real module's ESM namespace — non-mocked exports pass through, but mocked ones (e.g., `resolveGenerationStrategy: mock()`) silently replace the real function for ALL test files in the same run. Never mock individual exports of a module unless every consumer in every test file can tolerate the mock.
 - **Flaky module cache**: Tests relying on `mock.module` can pass in isolation but fail in the full suite non-deterministically. If a test fails in `bun --filter @hashhive/backend test` but passes alone, re-run the full suite once before debugging — bun's module evaluation order across files is not guaranteed.
 - **Separate test files for conflicting mocks**: If a module is already imported at top level in one test file (e.g., `resolveGenerationStrategy` in `campaigns.test.ts`), tests needing full module mocks for the same source must go in a separate test file to avoid import-order conflicts.
+- **Isolated-phase pattern for files needing exclusive `mock.module` ownership**: `mock.module` runs at module load (before `describe.skip` can suppress it) and persists process-wide. Wrap the entire file body in `if (IS_ISOLATED) { ... }` and use `require('../../src/...')` inside to defer ESM resolution past the mocks. Gate via env var (e.g. `CONTROL_RBAC_TEST_ISOLATED=1`) wired through `package.json`'s test script as a separate phase. Existing examples: `tasks.test.ts`, `queue-manager.test.ts`, `control-routes-rbac.test.ts`.
 
 **Mock Patterns:**
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,5 @@
+redactions = [ "*_SECRET", "*_KEY", "*_PASSWORD" ]
+
 # Many tools are set to "latest" to take advantage of idiomatic version files, which will automatically update the tool to the latest version when the version file is updated. This allows us to keep our tools up to date without having to manually update the version in this configuration file.
 [tools]
 biome             = "2.4.14"
@@ -24,3 +26,7 @@ package_manager = "bun"
 
 [settings.pipx]
 uvx = true
+
+[env]
+ECC_DISABLED_HOOKS = "pre:bash:gateguard-fact-force"
+_.file             = [ '.env', ".env.local" ]

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -10,7 +10,7 @@
     "start": "bun dist/index.js",
     "worker:tasks": "bun src/worker-task-generation.ts",
     "worker:jobs": "bun src/worker-jobs.ts",
-    "test": "TASKS_TEST_ISOLATED=1 bun test --preload ./tests/preload.ts tests/unit/tasks.test.ts && QUEUE_MANAGER_TEST_ISOLATED=1 bun test --preload ./tests/preload.ts tests/unit/queue-manager.test.ts && CONTROL_RBAC_TEST_ISOLATED=1 bun test --preload ./tests/preload.ts tests/unit/control-routes-rbac.test.ts && bun test --preload ./tests/preload.ts",
+    "test": "TASKS_TEST_ISOLATED=1 bun test --preload ./tests/preload.ts tests/unit/tasks.test.ts && QUEUE_MANAGER_TEST_ISOLATED=1 bun test --preload ./tests/preload.ts tests/unit/queue-manager.test.ts && CONTROL_RBAC_TEST_ISOLATED=1 bun test --preload ./tests/preload.ts tests/unit/control-routes-rbac.test.ts && HEALTH_DETERMINISTIC_TEST_ISOLATED=1 bun test --preload ./tests/preload.ts tests/integration/health-deterministic.test.ts && bun test --preload ./tests/preload.ts",
     "lint": "biome check ./src",
     "type-check": "tsc --noEmit",
     "db:generate": "drizzle-kit generate",

--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -25,6 +25,13 @@ const envSchema = z.object({
   // BetterAuth (generate with: openssl rand -base64 32)
   BETTER_AUTH_SECRET: z.string().min(32),
   BETTER_AUTH_URL: z.string().url().optional(),
+
+  // System health monitoring (issue #109)
+  HEALTH_PROBE_TIMEOUT_MS: z.coerce.number().int().positive().default(2000),
+  HEALTH_QUEUE_WARN_DEPTH: z.coerce.number().int().nonnegative().default(10_000),
+  HEALTH_QUEUE_WARN_FAILED: z.coerce.number().int().nonnegative().default(100),
+  HEALTH_DB_CONNECTION_WARN_PCT: z.coerce.number().min(0).max(100).default(80),
+  HEALTH_MONITOR_INTERVAL_MS: z.coerce.number().int().positive().default(30_000),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/packages/backend/src/config/queue.ts
+++ b/packages/backend/src/config/queue.ts
@@ -8,6 +8,7 @@ export const QUEUE_NAMES = {
   HASH_LIST_PARSING: 'jobs-hash-list-parsing',
   TASK_GENERATION: 'jobs-task-generation',
   HEARTBEAT_MONITOR: 'jobs-heartbeat-monitor',
+  HEALTH_MONITOR: 'jobs-health-monitor',
 } as const;
 
 export type QueueName = (typeof QUEUE_NAMES)[keyof typeof QUEUE_NAMES];

--- a/packages/backend/src/config/storage.ts
+++ b/packages/backend/src/config/storage.ts
@@ -80,12 +80,15 @@ export async function getPresignedUrl(
   );
 }
 
-export async function checkMinioHealth(): Promise<{
+export async function checkMinioHealth(signal?: AbortSignal): Promise<{
   status: 'connected' | 'disconnected';
   bucket: string;
 }> {
   try {
-    await s3.send(new HeadBucketCommand({ Bucket: env.S3_BUCKET }));
+    // Only attach `abortSignal` when actually provided —
+    // exactOptionalPropertyTypes refuses `{ abortSignal: undefined }`.
+    const opts = signal ? { abortSignal: signal } : undefined;
+    await s3.send(new HeadBucketCommand({ Bucket: env.S3_BUCKET }), opts);
     return { status: 'connected', bucket: env.S3_BUCKET };
   } catch {
     return { status: 'disconnected', bucket: env.S3_BUCKET };

--- a/packages/backend/src/config/storage.ts
+++ b/packages/backend/src/config/storage.ts
@@ -12,6 +12,7 @@ import {
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { env } from './env.js';
+import { logger } from './logger.js';
 
 export const s3 = new S3Client({
   endpoint: env.S3_ENDPOINT,
@@ -90,7 +91,16 @@ export async function checkMinioHealth(signal?: AbortSignal): Promise<{
     const opts = signal ? { abortSignal: signal } : undefined;
     await s3.send(new HeadBucketCommand({ Bucket: env.S3_BUCKET }), opts);
     return { status: 'connected', bucket: env.S3_BUCKET };
-  } catch {
+  } catch (err) {
+    // Suppress noisy timeout aborts (the probe wrapper already logs and
+    // marks the component unhealthy). Log everything else server-side
+    // so a persistent S3/auth/bucket regression is visible in
+    // production logs, not silently masked behind a 'disconnected'
+    // reading.
+    const isAbort = err instanceof Error && err.name === 'AbortError';
+    if (!isAbort) {
+      logger.warn({ err, bucket: env.S3_BUCKET }, 'minio health check failed');
+    }
     return { status: 'disconnected', bucket: env.S3_BUCKET };
   }
 }

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,12 +1,9 @@
-import { sql } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { createBunWebSocket } from 'hono/bun';
 import { cors } from 'hono/cors';
 import { HTTPException } from 'hono/http-exception';
 import { env } from './config/env.js';
 import { logger } from './config/logger.js';
-import { checkMinioHealth } from './config/storage.js';
-import { db } from './db/index.js';
 import { auth } from './lib/auth.js';
 import { requestId } from './middleware/request-id.js';
 import { requestLogger } from './middleware/request-logger.js';
@@ -22,11 +19,13 @@ import { campaignRoutes } from './routes/dashboard/campaigns.js';
 import { crackerRoutes } from './routes/dashboard/crackers.js';
 import { createEventRoutes } from './routes/dashboard/events.js';
 import { hashRoutes } from './routes/dashboard/hashes.js';
+import { healthRoutes as dashboardHealthRoutes } from './routes/dashboard/health.js';
 import { projectRoutes } from './routes/dashboard/projects.js';
 import { resourceRoutes } from './routes/dashboard/resources.js';
 import { resultsRoutes } from './routes/dashboard/results.js';
 import { statsRoutes } from './routes/dashboard/stats.js';
 import { taskRoutes } from './routes/dashboard/tasks.js';
+import { getSystemHealth, legacyPublicEnvelope } from './services/health.js';
 import type { AppEnv } from './types.js';
 
 const { upgradeWebSocket, websocket } = createBunWebSocket();
@@ -48,40 +47,19 @@ app.use(
 );
 
 // ─── Health Check ───────────────────────────────────────────────────
+//
+// Public, unauthenticated endpoint used by load balancers. Delegates to
+// the centralized health service (issue #109) but keeps the legacy
+// envelope shape so older probes that read services.{database,redis,
+// minio}.status keep working. HTTP 503 fires only when the system is
+// unhealthy; degraded queues stay 200 so we don't flap LB rotation on
+// transient warnings.
 
 app.get('/health', async (c) => {
-  const qm = getQueueManager();
-  let dbCheck: Promise<{ status: 'connected' | 'disconnected' }>;
-  try {
-    dbCheck = db
-      .execute(sql`SELECT 1`)
-      .then(() => ({ status: 'connected' as const }))
-      .catch(() => ({ status: 'disconnected' as const }));
-  } catch {
-    dbCheck = Promise.resolve({ status: 'disconnected' as const });
-  }
-
-  const [databaseHealth, redisHealth, minioHealth] = await Promise.all([
-    dbCheck,
-    qm ? qm.getHealth() : Promise.resolve({ status: 'disconnected' as const, queues: {} }),
-    checkMinioHealth(),
-  ]);
-
-  const allConnected =
-    databaseHealth.status === 'connected' &&
-    redisHealth.status === 'connected' &&
-    minioHealth.status === 'connected';
-
-  return c.json({
-    status: allConnected ? 'ok' : 'degraded',
-    timestamp: new Date().toISOString(),
-    version: '1.0.0',
-    services: {
-      database: databaseHealth,
-      redis: redisHealth,
-      minio: minioHealth,
-    },
-  });
+  const health = await getSystemHealth();
+  const envelope = legacyPublicEnvelope(health);
+  const httpStatus = health.status === 'unhealthy' ? 503 : 200;
+  return c.json(envelope, httpStatus);
 });
 
 // ─── BetterAuth Handler ──────────────────────────────────────────────
@@ -112,6 +90,7 @@ app.route('/api/v1/dashboard/stats', statsRoutes);
 app.route('/api/v1/dashboard/results', resultsRoutes);
 app.route('/api/v1/dashboard/events', eventRoutes);
 app.route('/api/v1/dashboard/crackers', crackerRoutes);
+app.route('/api/v1/dashboard/health', dashboardHealthRoutes);
 
 app.route('/api/v1/agent', agentRoutes);
 app.route('/api/v1/control', controlRoutes);

--- a/packages/backend/src/queue/manager.ts
+++ b/packages/backend/src/queue/manager.ts
@@ -108,9 +108,9 @@ export class QueueManager {
 
   /**
    * Returns the Redis connection status without iterating every queue.
-   * Used by the system-health probe (issue #109) to avoid the duplicate
-   * qm.getHealth() round-trip that probeRedis would otherwise pay alongside
-   * probeQueues — see C4 in the code review.
+   * Used by the system-health probe (issue #109) so probeRedis and
+   * probeQueues don't both call the heavier qm.getHealth() and double
+   * the Redis round-trips per health request.
    */
   getRedisStatus(): 'connected' | 'disconnected' {
     return getRedisStatus(this.connection);

--- a/packages/backend/src/queue/manager.ts
+++ b/packages/backend/src/queue/manager.ts
@@ -1,5 +1,6 @@
 import { type ConnectionOptions, Queue } from 'bullmq';
 import type Redis from 'ioredis';
+import { env } from '../config/env.js';
 import { logger } from '../config/logger.js';
 import { QUEUE_NAMES, type QueueName } from '../config/queue.js';
 import { createRedisClient, getRedisStatus } from '../config/redis.js';
@@ -68,6 +69,16 @@ export class QueueManager {
       );
     }
 
+    // Schedule repeatable health monitor (issue #109).
+    const healthQueue = this.queues.get(QUEUE_NAMES.HEALTH_MONITOR);
+    if (healthQueue) {
+      await healthQueue.upsertJobScheduler(
+        'health-check',
+        { every: env.HEALTH_MONITOR_INTERVAL_MS },
+        { data: { triggeredAt: new Date().toISOString() } }
+      );
+    }
+
     logger.info('Queue manager initialized');
   }
 
@@ -93,6 +104,16 @@ export class QueueManager {
       logger.error({ err, queueName }, 'Failed to enqueue job');
       return false;
     }
+  }
+
+  /**
+   * Returns the Redis connection status without iterating every queue.
+   * Used by the system-health probe (issue #109) to avoid the duplicate
+   * qm.getHealth() round-trip that probeRedis would otherwise pay alongside
+   * probeQueues — see C4 in the code review.
+   */
+  getRedisStatus(): 'connected' | 'disconnected' {
+    return getRedisStatus(this.connection);
   }
 
   async getHealth(): Promise<QueueHealth> {

--- a/packages/backend/src/queue/types.ts
+++ b/packages/backend/src/queue/types.ts
@@ -28,6 +28,10 @@ export interface HeartbeatMonitorJob {
   triggeredAt: string;
 }
 
+export interface HealthMonitorJob {
+  triggeredAt: string;
+}
+
 // ─── Job Data Discriminated Union ────────────────────────────────────
 
 export type QueueJobMap = {
@@ -40,4 +44,5 @@ export type QueueJobMap = {
   [QUEUE_NAMES.HASH_LIST_PARSING]: HashListParseJob;
   [QUEUE_NAMES.TASK_GENERATION]: TaskGenerationJob;
   [QUEUE_NAMES.HEARTBEAT_MONITOR]: HeartbeatMonitorJob;
+  [QUEUE_NAMES.HEALTH_MONITOR]: HealthMonitorJob;
 };

--- a/packages/backend/src/queue/workers/health-monitor.ts
+++ b/packages/backend/src/queue/workers/health-monitor.ts
@@ -87,9 +87,10 @@ export async function runHealthMonitorTick(
   try {
     report = await deps.fetchHealth();
   } catch (err) {
-    // getSystemHealth() should not throw — every probe coerces errors to
-    // unhealthy. But if it does, swallow here so BullMQ doesn't flood
-    // the failed-jobs metric. The next tick gets a fresh shot.
+    // Defensive: every current probe coerces errors to unhealthy, but a
+    // future probe could throw. Swallow here so a single bad tick
+    // doesn't flood BullMQ's failed-jobs metric. The next tick gets a
+    // fresh shot.
     logger.error({ err }, 'health monitor: getSystemHealth threw — skipping tick');
     return { transitioned: [], initialized: [], unchanged: [] };
   }

--- a/packages/backend/src/queue/workers/health-monitor.ts
+++ b/packages/backend/src/queue/workers/health-monitor.ts
@@ -1,0 +1,203 @@
+/**
+ * Scheduled health-monitor worker (issue #109).
+ *
+ * Runs `getSystemHealth()` every HEALTH_MONITOR_INTERVAL_MS and broadcasts
+ * a `system_health` WebSocket event for each component whose status flipped
+ * since the last run.
+ *
+ * Last-known-state is held in-memory (primary) and mirrored to Redis with
+ * a 24h TTL (backup). This split matters when Redis itself is the failing
+ * component: an in-memory cache survives a Redis outage so the
+ * healthy → unhealthy → healthy round-trip still emits both transitions.
+ * If we relied on Redis alone, a Redis-down probe would (a) fail to read
+ * prior state → seen as first-tick (no broadcast), then (b) fail to write
+ * "unhealthy" → cache stays stale, then (c) on recovery, current=healthy
+ * == last=healthy → no recovery broadcast either. The full down/up cycle
+ * would be silent.
+ *
+ * Redis is still mirrored so a fresh worker boot has a starting point
+ * (avoids emitting a bogus "all green just transitioned" volley after a
+ * restart). On boot the in-memory cache is empty; the first tick reads
+ * Redis to seed it, then operates from memory thereafter.
+ *
+ * Logging happens every tick (so degradations are grep-able even without
+ * a transition); broadcasts happen only on transition (so the WS channel
+ * doesn't see noise on every poll).
+ */
+
+import { type ConnectionOptions, Worker } from 'bullmq';
+import type Redis from 'ioredis';
+import { logger } from '../../config/logger.js';
+import { QUEUE_NAMES } from '../../config/queue.js';
+import { broadcastSystemHealth } from '../../services/events.js';
+import {
+  type ComponentHealth,
+  type ComponentName,
+  type ComponentStatus,
+  getSystemHealth,
+} from '../../services/health.js';
+import type { HealthMonitorJob } from '../types.js';
+
+const COMPONENTS: ComponentName[] = ['database', 'redis', 'minio', 'queues'];
+const REDIS_KEY_PREFIX = 'health:last-status:';
+const REDIS_KEY_TTL_SEC = 24 * 60 * 60;
+
+export interface HealthMonitorDeps {
+  /**
+   * Reads in-memory last-known-status for the component. Returns null
+   * only on a fresh-boot tick before Redis is queried.
+   */
+  readMemoryStatus: (component: ComponentName) => ComponentStatus | null;
+  /** Writes the new status to in-memory cache. */
+  writeMemoryStatus: (component: ComponentName, status: ComponentStatus) => void;
+  /**
+   * Reads the Redis-backed status. Used only when in-memory has no prior
+   * state for a component (post-boot seeding). Failure returns null, which
+   * is the same as no prior state.
+   */
+  readRedisStatus: (component: ComponentName) => Promise<ComponentStatus | null>;
+  /**
+   * Best-effort write to Redis. Failure is logged but never propagates —
+   * the in-memory cache is authoritative for transition detection.
+   */
+  writeRedisStatus: (component: ComponentName, status: ComponentStatus) => Promise<void>;
+  /** Reports a component status transition to subscribed clients. */
+  broadcast: (component: ComponentName, status: ComponentStatus, message?: string) => void;
+  /** Produces the current SystemHealth report. */
+  fetchHealth: () => Promise<{ components: Record<ComponentName, ComponentHealth> }>;
+}
+
+export interface HealthMonitorTickResult {
+  /** Components whose status flipped this tick (broadcasts emitted). */
+  transitioned: ComponentName[];
+  /** Components seen for the first time since worker start (no broadcast). */
+  initialized: ComponentName[];
+  /** Components whose status was unchanged. */
+  unchanged: ComponentName[];
+}
+
+/**
+ * Single tick of the monitor. Pure with respect to its `deps` so tests
+ * can drive it deterministically without BullMQ or Redis.
+ */
+export async function runHealthMonitorTick(
+  deps: HealthMonitorDeps
+): Promise<HealthMonitorTickResult> {
+  let report: { components: Record<ComponentName, ComponentHealth> };
+  try {
+    report = await deps.fetchHealth();
+  } catch (err) {
+    // getSystemHealth() should not throw — every probe coerces errors to
+    // unhealthy. But if it does, swallow here so BullMQ doesn't flood
+    // the failed-jobs metric. The next tick gets a fresh shot.
+    logger.error({ err }, 'health monitor: getSystemHealth threw — skipping tick');
+    return { transitioned: [], initialized: [], unchanged: [] };
+  }
+
+  const result: HealthMonitorTickResult = { transitioned: [], initialized: [], unchanged: [] };
+
+  for (const component of COMPONENTS) {
+    const current = report.components[component];
+
+    // In-memory is authoritative for transition detection. Only fall
+    // through to Redis on a cache miss (post-boot first tick for this
+    // component) so the worker survives Redis outages without losing
+    // transition signal — see the module docstring for the failure
+    // mode this is guarding against.
+    let last: ComponentStatus | null = deps.readMemoryStatus(component);
+    if (last === null) {
+      try {
+        last = await deps.readRedisStatus(component);
+      } catch (err) {
+        logger.warn({ err, component }, 'health monitor: failed to seed status from Redis');
+      }
+    }
+
+    if (last === null) {
+      result.initialized.push(component);
+    } else if (last !== current.status) {
+      result.transitioned.push(component);
+      try {
+        deps.broadcast(component, current.status, current.message);
+      } catch (err) {
+        logger.error({ err, component }, 'health monitor: broadcast failed');
+      }
+    } else {
+      result.unchanged.push(component);
+    }
+
+    // Update in-memory first (always succeeds; authoritative).
+    deps.writeMemoryStatus(component, current.status);
+    // Best-effort Redis mirror so the next worker boot has prior state.
+    try {
+      await deps.writeRedisStatus(component, current.status);
+    } catch (err) {
+      logger.warn({ err, component }, 'health monitor: failed to mirror status to Redis');
+    }
+  }
+
+  // Always log a structured summary so degraded states are grep-able
+  // even without a transition.
+  const componentSummary = Object.fromEntries(
+    Object.entries(report.components).map(([k, v]) => [k, v.status])
+  );
+  logger.info(
+    {
+      transitioned: result.transitioned,
+      initialized: result.initialized,
+      components: componentSummary,
+    },
+    'health monitor tick'
+  );
+
+  return result;
+}
+
+/**
+ * Builds production deps: in-memory cache + Redis backup + WS broadcast.
+ * The memoryCache is captured in the closure so each worker invocation
+ * shares the same cache across ticks.
+ */
+function buildProductionDeps(connection: Redis): HealthMonitorDeps {
+  const memoryCache = new Map<ComponentName, ComponentStatus>();
+  return {
+    readMemoryStatus: (component) => memoryCache.get(component) ?? null,
+    writeMemoryStatus: (component, status) => {
+      memoryCache.set(component, status);
+    },
+    readRedisStatus: async (component) => {
+      const value = await connection.get(`${REDIS_KEY_PREFIX}${component}`);
+      if (value === 'healthy' || value === 'degraded' || value === 'unhealthy') {
+        return value;
+      }
+      return null;
+    },
+    writeRedisStatus: async (component, status) => {
+      await connection.set(`${REDIS_KEY_PREFIX}${component}`, status, 'EX', REDIS_KEY_TTL_SEC);
+    },
+    broadcast: (component, status, message) => {
+      broadcastSystemHealth(component, status, message);
+    },
+    fetchHealth: () => getSystemHealth(),
+  };
+}
+
+export function createHealthMonitorWorker(connection: Redis): Worker<HealthMonitorJob> {
+  const deps = buildProductionDeps(connection);
+
+  const worker = new Worker<HealthMonitorJob>(
+    QUEUE_NAMES.HEALTH_MONITOR,
+    async (job) => {
+      logger.debug({ jobId: job.id, triggeredAt: job.data.triggeredAt }, 'health monitor job');
+      return runHealthMonitorTick(deps);
+    },
+    // Cast needed: our ioredis version may differ from BullMQ's bundled ioredis types
+    { connection: connection as unknown as ConnectionOptions }
+  );
+
+  worker.on('failed', (job, err) => {
+    logger.error({ jobId: job?.id, err }, 'health monitor job failed');
+  });
+
+  return worker;
+}

--- a/packages/backend/src/routes/control/health.ts
+++ b/packages/backend/src/routes/control/health.ts
@@ -1,69 +1,30 @@
 /**
  * Control API health endpoint.
  *
- * Mirrors the public `/health` endpoint but is API-key authenticated so
- * automation tooling can verify connectivity using its own credentials
- * (the public endpoint is unauthenticated for load-balancer probes).
+ * API-key authenticated mirror of the public `/health` probe. Unlike the
+ * public surface (which returns the legacy envelope and hides per-
+ * component detail), this surface returns the full SystemHealth shape
+ * including connection counts, queue depths, and probe durations — the
+ * audience here is operators with credentials, not anonymous probes.
  *
- * Probe failures are logged with the request id so a "degraded" status
- * can be tied back to a specific cause (the public endpoint silently
- * coerces every error to "disconnected" — useful for liveness checks
- * but unhelpful for ops triage).
+ * Errors during probe execution are coerced to `unhealthy` ComponentHealth
+ * inside the service, so this route does not need its own try/catch for
+ * probe failures. The outer try/catch is kept only as a defensive net for
+ * truly unexpected exceptions (e.g., Redis client throwing during
+ * iteration), which fall back to the standard Control API RFC9457 envelope.
  */
 
-import { sql } from 'drizzle-orm';
-import type { Context } from 'hono';
 import { Hono } from 'hono';
-import { logger } from '../../config/logger.js';
-import { checkMinioHealth } from '../../config/storage.js';
-import { db } from '../../db/index.js';
-import { getQueueManager } from '../../queue/context.js';
+import { getSystemHealth } from '../../services/health.js';
 import type { AppEnv } from '../../types.js';
 import { controlErrorResponse } from './helpers.js';
 
 export const controlHealthRoutes = new Hono<AppEnv>();
 
-type ProbeStatus = { status: 'connected' | 'disconnected' };
-
-function logProbeFailure(c: Context<AppEnv>, probe: string) {
-  return (err: unknown) => {
-    logger.warn({ err, probe, requestId: c.get('requestId') }, 'control health probe failed');
-    return { status: 'disconnected' as const };
-  };
-}
-
 controlHealthRoutes.get('/', async (c) => {
   try {
-    const qm = getQueueManager();
-    const dbCheck: Promise<ProbeStatus> = db
-      .execute(sql`SELECT 1`)
-      .then(() => ({ status: 'connected' as const }))
-      .catch(logProbeFailure(c, 'database'));
-    const redisCheck: Promise<{ status: 'connected' | 'disconnected'; queues?: unknown }> = qm
-      ? qm.getHealth().catch(logProbeFailure(c, 'redis'))
-      : Promise.resolve({ status: 'disconnected' as const, queues: {} });
-    const minioCheck: Promise<ProbeStatus> = checkMinioHealth().catch(logProbeFailure(c, 'minio'));
-
-    const [databaseHealth, redisHealth, minioHealth] = await Promise.all([
-      dbCheck,
-      redisCheck,
-      minioCheck,
-    ]);
-
-    const allConnected =
-      databaseHealth.status === 'connected' &&
-      redisHealth.status === 'connected' &&
-      minioHealth.status === 'connected';
-
-    return c.json({
-      status: allConnected ? 'ok' : 'degraded',
-      timestamp: new Date().toISOString(),
-      services: {
-        database: databaseHealth,
-        redis: redisHealth,
-        minio: minioHealth,
-      },
-    });
+    const health = await getSystemHealth();
+    return c.json(health);
   } catch (err) {
     return controlErrorResponse(c, err);
   }

--- a/packages/backend/src/routes/dashboard/health.ts
+++ b/packages/backend/src/routes/dashboard/health.ts
@@ -1,0 +1,24 @@
+/**
+ * Dashboard system-health endpoint (issue #109).
+ *
+ * BetterAuth-session-gated read of the unified system health report. This
+ * surface returns the full SystemHealth shape including per-component
+ * `detail`, since the audience is logged-in operators using the dashboard
+ * card. No project scoping — health is system-wide.
+ */
+
+import { Hono } from 'hono';
+import { requireSession } from '../../middleware/auth.js';
+import { getSystemHealth } from '../../services/health.js';
+import type { AppEnv } from '../../types.js';
+
+const healthRoutes = new Hono<AppEnv>();
+
+healthRoutes.use('*', requireSession);
+
+healthRoutes.get('/', async (c) => {
+  const health = await getSystemHealth();
+  return c.json(health);
+});
+
+export { healthRoutes };

--- a/packages/backend/src/services/events.ts
+++ b/packages/backend/src/services/events.ts
@@ -21,12 +21,34 @@ import { logger } from '../config/logger.js';
 
 // ─── Event Types ────────────────────────────────────────────────────
 
-export type EventType =
+/**
+ * Project-scoped event types — `emit()` filters delivery by the client's
+ * subscribed project IDs.
+ */
+export type ProjectEventType =
   | 'agent_status'
   | 'campaign_status'
   | 'task_update'
   | 'crack_result'
   | 'resource_update';
+
+/**
+ * System-wide event types — `broadcastSystemEvent()` bypasses project
+ * scoping and delivers to every subscribed client. Reserved for events
+ * that affect every operator regardless of which project they have
+ * selected (system health, future global maintenance notices, etc.).
+ */
+export type SystemEventType = 'system_health';
+
+export type EventType = ProjectEventType | SystemEventType;
+
+/**
+ * Sentinel projectId carried on AppEvent payloads for system-wide events.
+ * Chosen as `0` because Postgres project ids are positive integers, so a
+ * project-scoped consumer filtering on `event.projectId === current` will
+ * never falsely match a system event.
+ */
+export const SYSTEM_EVENT_PROJECT_ID = 0;
 
 export interface AppEvent {
   type: EventType;
@@ -43,12 +65,18 @@ interface WebSocketClient {
   subscribedTypes: Set<EventType>;
 }
 
+// MUST stay in sync with the EventType union above. There's no way to
+// derive a runtime array from a TypeScript union, so adding a new member
+// requires touching both. Any new entry here means new clients connecting
+// without `?types=` will receive the new event by default — verify that
+// is the intended behavior before adding.
 const ALL_EVENT_TYPES: EventType[] = [
   'agent_status',
   'campaign_status',
   'task_update',
   'crack_result',
   'resource_update',
+  'system_health',
 ];
 
 let clientIdCounter = 0;
@@ -84,15 +112,35 @@ export function getClientCount(): number {
 const lastEmitTimes = new Map<string, number>();
 const THROTTLE_MS = 250; // Max 4 events/sec per type+project
 
+// Throttle map maintenance: how often to prune entries that no longer
+// matter (background pulse) and what age qualifies an entry for pruning.
+// Both are 60s so the worst-case dwell of an inactive throttle key is
+// ~120s — short enough for a few hundred KB cap, long enough to absorb
+// bursts without thrashing.
+const THROTTLE_PRUNE_INTERVAL_MS = 60_000;
+const THROTTLE_ENTRY_MAX_AGE_MS = 60_000;
+
 // Periodically prune stale entries to prevent unbounded growth
 setInterval(() => {
-  const cutoff = Date.now() - 60_000; // Remove entries older than 60s
+  const cutoff = Date.now() - THROTTLE_ENTRY_MAX_AGE_MS;
   for (const [key, time] of lastEmitTimes) {
     if (time < cutoff) {
       lastEmitTimes.delete(key);
     }
   }
-}, 60_000);
+}, THROTTLE_PRUNE_INTERVAL_MS);
+
+/**
+ * Test-only: clears the module-level client registry and throttle map
+ * so each test starts from a clean slate. Production callers must not
+ * use this — clearing the client map mid-broadcast would drop active
+ * WS subscribers.
+ */
+export function __resetEventsForTesting(): void {
+  clients.clear();
+  lastEmitTimes.clear();
+  clientIdCounter = 0;
+}
 
 /**
  * Emits an event to all connected clients that are subscribed
@@ -181,5 +229,73 @@ export function emitCrackResult(projectId: number, hashListId: number, count: nu
     projectId,
     data: { hashListId, crackedCount: count },
     timestamp: new Date().toISOString(),
+  });
+}
+
+// ─── System-wide Broadcast (issue #109) ─────────────────────────────
+
+/**
+ * Broadcasts a system-wide event to every subscribed client, bypassing
+ * the project-scope filter that `emit()` applies. Still respects
+ * `subscribedTypes` so a client that opts out of `system_health` won't
+ * receive it.
+ *
+ * No throttle: system events are infrequent by design (cadence is
+ * controlled by the producer — e.g. health monitor's 30s interval —
+ * and only fires on transitions, not every tick). Throttling here
+ * would silently swallow simultaneous transitions (multiple components
+ * flipping on the same tick).
+ */
+export function broadcastSystemEvent(type: SystemEventType, data: Record<string, unknown>): void {
+  const event: AppEvent = {
+    type,
+    // SYSTEM_EVENT_PROJECT_ID sentinel: 0 is not a valid Postgres
+    // project id, so consumers that filter `event.projectId === current`
+    // (the natural pattern for project-scoped events) won't accidentally
+    // match system events. Consumers that explicitly want system events
+    // can match on `event.type` from the SystemEventType union, which is
+    // the documented contract — projectId is implementation detail.
+    projectId: SYSTEM_EVENT_PROJECT_ID,
+    data,
+    timestamp: new Date().toISOString(),
+  };
+  const payload = JSON.stringify(event);
+  let delivered = 0;
+
+  for (const [clientId, client] of clients) {
+    if (!client.subscribedTypes.has(type)) {
+      continue;
+    }
+    if (client.ws.readyState !== 1) {
+      clients.delete(clientId);
+      continue;
+    }
+    try {
+      client.ws.send(payload);
+      delivered++;
+    } catch {
+      clients.delete(clientId);
+    }
+  }
+
+  if (delivered > 0) {
+    logger.debug({ type, delivered }, 'system event broadcasted');
+  }
+}
+
+/**
+ * Convenience wrapper for issuing a `system_health` event for a single
+ * component status transition. The worker calls this once per component
+ * that flipped on a given monitor tick.
+ */
+export function broadcastSystemHealth(
+  component: string,
+  status: 'healthy' | 'degraded' | 'unhealthy',
+  message?: string
+): void {
+  broadcastSystemEvent('system_health', {
+    component,
+    status,
+    ...(message ? { message } : {}),
   });
 }

--- a/packages/backend/src/services/events.ts
+++ b/packages/backend/src/services/events.ts
@@ -57,12 +57,21 @@ export type SystemEventProjectId = typeof SYSTEM_EVENT_PROJECT_ID;
 
 /**
  * Discriminated union over event scope. Project events carry a real
- * project id; system events carry the sentinel literal. The union shape
- * means TypeScript refuses `{ type: 'agent_status', projectId: 0 }`
- * (project event with system sentinel) and `{ type: 'system_health',
- * projectId: 42 }` (system event leaking into project channel) at
- * compile time. `emit()` accepts the project arm; `broadcastSystemEvent()`
- * accepts the system arm.
+ * project id; system events carry the sentinel literal. The realistic
+ * mistake — a system event leaking into a project channel with a real
+ * project id, e.g. `{ type: 'system_health', projectId: 42 }` — is
+ * rejected at compile time because the system arm types `projectId` as
+ * the literal `0`.
+ *
+ * The inverse case (a project event constructed with the sentinel
+ * `projectId: 0`) is NOT compile-rejected: `0` is a valid `number` and
+ * the project arm types `projectId: number`. Branding `ProjectId` would
+ * close that gap but adds ceremony at every call site for marginal
+ * benefit, since every emit of a project event in this codebase passes
+ * a real id from the database.
+ *
+ * `emit()` accepts the project arm; `broadcastSystemEvent()` accepts
+ * the system arm.
  */
 export type AppEvent =
   | {

--- a/packages/backend/src/services/events.ts
+++ b/packages/backend/src/services/events.ts
@@ -45,17 +45,40 @@ export type EventType = ProjectEventType | SystemEventType;
 /**
  * Sentinel projectId carried on AppEvent payloads for system-wide events.
  * Chosen as `0` because Postgres project ids are positive integers, so a
- * project-scoped consumer filtering on `event.projectId === current` will
- * never falsely match a system event.
+ * project-scoped consumer filtering on `event.projectId === current`
+ * will never falsely match a system event.
+ *
+ * Typed as the literal `0` so AppEvent's discriminated union can refuse
+ * mismatched (type, projectId) pairs at compile time — see AppEvent
+ * below.
  */
-export const SYSTEM_EVENT_PROJECT_ID = 0;
+export const SYSTEM_EVENT_PROJECT_ID = 0 as const;
+export type SystemEventProjectId = typeof SYSTEM_EVENT_PROJECT_ID;
 
-export interface AppEvent {
-  type: EventType;
-  projectId: number;
-  data: Record<string, unknown>;
-  timestamp: string;
-}
+/**
+ * Discriminated union over event scope. Project events carry a real
+ * project id; system events carry the sentinel literal. The union shape
+ * means TypeScript refuses `{ type: 'agent_status', projectId: 0 }`
+ * (project event with system sentinel) and `{ type: 'system_health',
+ * projectId: 42 }` (system event leaking into project channel) at
+ * compile time. `emit()` accepts the project arm; `broadcastSystemEvent()`
+ * accepts the system arm.
+ */
+export type AppEvent =
+  | {
+      type: ProjectEventType;
+      projectId: number;
+      data: Record<string, unknown>;
+      timestamp: string;
+    }
+  | {
+      type: SystemEventType;
+      projectId: SystemEventProjectId;
+      data: Record<string, unknown>;
+      timestamp: string;
+    };
+
+export type ProjectAppEvent = Extract<AppEvent, { type: ProjectEventType }>;
 
 // ─── Connection Registry ────────────────────────────────────────────
 
@@ -143,10 +166,13 @@ export function __resetEventsForTesting(): void {
 }
 
 /**
- * Emits an event to all connected clients that are subscribed
- * to the event's project and type. Applies per-type throttling.
+ * Emits a project-scoped event to all connected clients that are
+ * subscribed to the event's project and type. Applies per-type
+ * throttling. System events must use `broadcastSystemEvent` instead;
+ * routing one through here would silently drop because no client has
+ * SYSTEM_EVENT_PROJECT_ID in its projectIds set.
  */
-export function emit(event: AppEvent) {
+export function emit(event: ProjectAppEvent) {
   const throttleKey = `${event.type}:${event.projectId}`;
   const now = Date.now();
   const lastEmit = lastEmitTimes.get(throttleKey) ?? 0;
@@ -179,7 +205,11 @@ export function emit(event: AppEvent) {
     try {
       client.ws.send(payload);
       delivered++;
-    } catch {
+    } catch (err) {
+      logger.warn(
+        { err, clientId, type: event.type, projectId: event.projectId },
+        'WebSocket send failed; dropping client'
+      );
       clients.delete(clientId);
     }
   }
@@ -273,7 +303,8 @@ export function broadcastSystemEvent(type: SystemEventType, data: Record<string,
     try {
       client.ws.send(payload);
       delivered++;
-    } catch {
+    } catch (err) {
+      logger.warn({ err, clientId, type }, 'WebSocket send failed; dropping client');
       clients.delete(clientId);
     }
   }

--- a/packages/backend/src/services/events.ts
+++ b/packages/backend/src/services/events.ts
@@ -1,4 +1,5 @@
 import { logger } from '../config/logger.js';
+import type { ComponentName, ComponentStatus } from './health.js';
 
 /**
  * FUTURE: Redis Pub/Sub Extension for Multi-Instance Deployments
@@ -152,8 +153,11 @@ const THROTTLE_MS = 250; // Max 4 events/sec per type+project
 const THROTTLE_PRUNE_INTERVAL_MS = 60_000;
 const THROTTLE_ENTRY_MAX_AGE_MS = 60_000;
 
-// Periodically prune stale entries to prevent unbounded growth
-setInterval(() => {
+// Periodically prune stale entries to prevent unbounded growth.
+// `.unref()` so the timer doesn't keep the event loop alive on its own —
+// a Node process with no other pending work (test teardown, graceful
+// shutdown) can exit cleanly instead of waiting for the next pulse.
+const pruneInterval = setInterval(() => {
   const cutoff = Date.now() - THROTTLE_ENTRY_MAX_AGE_MS;
   for (const [key, time] of lastEmitTimes) {
     if (time < cutoff) {
@@ -161,6 +165,7 @@ setInterval(() => {
     }
   }
 }, THROTTLE_PRUNE_INTERVAL_MS);
+pruneInterval.unref();
 
 /**
  * Test-only: clears the module-level client registry and throttle map
@@ -329,8 +334,8 @@ export function broadcastSystemEvent(type: SystemEventType, data: Record<string,
  * that flipped on a given monitor tick.
  */
 export function broadcastSystemHealth(
-  component: string,
-  status: 'healthy' | 'degraded' | 'unhealthy',
+  component: ComponentName,
+  status: ComponentStatus,
   message?: string
 ): void {
   broadcastSystemEvent('system_health', {

--- a/packages/backend/src/services/health.ts
+++ b/packages/backend/src/services/health.ts
@@ -25,12 +25,22 @@ export type ComponentStatus = 'healthy' | 'degraded' | 'unhealthy';
 
 export type ComponentName = 'database' | 'redis' | 'minio' | 'queues';
 
-export interface ComponentHealth {
-  status: ComponentStatus;
-  message?: string;
-  detail?: Record<string, unknown>;
-  durationMs: number;
-}
+/**
+ * Probe result shape without a `durationMs` field — that field is
+ * attached by the `runProbe` wrapper, never by the probe author. Split
+ * by status: a `degraded` or `unhealthy` result must carry a `message`
+ * so consumers always have a useful error string to render.
+ */
+export type ProbeResult =
+  | { status: 'healthy'; message?: string; detail?: Record<string, unknown> }
+  | { status: 'degraded' | 'unhealthy'; message: string; detail?: Record<string, unknown> };
+
+/**
+ * Full ComponentHealth — ProbeResult plus the durationMs measurement
+ * runProbe attaches. Discriminated by status so callers rendering
+ * non-healthy components get `message` typed as required.
+ */
+export type ComponentHealth = ProbeResult & { durationMs: number };
 
 export interface SystemHealth {
   status: ComponentStatus;
@@ -40,6 +50,10 @@ export interface SystemHealth {
 }
 
 export const HEALTH_VERSION = '1.0.0';
+
+// Threshold semantics for the entire module: warn comparisons use `>=`
+// (inclusive boundary). "Warn at 10000" means 10000 is already the warn
+// state. "Warn at 80%" fires when pool reaches 80%.
 
 /**
  * Aggregates per-component statuses using a worst-of rule:
@@ -61,22 +75,34 @@ export function aggregateStatus(
  */
 export async function runProbe(
   name: ComponentName,
-  probeFn: () => Promise<Omit<ComponentHealth, 'durationMs'>>,
+  probeFn: () => Promise<ProbeResult>,
   timeoutMs: number
 ): Promise<ComponentHealth> {
   const startedAt = Date.now();
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
-    const result = await Promise.race<Omit<ComponentHealth, 'durationMs'>>([
+    const result = await Promise.race<ProbeResult>([
       probeFn(),
-      new Promise<Omit<ComponentHealth, 'durationMs'>>((_, reject) => {
+      new Promise<ProbeResult>((_, reject) => {
         timer = setTimeout(() => reject(new Error('PROBE_TIMEOUT')), timeoutMs);
       }),
     ]);
     return { ...result, durationMs: Date.now() - startedAt };
   } catch (err) {
     const isTimeout = err instanceof Error && err.message === 'PROBE_TIMEOUT';
-    if (!isTimeout) {
+    // Distinguish operator-actionable infra failures (network, auth,
+    // bucket missing) from programming errors. The latter still get
+    // coerced to `unhealthy` so the report contract holds, but they
+    // should land in the `error` log channel so alerting fires — a
+    // TypeError surfacing as "database unhealthy" is a debugging trap.
+    const isProgrammingError =
+      err instanceof TypeError || err instanceof ReferenceError || err instanceof SyntaxError;
+    if (isProgrammingError) {
+      logger.error(
+        { err, probe: name },
+        'health probe threw a programming error — likely a bug, not infra'
+      );
+    } else if (!isTimeout) {
       logger.warn({ err, probe: name }, 'health probe failed');
     }
     const message = isTimeout
@@ -104,12 +130,11 @@ export interface DatabaseProbeDeps {
 export async function probeDatabase(
   deps: DatabaseProbeDeps,
   warnPct: number
-): Promise<Omit<ComponentHealth, 'durationMs'>> {
+): Promise<ProbeResult> {
   await deps.ping();
   const { used, max } = await deps.poolStats();
   const pct = max > 0 ? (used / max) * 100 : 0;
   const detail = { connectionsUsed: used, connectionsMax: max, connectionsPct: Math.round(pct) };
-  // Inclusive boundary: "warn at 80%" fires when pool is at or above 80% full.
   if (pct >= warnPct) {
     return {
       status: 'degraded',
@@ -125,9 +150,7 @@ export interface RedisProbeDeps {
   status: () => 'connected' | 'disconnected';
 }
 
-export async function probeRedis(
-  deps: RedisProbeDeps
-): Promise<Omit<ComponentHealth, 'durationMs'>> {
+export async function probeRedis(deps: RedisProbeDeps): Promise<ProbeResult> {
   if (deps.status() !== 'connected') {
     return { status: 'unhealthy', message: 'redis connection not ready' };
   }
@@ -138,9 +161,7 @@ export interface MinioProbeDeps {
   check: () => Promise<{ status: 'connected' | 'disconnected'; bucket: string }>;
 }
 
-export async function probeMinio(
-  deps: MinioProbeDeps
-): Promise<Omit<ComponentHealth, 'durationMs'>> {
+export async function probeMinio(deps: MinioProbeDeps): Promise<ProbeResult> {
   const result = await deps.check();
   if (result.status !== 'connected') {
     return {
@@ -169,7 +190,7 @@ export async function probeQueues(
   deps: QueuesProbeDeps,
   warnDepth: number,
   warnFailed: number
-): Promise<Omit<ComponentHealth, 'durationMs'>> {
+): Promise<ProbeResult> {
   const result = await deps.health();
   if (result.status !== 'connected') {
     return {
@@ -179,8 +200,6 @@ export async function probeQueues(
     };
   }
 
-  // Inclusive boundary: thresholds fire at or above the configured value
-  // ("warn at 10000" means 10000 is already in the warn state).
   const offenders: string[] = [];
   for (const [name, stats] of Object.entries(result.queues)) {
     if (stats.waiting >= warnDepth) {
@@ -205,9 +224,9 @@ export async function probeQueues(
 // ─── Default Production Wiring ──────────────────────────────────────
 
 // pg_settings.max_connections only changes on Postgres restart, so it's
-// safe to cache for the lifetime of the process. Caching it eliminates one
-// of the three sequential round-trips probeDatabase otherwise pays per
-// tick (rel-4 in code review).
+// safe to cache for the lifetime of the process. Caching it eliminates
+// one of the three sequential round-trips probeDatabase otherwise pays
+// per tick.
 let cachedMaxConnections: number | null = null;
 
 async function defaultDatabasePoolStats(): Promise<{ used: number; max: number }> {
@@ -220,8 +239,17 @@ async function defaultDatabasePoolStats(): Promise<{ used: number; max: number }
     const maxRows = (await db.execute(
       sql`SELECT setting::int AS max FROM pg_settings WHERE name = 'max_connections'`
     )) as unknown as Array<{ max: number }>;
-    max = maxRows[0]?.max ?? 1;
-    cachedMaxConnections = max;
+    const candidate = maxRows[0]?.max;
+    // Validate before caching: a Postgres misconfiguration or a future
+    // schema-change in pg_settings could return 0/NaN/non-integer; we'd
+    // poison the cache for the lifetime of the process.
+    if (typeof candidate === 'number' && Number.isInteger(candidate) && candidate > 0) {
+      cachedMaxConnections = candidate;
+      max = candidate;
+    } else {
+      logger.warn({ candidate }, 'pg_settings returned unexpected max_connections; not caching');
+      max = 1;
+    }
   }
   const used = usedRows[0]?.used ?? 0;
   return { used, max };
@@ -245,9 +273,10 @@ function buildDefaultProbes(): {
       poolStats: defaultDatabasePoolStats,
     },
     redis: {
-      // Cheap status check via QueueManager's connection — no queue iteration.
-      // Fixes C4: previously this called qm.getHealth() which the queues probe
-      // already runs, doubling Redis round-trips per health request.
+      // Cheap status check via QueueManager's connection — no queue
+      // iteration. Avoids doubling Redis round-trips per health request,
+      // which would happen if redis and queues probes both called
+      // qm.getHealth().
       status: () => qm?.getRedisStatus() ?? 'disconnected',
     },
     minio: { check: checkMinioHealth },
@@ -320,7 +349,7 @@ async function executeProbes(opts: SystemHealthOptions): Promise<SystemHealth> {
   };
 }
 
-// ─── Caching layer (rel-2) ──────────────────────────────────────────
+// ─── Caching layer ──────────────────────────────────────────────────
 //
 // Each call fans out probes that hit Postgres (3 queries), Redis (status
 // + per-queue counts × 7 queues = ~21 calls), MinIO (HeadBucket), and
@@ -387,24 +416,34 @@ export async function getSystemHealth(opts: SystemHealthOptions = {}): Promise<S
  *   `connected` since it's reachable; only `unhealthy` collapses to
  *   `disconnected`.
  * - `services.minio.bucket` — preserved.
- * - `services.queues.queues` — restored (api-contract-3): a flat
- *   `{ queueName: { waiting, active, failed } }` map matching what
- *   `qm.getHealth()` previously returned in the inline /health handler.
- *   Anonymous callers can already infer queue health from this; keeping
- *   it preserves the contract.
+ * - `services.queues.queues` — a flat `{ queueName: { waiting, active,
+ *   failed } }` map matching what `qm.getHealth()` previously returned
+ *   in the inline /health handler. Preserved so anonymous probes that
+ *   already iterated this map keep working.
  *
  * New additive field:
  * - `aggregateStatus: 'healthy' | 'degraded' | 'unhealthy'` — the full
  *   three-tier signal, exposed in the body so JSON-only monitors can
  *   distinguish degraded from unhealthy without inspecting the HTTP
- *   status (api-contract-4).
+ *   status.
  *
  * Anti-leak guarantee: per-component `detail` and `message` are omitted
  * so probe error messages, DB connection counts, and queue offender
- * details never reach anonymous callers (security review residual
- * risks). The only structured data that survives is queue counts —
- * already part of the pre-#109 contract.
+ * details never reach anonymous callers. The only structured data that
+ * survives is queue counts — already part of the pre-#109 contract.
  */
+/**
+ * Anti-leak guard fields on every legacy-envelope service entry: a
+ * future PR adding `message` or `detail` here would silently leak
+ * probe internals to anonymous callers, so we make it a compile error
+ * instead. New per-service fields (like `bucket` on minio or `queues`
+ * on queues) are added by intersection on the specific entry below.
+ */
+type LegacyServiceGuards = {
+  message?: never;
+  detail?: never;
+};
+
 export interface LegacyHealthEnvelope {
   status: 'ok' | 'degraded';
   /** Three-tier aggregate: healthy | degraded | unhealthy. */
@@ -412,10 +451,13 @@ export interface LegacyHealthEnvelope {
   timestamp: string;
   version: string;
   services: {
-    database: { status: 'connected' | 'disconnected' };
-    redis: { status: 'connected' | 'disconnected' };
-    minio: { status: 'connected' | 'disconnected'; bucket?: string };
-    queues: {
+    database: LegacyServiceGuards & { status: 'connected' | 'disconnected' };
+    redis: LegacyServiceGuards & { status: 'connected' | 'disconnected' };
+    minio: LegacyServiceGuards & {
+      status: 'connected' | 'disconnected';
+      bucket?: string;
+    };
+    queues: LegacyServiceGuards & {
       status: 'connected' | 'disconnected';
       queues: Record<string, { waiting: number; active: number; failed: number }>;
     };

--- a/packages/backend/src/services/health.ts
+++ b/packages/backend/src/services/health.ts
@@ -525,8 +525,7 @@ function extractQueueStats(
 }
 
 export function legacyPublicEnvelope(health: SystemHealth): LegacyHealthEnvelope {
-  const minioBucket =
-    (health.components.minio.detail?.['bucket'] as string | undefined) ?? undefined;
+  const minioBucket = health.components.minio.detail?.['bucket'] as string | undefined;
   return {
     status: health.status === 'healthy' ? 'ok' : 'degraded',
     aggregateStatus: health.status,

--- a/packages/backend/src/services/health.ts
+++ b/packages/backend/src/services/health.ts
@@ -96,7 +96,11 @@ export async function runProbe(
     // should land in the `error` log channel so alerting fires — a
     // TypeError surfacing as "database unhealthy" is a debugging trap.
     const isProgrammingError =
-      err instanceof TypeError || err instanceof ReferenceError || err instanceof SyntaxError;
+      err instanceof TypeError ||
+      err instanceof ReferenceError ||
+      err instanceof SyntaxError ||
+      err instanceof RangeError ||
+      err instanceof URIError;
     if (isProgrammingError) {
       logger.error(
         { err, probe: name },
@@ -105,11 +109,18 @@ export async function runProbe(
     } else if (!isTimeout) {
       logger.warn({ err, probe: name }, 'health probe failed');
     }
+    // Programming errors carry stack-revealing messages (e.g.
+    // "Cannot read properties of undefined (reading 'foo')") that
+    // would leak through to authenticated SystemHealth consumers.
+    // The full err is in the structured log line; clients see a
+    // generic message so probe-internal state is never on the wire.
     const message = isTimeout
       ? `probe timed out after ${timeoutMs}ms`
-      : err instanceof Error
-        ? err.message
-        : 'probe failed';
+      : isProgrammingError
+        ? 'probe failed: internal error'
+        : err instanceof Error
+          ? err.message
+          : 'probe failed';
     return {
       status: 'unhealthy',
       message,

--- a/packages/backend/src/services/health.ts
+++ b/packages/backend/src/services/health.ts
@@ -49,7 +49,15 @@ export interface SystemHealth {
   components: Record<ComponentName, ComponentHealth>;
 }
 
-export const HEALTH_VERSION = '1.0.0';
+/**
+ * Schema version of the SystemHealth envelope. Bump when the
+ * `components` shape, status enum, or aggregate semantics change in a
+ * way consumers must adapt to. Distinct from the app's package version
+ * since the health surface evolves on its own cadence; see the
+ * Control API spec at packages/openapi/control-api.yaml for the
+ * matching `info.version` it documents.
+ */
+export const HEALTH_VERSION = '1.1.0';
 
 // Threshold semantics for the entire module: warn comparisons use `>=`
 // (inclusive boundary). "Warn at 10000" means 10000 is already the warn
@@ -72,19 +80,31 @@ export function aggregateStatus(
  * Runs a probe with a timeout. The probe returns a ComponentHealth-shaped
  * value (without durationMs); this wrapper attaches durationMs and coerces
  * thrown errors and timeouts into `unhealthy` ComponentHealth.
+ *
+ * The probe receives an AbortSignal that fires when the timeout wins so
+ * cancellation-aware drivers (S3 SDK's `abortSignal`, fetch, etc.) can
+ * actually terminate hung operations. Probes whose drivers do not
+ * support cancellation can ignore the signal — the wrapper still
+ * resolves on timeout, just without freeing the underlying resource.
+ * Postgres callers should also configure `statement_timeout` at the
+ * connection level so a hung query doesn't outlive the probe wrapper.
  */
 export async function runProbe(
   name: ComponentName,
-  probeFn: () => Promise<ProbeResult>,
+  probeFn: (signal: AbortSignal) => Promise<ProbeResult>,
   timeoutMs: number
 ): Promise<ComponentHealth> {
   const startedAt = Date.now();
+  const ac = new AbortController();
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
     const result = await Promise.race<ProbeResult>([
-      probeFn(),
+      probeFn(ac.signal),
       new Promise<ProbeResult>((_, reject) => {
-        timer = setTimeout(() => reject(new Error('PROBE_TIMEOUT')), timeoutMs);
+        timer = setTimeout(() => {
+          ac.abort();
+          reject(new Error('PROBE_TIMEOUT'));
+        }, timeoutMs);
       }),
     ]);
     return { ...result, durationMs: Date.now() - startedAt };
@@ -145,11 +165,15 @@ export async function probeDatabase(
   await deps.ping();
   const { used, max } = await deps.poolStats();
   const pct = max > 0 ? (used / max) * 100 : 0;
-  const detail = { connectionsUsed: used, connectionsMax: max, connectionsPct: Math.round(pct) };
+  // Report the unrounded percentage so the displayed value never
+  // disagrees with the threshold check. Previously detail.connectionsPct
+  // could read 80 while the underlying 79.6% kept the status healthy,
+  // which was confusing for operators reading the number alone.
+  const detail = { connectionsUsed: used, connectionsMax: max, connectionsPct: pct };
   if (pct >= warnPct) {
     return {
       status: 'degraded',
-      message: `database connection pool ${Math.round(pct)}% full (${used}/${max}) at or above warn threshold ${warnPct}%`,
+      message: `database connection pool ${pct.toFixed(1)}% full (${used}/${max}) at or above warn threshold ${warnPct}%`,
       detail,
     };
   }
@@ -169,11 +193,20 @@ export async function probeRedis(deps: RedisProbeDeps): Promise<ProbeResult> {
 }
 
 export interface MinioProbeDeps {
-  check: () => Promise<{ status: 'connected' | 'disconnected'; bucket: string }>;
+  /**
+   * Probe the bucket. The optional `signal` is wired through to the S3
+   * client so a timeout in `runProbe` actually aborts the underlying
+   * HEAD request — without it, the AWS SDK socket can stay alive long
+   * after the wrapper resolves.
+   */
+  check: (signal?: AbortSignal) => Promise<{
+    status: 'connected' | 'disconnected';
+    bucket: string;
+  }>;
 }
 
-export async function probeMinio(deps: MinioProbeDeps): Promise<ProbeResult> {
-  const result = await deps.check();
+export async function probeMinio(deps: MinioProbeDeps, signal?: AbortSignal): Promise<ProbeResult> {
+  const result = await deps.check(signal);
   if (result.status !== 'connected') {
     return {
       status: 'unhealthy',
@@ -337,13 +370,17 @@ async function executeProbes(opts: SystemHealthOptions): Promise<SystemHealth> {
   };
 
   const [database, redis, minio, queues] = await Promise.all([
+    // probeFn signatures all accept (signal: AbortSignal) so runProbe
+    // can abort the underlying driver call on timeout. probes that
+    // don't need it (sync redis status check, queue stat fan-out)
+    // simply ignore the argument.
     runProbe(
       'database',
       () => probeDatabase(probes.database, thresholds.dbConnectionWarnPct),
       thresholds.probeTimeoutMs
     ),
     runProbe('redis', () => probeRedis(probes.redis), thresholds.probeTimeoutMs),
-    runProbe('minio', () => probeMinio(probes.minio), thresholds.probeTimeoutMs),
+    runProbe('minio', (signal) => probeMinio(probes.minio, signal), thresholds.probeTimeoutMs),
     runProbe(
       'queues',
       () => probeQueues(probes.queues, thresholds.queueWarnDepth, thresholds.queueWarnFailed),

--- a/packages/backend/src/services/health.ts
+++ b/packages/backend/src/services/health.ts
@@ -1,0 +1,458 @@
+/**
+ * System health monitoring service.
+ *
+ * Centralizes probe orchestration, threshold logic, and the SystemHealth
+ * shape used by all three health-reporting surfaces:
+ *
+ *   - GET /health (public, unauthenticated, used by load balancers)
+ *   - GET /api/v1/control/health (API-key authenticated, for automation)
+ *   - GET /api/v1/dashboard/health (BetterAuth session, for the UI card)
+ *
+ * Probes run in parallel via Promise.race + a probe-level timeout so one
+ * slow component never stalls the whole report. Each probe coerces its
+ * own errors to `unhealthy` ComponentHealth — the service never throws
+ * from getSystemHealth().
+ */
+
+import { sql } from 'drizzle-orm';
+import { env } from '../config/env.js';
+import { logger } from '../config/logger.js';
+import { checkMinioHealth } from '../config/storage.js';
+import { db } from '../db/index.js';
+import { getQueueManager } from '../queue/context.js';
+
+export type ComponentStatus = 'healthy' | 'degraded' | 'unhealthy';
+
+export type ComponentName = 'database' | 'redis' | 'minio' | 'queues';
+
+export interface ComponentHealth {
+  status: ComponentStatus;
+  message?: string;
+  detail?: Record<string, unknown>;
+  durationMs: number;
+}
+
+export interface SystemHealth {
+  status: ComponentStatus;
+  timestamp: string;
+  version: string;
+  components: Record<ComponentName, ComponentHealth>;
+}
+
+export const HEALTH_VERSION = '1.0.0';
+
+/**
+ * Aggregates per-component statuses using a worst-of rule:
+ * unhealthy > degraded > healthy.
+ */
+export function aggregateStatus(
+  components: Record<ComponentName, ComponentHealth>
+): ComponentStatus {
+  const statuses = Object.values(components).map((c) => c.status);
+  if (statuses.includes('unhealthy')) return 'unhealthy';
+  if (statuses.includes('degraded')) return 'degraded';
+  return 'healthy';
+}
+
+/**
+ * Runs a probe with a timeout. The probe returns a ComponentHealth-shaped
+ * value (without durationMs); this wrapper attaches durationMs and coerces
+ * thrown errors and timeouts into `unhealthy` ComponentHealth.
+ */
+export async function runProbe(
+  name: ComponentName,
+  probeFn: () => Promise<Omit<ComponentHealth, 'durationMs'>>,
+  timeoutMs: number
+): Promise<ComponentHealth> {
+  const startedAt = Date.now();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const result = await Promise.race<Omit<ComponentHealth, 'durationMs'>>([
+      probeFn(),
+      new Promise<Omit<ComponentHealth, 'durationMs'>>((_, reject) => {
+        timer = setTimeout(() => reject(new Error('PROBE_TIMEOUT')), timeoutMs);
+      }),
+    ]);
+    return { ...result, durationMs: Date.now() - startedAt };
+  } catch (err) {
+    const isTimeout = err instanceof Error && err.message === 'PROBE_TIMEOUT';
+    if (!isTimeout) {
+      logger.warn({ err, probe: name }, 'health probe failed');
+    }
+    const message = isTimeout
+      ? `probe timed out after ${timeoutMs}ms`
+      : err instanceof Error
+        ? err.message
+        : 'probe failed';
+    return {
+      status: 'unhealthy',
+      message,
+      durationMs: Date.now() - startedAt,
+    };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+// ─── Probe Implementations ──────────────────────────────────────────
+
+export interface DatabaseProbeDeps {
+  ping: () => Promise<unknown>;
+  poolStats: () => Promise<{ used: number; max: number }>;
+}
+
+export async function probeDatabase(
+  deps: DatabaseProbeDeps,
+  warnPct: number
+): Promise<Omit<ComponentHealth, 'durationMs'>> {
+  await deps.ping();
+  const { used, max } = await deps.poolStats();
+  const pct = max > 0 ? (used / max) * 100 : 0;
+  const detail = { connectionsUsed: used, connectionsMax: max, connectionsPct: Math.round(pct) };
+  // Inclusive boundary: "warn at 80%" fires when pool is at or above 80% full.
+  if (pct >= warnPct) {
+    return {
+      status: 'degraded',
+      message: `database connection pool ${Math.round(pct)}% full (${used}/${max}) at or above warn threshold ${warnPct}%`,
+      detail,
+    };
+  }
+  return { status: 'healthy', detail };
+}
+
+export interface RedisProbeDeps {
+  /** Returns 'connected' iff the Redis client is in the ready state. */
+  status: () => 'connected' | 'disconnected';
+}
+
+export async function probeRedis(
+  deps: RedisProbeDeps
+): Promise<Omit<ComponentHealth, 'durationMs'>> {
+  if (deps.status() !== 'connected') {
+    return { status: 'unhealthy', message: 'redis connection not ready' };
+  }
+  return { status: 'healthy' };
+}
+
+export interface MinioProbeDeps {
+  check: () => Promise<{ status: 'connected' | 'disconnected'; bucket: string }>;
+}
+
+export async function probeMinio(
+  deps: MinioProbeDeps
+): Promise<Omit<ComponentHealth, 'durationMs'>> {
+  const result = await deps.check();
+  if (result.status !== 'connected') {
+    return {
+      status: 'unhealthy',
+      message: `minio bucket ${result.bucket} unreachable`,
+      detail: { bucket: result.bucket },
+    };
+  }
+  return { status: 'healthy', detail: { bucket: result.bucket } };
+}
+
+export interface QueueStat {
+  waiting: number;
+  active: number;
+  failed: number;
+}
+
+export interface QueuesProbeDeps {
+  health: () => Promise<{
+    status: 'connected' | 'disconnected';
+    queues: Record<string, QueueStat>;
+  }>;
+}
+
+export async function probeQueues(
+  deps: QueuesProbeDeps,
+  warnDepth: number,
+  warnFailed: number
+): Promise<Omit<ComponentHealth, 'durationMs'>> {
+  const result = await deps.health();
+  if (result.status !== 'connected') {
+    return {
+      status: 'unhealthy',
+      message: 'queue manager not connected to redis',
+      detail: { queues: {} },
+    };
+  }
+
+  // Inclusive boundary: thresholds fire at or above the configured value
+  // ("warn at 10000" means 10000 is already in the warn state).
+  const offenders: string[] = [];
+  for (const [name, stats] of Object.entries(result.queues)) {
+    if (stats.waiting >= warnDepth) {
+      offenders.push(`${name} waiting=${stats.waiting} >= ${warnDepth}`);
+    }
+    if (stats.failed >= warnFailed) {
+      offenders.push(`${name} failed=${stats.failed} >= ${warnFailed}`);
+    }
+  }
+
+  if (offenders.length > 0) {
+    return {
+      status: 'degraded',
+      message: `queue thresholds exceeded: ${offenders.join('; ')}`,
+      detail: { queues: result.queues, offenders },
+    };
+  }
+
+  return { status: 'healthy', detail: { queues: result.queues } };
+}
+
+// ─── Default Production Wiring ──────────────────────────────────────
+
+// pg_settings.max_connections only changes on Postgres restart, so it's
+// safe to cache for the lifetime of the process. Caching it eliminates one
+// of the three sequential round-trips probeDatabase otherwise pays per
+// tick (rel-4 in code review).
+let cachedMaxConnections: number | null = null;
+
+async function defaultDatabasePoolStats(): Promise<{ used: number; max: number }> {
+  const usedRows = (await db.execute(
+    sql`SELECT count(*)::int AS used FROM pg_stat_activity WHERE datname = current_database()`
+  )) as unknown as Array<{ used: number }>;
+
+  let max = cachedMaxConnections;
+  if (max === null) {
+    const maxRows = (await db.execute(
+      sql`SELECT setting::int AS max FROM pg_settings WHERE name = 'max_connections'`
+    )) as unknown as Array<{ max: number }>;
+    max = maxRows[0]?.max ?? 1;
+    cachedMaxConnections = max;
+  }
+  const used = usedRows[0]?.used ?? 0;
+  return { used, max };
+}
+
+/** Test-only: clears the max_connections cache (e.g. between Postgres versions). */
+export function __resetMaxConnectionsCache(): void {
+  cachedMaxConnections = null;
+}
+
+function buildDefaultProbes(): {
+  database: DatabaseProbeDeps;
+  redis: RedisProbeDeps;
+  minio: MinioProbeDeps;
+  queues: QueuesProbeDeps;
+} {
+  const qm = getQueueManager();
+  return {
+    database: {
+      ping: () => db.execute(sql`SELECT 1`),
+      poolStats: defaultDatabasePoolStats,
+    },
+    redis: {
+      // Cheap status check via QueueManager's connection — no queue iteration.
+      // Fixes C4: previously this called qm.getHealth() which the queues probe
+      // already runs, doubling Redis round-trips per health request.
+      status: () => qm?.getRedisStatus() ?? 'disconnected',
+    },
+    minio: { check: checkMinioHealth },
+    queues: {
+      health: async () => {
+        if (!qm) {
+          return { status: 'disconnected', queues: {} };
+        }
+        return qm.getHealth();
+      },
+    },
+  };
+}
+
+// ─── Public Entry Point ─────────────────────────────────────────────
+
+export interface SystemHealthOptions {
+  /** Override probes for testing. */
+  probes?: {
+    database?: DatabaseProbeDeps;
+    redis?: RedisProbeDeps;
+    minio?: MinioProbeDeps;
+    queues?: QueuesProbeDeps;
+  };
+  /** Override thresholds for testing. */
+  thresholds?: {
+    probeTimeoutMs?: number;
+    queueWarnDepth?: number;
+    queueWarnFailed?: number;
+    dbConnectionWarnPct?: number;
+  };
+}
+
+async function executeProbes(opts: SystemHealthOptions): Promise<SystemHealth> {
+  const defaults = buildDefaultProbes();
+  const probes = {
+    database: opts.probes?.database ?? defaults.database,
+    redis: opts.probes?.redis ?? defaults.redis,
+    minio: opts.probes?.minio ?? defaults.minio,
+    queues: opts.probes?.queues ?? defaults.queues,
+  };
+  const thresholds = {
+    probeTimeoutMs: opts.thresholds?.probeTimeoutMs ?? env.HEALTH_PROBE_TIMEOUT_MS,
+    queueWarnDepth: opts.thresholds?.queueWarnDepth ?? env.HEALTH_QUEUE_WARN_DEPTH,
+    queueWarnFailed: opts.thresholds?.queueWarnFailed ?? env.HEALTH_QUEUE_WARN_FAILED,
+    dbConnectionWarnPct: opts.thresholds?.dbConnectionWarnPct ?? env.HEALTH_DB_CONNECTION_WARN_PCT,
+  };
+
+  const [database, redis, minio, queues] = await Promise.all([
+    runProbe(
+      'database',
+      () => probeDatabase(probes.database, thresholds.dbConnectionWarnPct),
+      thresholds.probeTimeoutMs
+    ),
+    runProbe('redis', () => probeRedis(probes.redis), thresholds.probeTimeoutMs),
+    runProbe('minio', () => probeMinio(probes.minio), thresholds.probeTimeoutMs),
+    runProbe(
+      'queues',
+      () => probeQueues(probes.queues, thresholds.queueWarnDepth, thresholds.queueWarnFailed),
+      thresholds.probeTimeoutMs
+    ),
+  ]);
+
+  const components: Record<ComponentName, ComponentHealth> = { database, redis, minio, queues };
+  return {
+    status: aggregateStatus(components),
+    timestamp: new Date().toISOString(),
+    version: HEALTH_VERSION,
+    components,
+  };
+}
+
+// ─── Caching layer (rel-2) ──────────────────────────────────────────
+//
+// Each call fans out probes that hit Postgres (3 queries), Redis (status
+// + per-queue counts × 7 queues = ~21 calls), MinIO (HeadBucket), and
+// usually completes in tens of ms. Without caching, three surfaces
+// (/health, /api/v1/control/health, /api/v1/dashboard/health) plus the
+// 30s scheduled monitor plus a polling dashboard could pile probes
+// against a degraded backend exactly when latency is already high.
+//
+// The cache and in-flight dedup are bypassed when the caller passes
+// `opts.probes` or `opts.thresholds` (i.e. tests using injected probes)
+// so unit tests remain deterministic and isolated.
+
+const HEALTH_CACHE_TTL_MS = 5_000;
+let cachedHealth: { value: SystemHealth; expiresAt: number } | null = null;
+let inFlightHealth: Promise<SystemHealth> | null = null;
+
+/** Test-only: clears the module-level cache. */
+export function __resetSystemHealthCache(): void {
+  cachedHealth = null;
+  inFlightHealth = null;
+}
+
+export async function getSystemHealth(opts: SystemHealthOptions = {}): Promise<SystemHealth> {
+  // Bypass cache when tests inject custom probes or thresholds — those
+  // calls are deterministic and must not see stale state from prior
+  // tests or production calls.
+  if (opts.probes || opts.thresholds) {
+    return executeProbes(opts);
+  }
+
+  const now = Date.now();
+  if (cachedHealth && cachedHealth.expiresAt > now) {
+    return cachedHealth.value;
+  }
+
+  // In-flight dedup: concurrent callers under load share one execution.
+  if (inFlightHealth) {
+    return inFlightHealth;
+  }
+
+  inFlightHealth = executeProbes(opts)
+    .then((value) => {
+      cachedHealth = { value, expiresAt: Date.now() + HEALTH_CACHE_TTL_MS };
+      return value;
+    })
+    .finally(() => {
+      inFlightHealth = null;
+    });
+
+  return inFlightHealth;
+}
+
+/**
+ * Translates SystemHealth into the legacy public /health envelope shape.
+ *
+ * Backward-compat surface preserved for load balancers and anonymous
+ * probes that consumed the pre-#109 endpoint:
+ * - `status: 'ok' | 'degraded'` — coarse two-tier signal kept for older
+ *   monitors. The HTTP status code (503 on unhealthy) is the additional
+ *   signal those monitors can opt into.
+ * - `services.{database,redis,minio,queues}.status: 'connected' |
+ *   'disconnected'` — coarse connectivity. A "degraded" component
+ *   (queue depth above warn threshold, DB pool >= warn percent) is still
+ *   `connected` since it's reachable; only `unhealthy` collapses to
+ *   `disconnected`.
+ * - `services.minio.bucket` — preserved.
+ * - `services.queues.queues` — restored (api-contract-3): a flat
+ *   `{ queueName: { waiting, active, failed } }` map matching what
+ *   `qm.getHealth()` previously returned in the inline /health handler.
+ *   Anonymous callers can already infer queue health from this; keeping
+ *   it preserves the contract.
+ *
+ * New additive field:
+ * - `aggregateStatus: 'healthy' | 'degraded' | 'unhealthy'` — the full
+ *   three-tier signal, exposed in the body so JSON-only monitors can
+ *   distinguish degraded from unhealthy without inspecting the HTTP
+ *   status (api-contract-4).
+ *
+ * Anti-leak guarantee: per-component `detail` and `message` are omitted
+ * so probe error messages, DB connection counts, and queue offender
+ * details never reach anonymous callers (security review residual
+ * risks). The only structured data that survives is queue counts —
+ * already part of the pre-#109 contract.
+ */
+export interface LegacyHealthEnvelope {
+  status: 'ok' | 'degraded';
+  /** Three-tier aggregate: healthy | degraded | unhealthy. */
+  aggregateStatus: ComponentStatus;
+  timestamp: string;
+  version: string;
+  services: {
+    database: { status: 'connected' | 'disconnected' };
+    redis: { status: 'connected' | 'disconnected' };
+    minio: { status: 'connected' | 'disconnected'; bucket?: string };
+    queues: {
+      status: 'connected' | 'disconnected';
+      queues: Record<string, { waiting: number; active: number; failed: number }>;
+    };
+  };
+}
+
+function legacyServiceStatus(s: ComponentStatus): 'connected' | 'disconnected' {
+  return s === 'unhealthy' ? 'disconnected' : 'connected';
+}
+
+function extractQueueStats(
+  detail: Record<string, unknown> | undefined
+): Record<string, { waiting: number; active: number; failed: number }> {
+  const raw = detail?.['queues'];
+  if (!raw || typeof raw !== 'object') return {};
+  return raw as Record<string, { waiting: number; active: number; failed: number }>;
+}
+
+export function legacyPublicEnvelope(health: SystemHealth): LegacyHealthEnvelope {
+  const minioBucket =
+    (health.components.minio.detail?.['bucket'] as string | undefined) ?? undefined;
+  return {
+    status: health.status === 'healthy' ? 'ok' : 'degraded',
+    aggregateStatus: health.status,
+    timestamp: health.timestamp,
+    version: health.version,
+    services: {
+      database: { status: legacyServiceStatus(health.components.database.status) },
+      redis: { status: legacyServiceStatus(health.components.redis.status) },
+      minio: {
+        status: legacyServiceStatus(health.components.minio.status),
+        ...(minioBucket ? { bucket: minioBucket } : {}),
+      },
+      queues: {
+        status: legacyServiceStatus(health.components.queues.status),
+        queues: extractQueueStats(health.components.queues.detail),
+      },
+    },
+  };
+}

--- a/packages/backend/src/worker-jobs.ts
+++ b/packages/backend/src/worker-jobs.ts
@@ -26,8 +26,12 @@ async function main() {
   // connection failure and waits for the `ready` event; "fail-fast"
   // here covers post-connect setup errors, not Redis-down-at-startup.
   const queueManager = new QueueManager();
-  setQueueManager(queueManager);
+  // Initialize first, register second: the registry should never hold
+  // a half-initialized manager. Today the two calls are synchronous
+  // and non-overlapping, but the order makes the invariant explicit
+  // for any future change that adds an await between them.
   await queueManager.init();
+  setQueueManager(queueManager);
 
   const hashListWorker = createHashListParserWorker(connection);
   logger.info('Hash list parser worker started');

--- a/packages/backend/src/worker-jobs.ts
+++ b/packages/backend/src/worker-jobs.ts
@@ -12,18 +12,20 @@ async function main() {
   await connection.connect();
   logger.info('Jobs worker connected to Redis');
 
-  // Issue #109 fix (rel-1): the health-monitor worker calls
-  // getSystemHealth() → getQueueManager(); without a QueueManager in the
-  // worker process the redis and queues probes silently report unhealthy
-  // forever. Instantiate one here so the worker has the same probe
-  // surface as the API process. BullMQ's upsertJobScheduler is
-  // idempotent so the duplicate scheduler upsert from the API and
-  // worker processes is safe.
+  // The health-monitor worker calls getSystemHealth() →
+  // getQueueManager(); without a QueueManager in the worker process the
+  // redis and queues probes silently report unhealthy forever.
+  // Instantiate one here so the worker has the same probe surface as
+  // the API process. BullMQ's upsertJobScheduler is idempotent so the
+  // duplicate scheduler upsert from the API and worker processes is
+  // safe.
+  //
+  // Init failure is treated as fail-fast: a worker without a
+  // QueueManager cannot do its job, and warn-and-continue would leave
+  // the process alive but silently broken until ops noticed.
   const queueManager = new QueueManager();
   setQueueManager(queueManager);
-  await queueManager.init().catch((err) => {
-    logger.warn({ err }, 'Worker QueueManager init failed — health probes may misreport');
-  });
+  await queueManager.init();
 
   const hashListWorker = createHashListParserWorker(connection);
   logger.info('Hash list parser worker started');

--- a/packages/backend/src/worker-jobs.ts
+++ b/packages/backend/src/worker-jobs.ts
@@ -20,9 +20,11 @@ async function main() {
   // duplicate scheduler upsert from the API and worker processes is
   // safe.
   //
-  // Init failure is treated as fail-fast: a worker without a
-  // QueueManager cannot do its job, and warn-and-continue would leave
-  // the process alive but silently broken until ops noticed.
+  // Synchronous init failure (e.g. queue construction throws after
+  // Redis connects) propagates to main().catch and exits the process.
+  // Note that QueueManager.init() itself swallows initial Redis
+  // connection failure and waits for the `ready` event; "fail-fast"
+  // here covers post-connect setup errors, not Redis-down-at-startup.
   const queueManager = new QueueManager();
   setQueueManager(queueManager);
   await queueManager.init();

--- a/packages/backend/src/worker-jobs.ts
+++ b/packages/backend/src/worker-jobs.ts
@@ -1,6 +1,9 @@
 import { logger } from './config/logger.js';
 import { createRedisClient } from './config/redis.js';
+import { setQueueManager } from './queue/context.js';
+import { QueueManager } from './queue/manager.js';
 import { createHashListParserWorker } from './queue/workers/hash-list-parser.js';
+import { createHealthMonitorWorker } from './queue/workers/health-monitor.js';
 import { createHeartbeatMonitorWorker } from './queue/workers/heartbeat-monitor.js';
 
 const connection = createRedisClient('jobs-worker');
@@ -9,17 +12,34 @@ async function main() {
   await connection.connect();
   logger.info('Jobs worker connected to Redis');
 
+  // Issue #109 fix (rel-1): the health-monitor worker calls
+  // getSystemHealth() → getQueueManager(); without a QueueManager in the
+  // worker process the redis and queues probes silently report unhealthy
+  // forever. Instantiate one here so the worker has the same probe
+  // surface as the API process. BullMQ's upsertJobScheduler is
+  // idempotent so the duplicate scheduler upsert from the API and
+  // worker processes is safe.
+  const queueManager = new QueueManager();
+  setQueueManager(queueManager);
+  await queueManager.init().catch((err) => {
+    logger.warn({ err }, 'Worker QueueManager init failed — health probes may misreport');
+  });
+
   const hashListWorker = createHashListParserWorker(connection);
   logger.info('Hash list parser worker started');
 
   const heartbeatWorker = createHeartbeatMonitorWorker(connection);
   logger.info('Heartbeat monitor worker started');
 
-  const workers = [hashListWorker, heartbeatWorker];
+  const healthWorker = createHealthMonitorWorker(connection);
+  logger.info('Health monitor worker started');
+
+  const workers = [hashListWorker, heartbeatWorker, healthWorker];
 
   async function shutdown(signal: string) {
     logger.info({ signal }, 'Shutting down job workers');
     await Promise.all(workers.map((w) => w.close()));
+    await queueManager.shutdown();
     await connection.disconnect();
     process.exit(0);
   }

--- a/packages/backend/tests/integration/control-health.test.ts
+++ b/packages/backend/tests/integration/control-health.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Integration tests for GET /api/v1/control/health (issue #109).
+ *
+ * The control health endpoint was refactored to delegate to the unified
+ * health service. Verifies the SystemHealth shape on success and the
+ * RFC 9457 problem-details envelope when the service throws — both
+ * paths previously had zero coverage (testing review T-001).
+ */
+import { describe, expect, it, mock } from 'bun:test';
+
+// MinIO probe stubbed so the health probe doesn't depend on a live bucket.
+mock.module('../../src/config/storage.js', () => ({
+  checkMinioHealth: mock(() =>
+    Promise.resolve({ status: 'connected' as const, bucket: 'hashhive-test' })
+  ),
+  s3: {},
+  uploadFile: mock(),
+  downloadFile: mock(),
+  deleteFile: mock(),
+  getPresignedUrl: mock(),
+}));
+
+import { app } from '../../src/index.js';
+
+describe('GET /api/v1/control/health', () => {
+  it('returns 401 (RFC 9457 problem details) without an API key', async () => {
+    const res = await app.request('/api/v1/control/health');
+    expect(res.status).toBe(401);
+    expect(res.headers.get('content-type')).toContain('application/problem+json');
+  });
+
+  it('rejects an invalid Bearer scheme with 401 problem details', async () => {
+    const res = await app.request('/api/v1/control/health', {
+      headers: { authorization: 'Basic deadbeef' },
+    });
+    expect(res.status).toBe(401);
+    expect(res.headers.get('content-type')).toContain('application/problem+json');
+  });
+
+  it('rejects a malformed control API key with 401 problem details', async () => {
+    // Valid `Bearer cst_*` shape but the key has never been issued.
+    const res = await app.request('/api/v1/control/health', {
+      headers: { authorization: 'Bearer cst_999_' + 'x'.repeat(40) },
+    });
+    expect(res.status).toBe(401);
+    expect(res.headers.get('content-type')).toContain('application/problem+json');
+  });
+});

--- a/packages/backend/tests/integration/control-health.test.ts
+++ b/packages/backend/tests/integration/control-health.test.ts
@@ -6,9 +6,37 @@
  * RFC 9457 problem-details envelope when the service throws — both
  * paths previously had zero coverage (testing review T-001).
  */
-import { describe, expect, it, mock } from 'bun:test';
+import { beforeAll, describe, expect, it, mock } from 'bun:test';
 
-// MinIO probe stubbed so the health probe doesn't depend on a live bucket.
+interface MockUserRow {
+  id: number;
+  email: string;
+  status: string;
+  apiKeyHash: string | null;
+  apiKeyLastUsedAt: Date | null;
+}
+
+let mockUserRow: MockUserRow | null = null;
+
+mock.module('../../src/db/index.js', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => Promise.resolve(mockUserRow ? [mockUserRow] : []),
+        }),
+      }),
+    }),
+    update: () => ({
+      set: () => ({
+        where: () => Promise.resolve(),
+      }),
+    }),
+    execute: async () => [{ used: 1, max: 100 }],
+  },
+  client: {},
+}));
+
 mock.module('../../src/config/storage.js', () => ({
   checkMinioHealth: mock(() =>
     Promise.resolve({ status: 'connected' as const, bucket: 'hashhive-test' })
@@ -20,6 +48,7 @@ mock.module('../../src/config/storage.js', () => ({
   getPresignedUrl: mock(),
 }));
 
+import { generateApiKey } from '../../src/lib/api-key.js';
 import { app } from '../../src/index.js';
 
 describe('GET /api/v1/control/health', () => {
@@ -44,5 +73,65 @@ describe('GET /api/v1/control/health', () => {
     });
     expect(res.status).toBe(401);
     expect(res.headers.get('content-type')).toContain('application/problem+json');
+  });
+
+  // PR review I-2: prior tests only covered 401 paths. Add a happy-path
+  // test that drives the route through to the SystemHealth response so a
+  // regression that returned the dashboard envelope shape (or an
+  // arbitrary shape) on the control surface would be caught.
+  describe('with a valid API key', () => {
+    let validToken: string;
+
+    beforeAll(async () => {
+      const { token, hash } = await generateApiKey(42);
+      validToken = token;
+      mockUserRow = {
+        id: 42,
+        email: 'control-health-tester@example.com',
+        status: 'active',
+        apiKeyHash: hash,
+        apiKeyLastUsedAt: null,
+      };
+    });
+
+    it('returns 200 with the full SystemHealth shape', async () => {
+      const res = await app.request('/api/v1/control/health', {
+        headers: { authorization: `Bearer ${validToken}` },
+      });
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toContain('application/json');
+
+      const body = (await res.json()) as {
+        status: string;
+        timestamp: string;
+        version: string;
+        components: Record<string, { status: string; durationMs: number }>;
+      };
+      expect(['healthy', 'degraded', 'unhealthy']).toContain(body.status);
+      expect(body.version).toBe('1.0.0');
+      expect(typeof body.timestamp).toBe('string');
+      // All four components present — same shape as the dashboard surface,
+      // unlike the public /health envelope.
+      expect(body.components.database).toBeDefined();
+      expect(body.components.redis).toBeDefined();
+      expect(body.components.minio).toBeDefined();
+      expect(body.components.queues).toBeDefined();
+      // Per-component status uses the three-tier enum
+      for (const c of Object.values(body.components)) {
+        expect(['healthy', 'degraded', 'unhealthy']).toContain(c.status);
+      }
+    });
+
+    it('does NOT return the legacy `services` envelope on the control surface', async () => {
+      const res = await app.request('/api/v1/control/health', {
+        headers: { authorization: `Bearer ${validToken}` },
+      });
+      const body = (await res.json()) as Record<string, unknown>;
+      // Dashboard / Control: rich `components` shape.
+      // Public /health: legacy `services` shape.
+      // The two must not be confused — control consumers should not see `services`.
+      expect(body['services']).toBeUndefined();
+      expect(body['components']).toBeDefined();
+    });
   });
 });

--- a/packages/backend/tests/integration/control-health.test.ts
+++ b/packages/backend/tests/integration/control-health.test.ts
@@ -32,7 +32,16 @@ mock.module('../../src/db/index.js', () => ({
         where: () => Promise.resolve(),
       }),
     }),
-    execute: async () => [{ used: 1, max: 100 }],
+    // Discriminate by query content so a regression that swapped
+    // pg_stat_activity / pg_settings shapes (or renamed `used`/`max`)
+    // would surface — a single shared shape would mask real column
+    // mismatches.
+    execute: async (q: unknown) => {
+      const sqlText = String(q);
+      if (sqlText.includes('pg_stat_activity')) return [{ used: 1 }];
+      if (sqlText.includes('pg_settings')) return [{ max: 100 }];
+      return [];
+    },
   },
   client: {},
 }));

--- a/packages/backend/tests/integration/control-health.test.ts
+++ b/packages/backend/tests/integration/control-health.test.ts
@@ -2,9 +2,12 @@
  * Integration tests for GET /api/v1/control/health (issue #109).
  *
  * The control health endpoint was refactored to delegate to the unified
- * health service. Verifies the SystemHealth shape on success and the
- * RFC 9457 problem-details envelope when the service throws — both
- * paths previously had zero coverage (testing review T-001).
+ * health service. Verifies:
+ *   - 401 paths: missing/invalid auth scheme and clearly malformed
+ *     bearer tokens land the RFC 9457 problem-details envelope.
+ *   - 200 path: a valid API key returns the SystemHealth shape with the
+ *     `components` envelope (and not the public legacy `services`
+ *     shape).
  */
 import { beforeAll, describe, expect, it, mock } from 'bun:test';
 
@@ -76,9 +79,13 @@ describe('GET /api/v1/control/health', () => {
   });
 
   it('rejects a malformed control API key with 401 problem details', async () => {
-    // Valid `Bearer cst_*` shape but the key has never been issued.
+    // Token is shaped wrong on purpose (no `cst_` prefix, no userId
+    // segment) so the parser rejects it before any DB lookup runs.
+    // A token shaped like `Bearer cst_999_<40-byte>` would pass the
+    // parser and hit a DB lookup that returns 500 in a fully-stubbed
+    // unit env (CI-red), masking the parser-level test intent.
     const res = await app.request('/api/v1/control/health', {
-      headers: { authorization: 'Bearer cst_999_' + 'x'.repeat(40) },
+      headers: { authorization: 'Bearer malformed-control-key' },
     });
     expect(res.status).toBe(401);
     expect(res.headers.get('content-type')).toContain('application/problem+json');
@@ -117,14 +124,16 @@ describe('GET /api/v1/control/health', () => {
         components: Record<string, { status: string; durationMs: number }>;
       };
       expect(['healthy', 'degraded', 'unhealthy']).toContain(body.status);
-      expect(body.version).toBe('1.0.0');
+      expect(body.version).toBe('1.1.0');
       expect(typeof body.timestamp).toBe('string');
       // All four components present — same shape as the dashboard surface,
-      // unlike the public /health envelope.
-      expect(body.components.database).toBeDefined();
-      expect(body.components.redis).toBeDefined();
-      expect(body.components.minio).toBeDefined();
-      expect(body.components.queues).toBeDefined();
+      // unlike the public /health envelope. Bracket notation per
+      // `noPropertyAccessFromIndexSignature` (Record<string, …> requires
+      // it).
+      expect(body.components['database']).toBeDefined();
+      expect(body.components['redis']).toBeDefined();
+      expect(body.components['minio']).toBeDefined();
+      expect(body.components['queues']).toBeDefined();
       // Per-component status uses the three-tier enum
       for (const c of Object.values(body.components)) {
         expect(['healthy', 'degraded', 'unhealthy']).toContain(c.status);

--- a/packages/backend/tests/integration/dashboard-health.test.ts
+++ b/packages/backend/tests/integration/dashboard-health.test.ts
@@ -146,12 +146,26 @@ describe('GET /api/v1/dashboard/health', () => {
     const someNonHealthy = Object.values(body.components).some((c) => c.status !== 'healthy');
     expect(someNonHealthy).toBe(true);
 
-    // Bracket access yields T | undefined under noUncheckedIndexedAccess;
-    // guard before reading nested fields.
+    // The contract under test: every non-healthy component carries a
+    // `message` (required by the ComponentHealth discriminated union).
+    // `detail` is optional per probe — redis omits it, queues+minio
+    // include it — so we only assert message presence on the
+    // first-non-healthy. Detail is asserted on the queues path (which
+    // always carries `{ queues: {} }`) and the minio path (which always
+    // carries `{ bucket }`) below.
+    const nonHealthy = Object.values(body.components).find((c) => c.status !== 'healthy');
+    expect(nonHealthy).toBeDefined();
+    expect(nonHealthy?.message).toBeDefined();
+    expect(typeof nonHealthy?.message).toBe('string');
+
+    // Pin the queues path: when queues is non-healthy (the reliable
+    // signal in unit-test env without a QueueManager), its detail must
+    // include the queues map. Bracket access yields T | undefined; pin
+    // presence first so a regression that drops the key entirely fails
+    // loudly instead of silently skipping via optional chaining.
     const queues = body.components['queues'];
+    expect(queues).toBeDefined();
     if (queues && queues.status !== 'healthy') {
-      expect(queues.message).toBeDefined();
-      expect(typeof queues.message).toBe('string');
       expect(queues.detail).toBeDefined();
     }
     // minio probe is stubbed, so its detail.bucket is reliably present

--- a/packages/backend/tests/integration/dashboard-health.test.ts
+++ b/packages/backend/tests/integration/dashboard-health.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Integration tests for GET /api/v1/dashboard/health (issue #109).
+ *
+ * Verifies the dashboard health endpoint:
+ *   - rejects unauthenticated requests with 401
+ *   - returns the SystemHealth shape (with `components` and `detail`)
+ *     when authenticated
+ *
+ * Mocks BetterAuth and storage so the test does not depend on real
+ * Postgres / Redis / MinIO availability.
+ */
+import { describe, expect, it, mock } from 'bun:test';
+
+// ─── Mock BetterAuth ─────────────────────────────────────────────────
+//
+// Reuse the same cookie convention as dashboard-api-contract tests so
+// the auth middleware behavior is identical.
+
+mock.module('../../src/lib/auth.js', () => ({
+  auth: {
+    api: {
+      getSession: async ({ headers }: { headers: Headers }) => {
+        const cookie = headers.get('cookie') ?? '';
+        if (cookie.includes('hh.session_token=valid-session')) {
+          return {
+            user: {
+              id: '1',
+              email: 'test@example.com',
+              name: 'Test User',
+              emailVerified: true,
+              image: null,
+            },
+            session: {
+              id: 'sess-1',
+              userId: '1',
+              token: 'tok-1',
+              expiresAt: new Date(Date.now() + 3_600_000),
+            },
+          };
+        }
+        return null;
+      },
+    },
+    handler: async () => new Response('ok'),
+  },
+}));
+
+mock.module('../../src/services/auth.js', () => ({
+  getUserWithProjects: async () => null,
+  findProjectMembership: async () => null,
+}));
+
+// MinIO probe stubbed to avoid bucket dependency.
+mock.module('../../src/config/storage.js', () => ({
+  checkMinioHealth: mock(() =>
+    Promise.resolve({ status: 'connected' as const, bucket: 'hashhive-test' })
+  ),
+  s3: {},
+  uploadFile: mock(),
+  downloadFile: mock(),
+  deleteFile: mock(),
+  getPresignedUrl: mock(),
+}));
+
+import { app } from '../../src/index.js';
+
+describe('GET /api/v1/dashboard/health', () => {
+  it('returns 401 without a session cookie', async () => {
+    const res = await app.request('/api/v1/dashboard/health');
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as Record<string, { code: string }>;
+    expect(body['error']?.code).toBe('AUTH_TOKEN_INVALID');
+  });
+
+  it('returns SystemHealth shape with all four components when authenticated', async () => {
+    const res = await app.request('/api/v1/dashboard/health', {
+      headers: { cookie: 'hh.session_token=valid-session' },
+    });
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      status: string;
+      timestamp: string;
+      version: string;
+      components: Record<string, { status: string; durationMs: number }>;
+    };
+
+    // Top-level envelope
+    expect(['healthy', 'degraded', 'unhealthy']).toContain(body.status);
+    expect(typeof body.timestamp).toBe('string');
+    expect(body.version).toBe('1.0.0');
+
+    // All four components present
+    expect(body.components.database).toBeDefined();
+    expect(body.components.redis).toBeDefined();
+    expect(body.components.minio).toBeDefined();
+    expect(body.components.queues).toBeDefined();
+
+    // Per-component status uses the new three-tier enum
+    for (const c of Object.values(body.components)) {
+      expect(['healthy', 'degraded', 'unhealthy']).toContain(c.status);
+      expect(typeof c.durationMs).toBe('number');
+    }
+  });
+
+  it('exposes per-component detail (unlike the public surface)', async () => {
+    const res = await app.request('/api/v1/dashboard/health', {
+      headers: { cookie: 'hh.session_token=valid-session' },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      components: Record<string, { detail?: Record<string, unknown> }>;
+    };
+    // MinIO probe is mocked to connected, so detail should include the bucket name
+    expect(body.components.minio.detail?.['bucket']).toBe('hashhive-test');
+  });
+});

--- a/packages/backend/tests/integration/dashboard-health.test.ts
+++ b/packages/backend/tests/integration/dashboard-health.test.ts
@@ -114,4 +114,38 @@ describe('GET /api/v1/dashboard/health', () => {
     // MinIO probe is mocked to connected, so detail should include the bucket name
     expect(body.components.minio.detail?.['bucket']).toBe('hashhive-test');
   });
+
+  // PR review I-1: the dashboard surface intentionally exposes the rich
+  // payload (detail + message) that the public envelope strips. Verify
+  // the *inverse* of the legacyPublicEnvelope leak-prevention tests —
+  // when a component is non-healthy, the dashboard reader must still see
+  // the structured detail so the card can render it. A regression that
+  // accidentally stripped detail on the dashboard route would silently
+  // degrade the card's diagnostic value.
+  it('preserves detail and message on non-healthy components for authenticated readers', async () => {
+    const res = await app.request('/api/v1/dashboard/health', {
+      headers: { cookie: 'hh.session_token=valid-session' },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      components: Record<
+        string,
+        { status: string; message?: string; detail?: Record<string, unknown> }
+      >;
+    };
+    // Whatever the actual component states, the response shape must
+    // preserve the structured envelope on every component. (In test env
+    // queues will be unhealthy because there's no QueueManager; that
+    // gives us a real non-healthy component to inspect.)
+    const queues = body.components.queues;
+    if (queues.status !== 'healthy') {
+      expect(queues.message).toBeDefined();
+      expect(typeof queues.message).toBe('string');
+      expect(queues.detail).toBeDefined();
+    }
+    // minio probe is stubbed, so its detail.bucket is reliably present
+    // — proves the dashboard surface keeps the field that the public
+    // envelope is allowed to strip.
+    expect(body.components.minio.detail?.['bucket']).toBe('hashhive-test');
+  });
 });

--- a/packages/backend/tests/integration/dashboard-health.test.ts
+++ b/packages/backend/tests/integration/dashboard-health.test.ts
@@ -9,7 +9,7 @@
  * Mocks BetterAuth and storage so the test does not depend on real
  * Postgres / Redis / MinIO availability.
  */
-import { describe, expect, it, mock } from 'bun:test';
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
 
 // ─── Mock BetterAuth ─────────────────────────────────────────────────
 //
@@ -62,7 +62,24 @@ mock.module('../../src/config/storage.js', () => ({
   getPresignedUrl: mock(),
 }));
 
+// Force the queue manager to be absent so the queues probe deterministically
+// reports `disconnected → unhealthy` regardless of what other test files have
+// set on the global registry. Combined with the cache reset below this makes
+// the "non-healthy component" assertions in this file order-independent.
+mock.module('../../src/queue/context.js', () => ({
+  getQueueManager: () => null,
+  setQueueManager: () => {},
+}));
+
 import { app } from '../../src/index.js';
+import { __resetSystemHealthCache } from '../../src/services/health.js';
+
+// Clear the 5s system-health cache before each case so a stale value
+// from a prior test (or another suite that ran moments earlier) cannot
+// leak through.
+beforeEach(() => {
+  __resetSystemHealthCache();
+});
 
 describe('GET /api/v1/dashboard/health', () => {
   it('returns 401 without a session cookie', async () => {

--- a/packages/backend/tests/integration/dashboard-health.test.ts
+++ b/packages/backend/tests/integration/dashboard-health.test.ts
@@ -88,13 +88,14 @@ describe('GET /api/v1/dashboard/health', () => {
     // Top-level envelope
     expect(['healthy', 'degraded', 'unhealthy']).toContain(body.status);
     expect(typeof body.timestamp).toBe('string');
-    expect(body.version).toBe('1.0.0');
+    expect(body.version).toBe('1.1.0');
 
-    // All four components present
-    expect(body.components.database).toBeDefined();
-    expect(body.components.redis).toBeDefined();
-    expect(body.components.minio).toBeDefined();
-    expect(body.components.queues).toBeDefined();
+    // All four components present. Bracket notation per
+    // `noPropertyAccessFromIndexSignature` (Record<string, …>).
+    expect(body.components['database']).toBeDefined();
+    expect(body.components['redis']).toBeDefined();
+    expect(body.components['minio']).toBeDefined();
+    expect(body.components['queues']).toBeDefined();
 
     // Per-component status uses the new three-tier enum
     for (const c of Object.values(body.components)) {
@@ -112,7 +113,7 @@ describe('GET /api/v1/dashboard/health', () => {
       components: Record<string, { detail?: Record<string, unknown> }>;
     };
     // MinIO probe is mocked to connected, so detail should include the bucket name
-    expect(body.components.minio.detail?.['bucket']).toBe('hashhive-test');
+    expect(body.components['minio']?.detail?.['bucket']).toBe('hashhive-test');
   });
 
   // PR review I-1: the dashboard surface intentionally exposes the rich
@@ -145,8 +146,10 @@ describe('GET /api/v1/dashboard/health', () => {
     const someNonHealthy = Object.values(body.components).some((c) => c.status !== 'healthy');
     expect(someNonHealthy).toBe(true);
 
-    const queues = body.components.queues;
-    if (queues.status !== 'healthy') {
+    // Bracket access yields T | undefined under noUncheckedIndexedAccess;
+    // guard before reading nested fields.
+    const queues = body.components['queues'];
+    if (queues && queues.status !== 'healthy') {
       expect(queues.message).toBeDefined();
       expect(typeof queues.message).toBe('string');
       expect(queues.detail).toBeDefined();
@@ -154,6 +157,6 @@ describe('GET /api/v1/dashboard/health', () => {
     // minio probe is stubbed, so its detail.bucket is reliably present
     // — proves the dashboard surface keeps the field that the public
     // envelope is allowed to strip.
-    expect(body.components.minio.detail?.['bucket']).toBe('hashhive-test');
+    expect(body.components['minio']?.detail?.['bucket']).toBe('hashhive-test');
   });
 });

--- a/packages/backend/tests/integration/dashboard-health.test.ts
+++ b/packages/backend/tests/integration/dashboard-health.test.ts
@@ -137,6 +137,14 @@ describe('GET /api/v1/dashboard/health', () => {
     // preserve the structured envelope on every component. (In test env
     // queues will be unhealthy because there's no QueueManager; that
     // gives us a real non-healthy component to inspect.)
+    // Precondition guard: the test's whole point is to verify
+    // non-healthy components retain message + detail. If a future
+    // refactor mocks the queue manager (or otherwise makes every
+    // component healthy in test env), this assertion fails loudly
+    // instead of letting the conditional block below silently skip.
+    const someNonHealthy = Object.values(body.components).some((c) => c.status !== 'healthy');
+    expect(someNonHealthy).toBe(true);
+
     const queues = body.components.queues;
     if (queues.status !== 'healthy') {
       expect(queues.message).toBeDefined();

--- a/packages/backend/tests/integration/health-deterministic.test.ts
+++ b/packages/backend/tests/integration/health-deterministic.test.ts
@@ -7,7 +7,7 @@
  * would pass that test vacuously. This file mocks `getSystemHealth`
  * directly to drive each terminal HTTP outcome.
  */
-import { describe, expect, it, mock } from 'bun:test';
+import { afterAll, describe, expect, it, mock } from 'bun:test';
 import type { ComponentHealth, SystemHealth } from '../../src/services/health.js';
 
 let mockedAggregateStatus: SystemHealth['status'] = 'healthy';
@@ -61,6 +61,15 @@ mock.module('../../src/config/storage.js', () => ({
 }));
 
 import { app } from '../../src/index.js';
+
+// Defensive cleanup: Bun normally isolates test files per process so
+// the health/storage mocks here don't bleed into other suites. If that
+// isolation model ever changes (e.g. running `bun test --concurrency=1`
+// across files in one process), `mock.restore()` keeps the unmocked
+// `getSystemHealth` for any test file that runs after this one.
+afterAll(() => {
+  mock.restore();
+});
 
 describe('GET /health — deterministic 200 vs 503', () => {
   it('returns 200 with body status="ok" when service reports healthy', async () => {

--- a/packages/backend/tests/integration/health-deterministic.test.ts
+++ b/packages/backend/tests/integration/health-deterministic.test.ts
@@ -38,14 +38,23 @@ function buildSystemHealth(): SystemHealth {
   };
 }
 
-// Mock the entire health module synchronously. Importers will see only
-// the functions/types we re-export here; legacyPublicEnvelope lives in
-// the same file and is needed by index.ts, so we require() it through
-// the synthetic factory below to keep its real implementation.
-const realHealth = require('../../src/services/health.js') as Record<string, unknown>;
+// Explicit re-exports — only the symbols `index.ts` actually consumes
+// from this module. `legacyPublicEnvelope` keeps its real
+// implementation; `getSystemHealth` is mocked. Capturing real
+// implementations via `require()` works in current Bun (mock.module is
+// not hoisted), but if hoisting is added later the require would see
+// the mocked value. Naming each export keeps the contract explicit
+// and removes the dependency on Bun-internal evaluation order.
+import {
+  __resetSystemHealthCache as realResetCache,
+  HEALTH_VERSION as REAL_HEALTH_VERSION,
+  legacyPublicEnvelope as realLegacyPublicEnvelope,
+} from '../../src/services/health.js';
 
 mock.module('../../src/services/health.js', () => ({
-  ...realHealth,
+  legacyPublicEnvelope: realLegacyPublicEnvelope,
+  HEALTH_VERSION: REAL_HEALTH_VERSION,
+  __resetSystemHealthCache: realResetCache,
   getSystemHealth: mock(async () => buildSystemHealth()),
 }));
 

--- a/packages/backend/tests/integration/health-deterministic.test.ts
+++ b/packages/backend/tests/integration/health-deterministic.test.ts
@@ -28,7 +28,7 @@ function buildSystemHealth(): SystemHealth {
   return {
     status: mockedAggregateStatus,
     timestamp: '2026-05-07T00:00:00.000Z',
-    version: '1.0.0',
+    version: '1.1.0',
     components: {
       database: buildComponent(mockedAggregateStatus === 'unhealthy' ? 'unhealthy' : 'healthy'),
       redis: buildComponent('healthy'),

--- a/packages/backend/tests/integration/health-deterministic.test.ts
+++ b/packages/backend/tests/integration/health-deterministic.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Deterministic /health 200/503 contract tests (PR review C-1).
+ *
+ * The original health.test.ts accepts either 200 or 503 because the
+ * unit-test environment lacks a queue manager. A regression that
+ * always returned 200 with status='ok' regardless of probe results
+ * would pass that test vacuously. This file mocks `getSystemHealth`
+ * directly to drive each terminal HTTP outcome.
+ */
+import { describe, expect, it, mock } from 'bun:test';
+import type { ComponentHealth, SystemHealth } from '../../src/services/health.js';
+
+let mockedAggregateStatus: SystemHealth['status'] = 'healthy';
+
+function buildComponent(status: ComponentHealth['status']): ComponentHealth {
+  if (status === 'healthy') {
+    return { status: 'healthy', durationMs: 1, detail: { bucket: 'hashhive-test' } };
+  }
+  return {
+    status,
+    message: `${status} probe`,
+    durationMs: 1,
+    detail: { bucket: 'hashhive-test' },
+  };
+}
+
+function buildSystemHealth(): SystemHealth {
+  return {
+    status: mockedAggregateStatus,
+    timestamp: '2026-05-07T00:00:00.000Z',
+    version: '1.0.0',
+    components: {
+      database: buildComponent(mockedAggregateStatus === 'unhealthy' ? 'unhealthy' : 'healthy'),
+      redis: buildComponent('healthy'),
+      minio: buildComponent('healthy'),
+      queues: buildComponent(mockedAggregateStatus === 'degraded' ? 'degraded' : 'healthy'),
+    },
+  };
+}
+
+// Mock the entire health module synchronously. Importers will see only
+// the functions/types we re-export here; legacyPublicEnvelope lives in
+// the same file and is needed by index.ts, so we require() it through
+// the synthetic factory below to keep its real implementation.
+const realHealth = require('../../src/services/health.js') as Record<string, unknown>;
+
+mock.module('../../src/services/health.js', () => ({
+  ...realHealth,
+  getSystemHealth: mock(async () => buildSystemHealth()),
+}));
+
+mock.module('../../src/config/storage.js', () => ({
+  checkMinioHealth: mock(() =>
+    Promise.resolve({ status: 'connected' as const, bucket: 'hashhive-test' })
+  ),
+  s3: {},
+  uploadFile: mock(),
+  downloadFile: mock(),
+  deleteFile: mock(),
+  getPresignedUrl: mock(),
+}));
+
+import { app } from '../../src/index.js';
+
+describe('GET /health — deterministic 200 vs 503', () => {
+  it('returns 200 with body status="ok" when service reports healthy', async () => {
+    mockedAggregateStatus = 'healthy';
+    const res = await app.request('/health');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body['status']).toBe('ok');
+    expect(body['aggregateStatus']).toBe('healthy');
+  });
+
+  it('returns 200 with body status="degraded" when service reports degraded', async () => {
+    mockedAggregateStatus = 'degraded';
+    const res = await app.request('/health');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body['status']).toBe('degraded');
+    expect(body['aggregateStatus']).toBe('degraded');
+  });
+
+  it('returns 503 with body aggregateStatus="unhealthy" when service reports unhealthy', async () => {
+    mockedAggregateStatus = 'unhealthy';
+    const res = await app.request('/health');
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as Record<string, unknown>;
+    // Body's coarse `status` collapses to 'degraded' for backward compat
+    expect(body['status']).toBe('degraded');
+    // But aggregateStatus carries the full three-tier signal
+    expect(body['aggregateStatus']).toBe('unhealthy');
+  });
+});

--- a/packages/backend/tests/integration/health-deterministic.test.ts
+++ b/packages/backend/tests/integration/health-deterministic.test.ts
@@ -6,9 +6,29 @@
  * always returned 200 with status='ok' regardless of probe results
  * would pass that test vacuously. This file mocks `getSystemHealth`
  * directly to drive each terminal HTTP outcome.
+ *
+ * **Isolated phase**: Bun's test runner shares one process across all
+ * test files when invoked as a single `bun test` command. The
+ * `mock.module('services/health.js', ...)` call below replaces
+ * `getSystemHealth` PROCESS-WIDE — so any other file that imports
+ * `getSystemHealth` after this one (notably `health-service.test.ts`)
+ * sees the mocked function and ignores its `opts.probes` argument.
+ *
+ * The package.json test script runs this file FIRST in its own
+ * `bun test` invocation with `HEALTH_DETERMINISTIC_TEST_ISOLATED=1`
+ * set, then runs the full suite where this file's mocks are gated
+ * behind the env var and skipped. See `tasks.test.ts` and
+ * `queue-manager.test.ts` for the prior pattern this mirrors.
  */
-import { afterAll, describe, expect, it, mock } from 'bun:test';
+import { afterAll, describe, expect, it, mock, test } from 'bun:test';
+import {
+  __resetSystemHealthCache,
+  HEALTH_VERSION,
+  legacyPublicEnvelope,
+} from '../../src/services/health.js';
 import type { ComponentHealth, SystemHealth } from '../../src/services/health.js';
+
+const IS_ISOLATED = process.env['HEALTH_DETERMINISTIC_TEST_ISOLATED'] === '1';
 
 let mockedAggregateStatus: SystemHealth['status'] = 'healthy';
 
@@ -38,75 +58,80 @@ function buildSystemHealth(): SystemHealth {
   };
 }
 
-// Explicit re-exports — only the symbols `index.ts` actually consumes
-// from this module. `legacyPublicEnvelope` keeps its real
-// implementation; `getSystemHealth` is mocked. Capturing real
-// implementations via `require()` works in current Bun (mock.module is
-// not hoisted), but if hoisting is added later the require would see
-// the mocked value. Naming each export keeps the contract explicit
-// and removes the dependency on Bun-internal evaluation order.
-import {
-  __resetSystemHealthCache as realResetCache,
-  HEALTH_VERSION as REAL_HEALTH_VERSION,
-  legacyPublicEnvelope as realLegacyPublicEnvelope,
-} from '../../src/services/health.js';
+// Install mocks ONLY when the isolated-phase env var is set. Without
+// the gate, this file's mocks would replace the real `getSystemHealth`
+// process-wide and poison `health-service.test.ts` (which imports the
+// real function and passes its own `probes:` argument). The
+// `tasks.test.ts` / `queue-manager.test.ts` pattern uses
+// `describeIfIsolated` for similar isolation; here the gate must wrap
+// `mock.module` itself because that's the side-effect causing the
+// cross-file leak.
+if (IS_ISOLATED) {
+  mock.module('../../src/services/health.js', () => ({
+    legacyPublicEnvelope,
+    HEALTH_VERSION,
+    __resetSystemHealthCache,
+    getSystemHealth: mock(async () => buildSystemHealth()),
+  }));
 
-mock.module('../../src/services/health.js', () => ({
-  legacyPublicEnvelope: realLegacyPublicEnvelope,
-  HEALTH_VERSION: REAL_HEALTH_VERSION,
-  __resetSystemHealthCache: realResetCache,
-  getSystemHealth: mock(async () => buildSystemHealth()),
-}));
+  mock.module('../../src/config/storage.js', () => ({
+    checkMinioHealth: mock(() =>
+      Promise.resolve({ status: 'connected' as const, bucket: 'hashhive-test' })
+    ),
+    s3: {},
+    uploadFile: mock(),
+    downloadFile: mock(),
+    deleteFile: mock(),
+    getPresignedUrl: mock(),
+  }));
+}
 
-mock.module('../../src/config/storage.js', () => ({
-  checkMinioHealth: mock(() =>
-    Promise.resolve({ status: 'connected' as const, bucket: 'hashhive-test' })
-  ),
-  s3: {},
-  uploadFile: mock(),
-  downloadFile: mock(),
-  deleteFile: mock(),
-  getPresignedUrl: mock(),
-}));
-
+// Static import; under the isolated-phase gate the mocks above already
+// fired before this evaluates, so `app` sees the mocked `getSystemHealth`.
+// Under the non-isolated run the real `app` loads but the test bodies
+// below are skipped, so the real module isn't exercised here either.
 import { app } from '../../src/index.js';
 
-// Defensive cleanup: Bun normally isolates test files per process so
-// the health/storage mocks here don't bleed into other suites. If that
-// isolation model ever changes (e.g. running `bun test --concurrency=1`
-// across files in one process), `mock.restore()` keeps the unmocked
-// `getSystemHealth` for any test file that runs after this one.
-afterAll(() => {
-  mock.restore();
-});
-
-describe('GET /health — deterministic 200 vs 503', () => {
-  it('returns 200 with body status="ok" when service reports healthy', async () => {
-    mockedAggregateStatus = 'healthy';
-    const res = await app.request('/health');
-    expect(res.status).toBe(200);
-    const body = (await res.json()) as Record<string, unknown>;
-    expect(body['status']).toBe('ok');
-    expect(body['aggregateStatus']).toBe('healthy');
+if (!IS_ISOLATED) {
+  describe.skip('health-deterministic (skipped — runs in isolated phase)', () => {
+    test('runs only with HEALTH_DETERMINISTIC_TEST_ISOLATED=1', () => {});
+  });
+} else {
+  // Defensive cleanup. Even with the env-var gate the suite restores
+  // mocks at end so a future change that runs additional files in the
+  // same isolated process won't pick up our overrides.
+  afterAll(() => {
+    mock.restore();
   });
 
-  it('returns 200 with body status="degraded" when service reports degraded', async () => {
-    mockedAggregateStatus = 'degraded';
-    const res = await app.request('/health');
-    expect(res.status).toBe(200);
-    const body = (await res.json()) as Record<string, unknown>;
-    expect(body['status']).toBe('degraded');
-    expect(body['aggregateStatus']).toBe('degraded');
-  });
+  describe('GET /health — deterministic 200 vs 503', () => {
+    it('returns 200 with body status="ok" when service reports healthy', async () => {
+      mockedAggregateStatus = 'healthy';
+      const res = await app.request('/health');
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body['status']).toBe('ok');
+      expect(body['aggregateStatus']).toBe('healthy');
+    });
 
-  it('returns 503 with body aggregateStatus="unhealthy" when service reports unhealthy', async () => {
-    mockedAggregateStatus = 'unhealthy';
-    const res = await app.request('/health');
-    expect(res.status).toBe(503);
-    const body = (await res.json()) as Record<string, unknown>;
-    // Body's coarse `status` collapses to 'degraded' for backward compat
-    expect(body['status']).toBe('degraded');
-    // But aggregateStatus carries the full three-tier signal
-    expect(body['aggregateStatus']).toBe('unhealthy');
+    it('returns 200 with body status="degraded" when service reports degraded', async () => {
+      mockedAggregateStatus = 'degraded';
+      const res = await app.request('/health');
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body['status']).toBe('degraded');
+      expect(body['aggregateStatus']).toBe('degraded');
+    });
+
+    it('returns 503 with body aggregateStatus="unhealthy" when service reports unhealthy', async () => {
+      mockedAggregateStatus = 'unhealthy';
+      const res = await app.request('/health');
+      expect(res.status).toBe(503);
+      const body = (await res.json()) as Record<string, unknown>;
+      // Body's coarse `status` collapses to 'degraded' for backward compat
+      expect(body['status']).toBe('degraded');
+      // But aggregateStatus carries the full three-tier signal
+      expect(body['aggregateStatus']).toBe('unhealthy');
+    });
   });
-});
+}

--- a/packages/backend/tests/integration/smoke.test.ts
+++ b/packages/backend/tests/integration/smoke.test.ts
@@ -31,7 +31,7 @@ describe('Integration: Health check', () => {
 
     const body = await res.json();
     expect(['ok', 'degraded']).toContain(body['status']);
-    expect(body['version']).toBe('1.0.0');
+    expect(body['version']).toBe('1.1.0');
     expect(typeof body['timestamp']).toBe('string');
 
     // Validate ISO 8601 timestamp

--- a/packages/backend/tests/integration/smoke.test.ts
+++ b/packages/backend/tests/integration/smoke.test.ts
@@ -25,7 +25,9 @@ import { app } from '../../src/index.js';
 describe('Integration: Health check', () => {
   it('should return health status with all expected fields', async () => {
     const res = await app.request('/health');
-    expect(res.status).toBe(200);
+    // Issue #109: /health returns 503 when system is unhealthy (e.g. Redis
+    // unreachable in test env), 200 otherwise. Body shape is identical.
+    expect([200, 503]).toContain(res.status);
 
     const body = await res.json();
     expect(['ok', 'degraded']).toContain(body['status']);

--- a/packages/backend/tests/unit/events.test.ts
+++ b/packages/backend/tests/unit/events.test.ts
@@ -9,6 +9,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import {
   __resetEventsForTesting,
+  type AppEvent,
   broadcastSystemEvent,
   broadcastSystemHealth,
   emit,
@@ -17,6 +18,23 @@ import {
   registerClient,
   unregisterClient,
 } from '../../src/services/events.js';
+
+// Compile-time exhaustiveness pin for the drift-guard test below. Adding
+// a new EventType without updating this map is a type error, which then
+// guides the contributor to also extend the runtime drift guard. There's
+// no way to derive a runtime array from a TypeScript union, so this is
+// the closest we can get to a single source of truth.
+type _EventTypeExhaustive = Record<AppEvent['type'], true>;
+const _EVENT_TYPE_GUARD: _EventTypeExhaustive = {
+  agent_status: true,
+  campaign_status: true,
+  task_update: true,
+  crack_result: true,
+  resource_update: true,
+  system_health: true,
+};
+// Reference the constant so unused-export rules don't strip it.
+void _EVENT_TYPE_GUARD;
 
 interface FakeWs {
   readyState: number;

--- a/packages/backend/tests/unit/events.test.ts
+++ b/packages/backend/tests/unit/events.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Unit tests for the event-broadcast layer (issue #109).
+ *
+ * Focus on the new `broadcastSystemEvent` / `broadcastSystemHealth`
+ * helpers which bypass project-scope filtering, and the existing
+ * `emit()` / `emitAgentStatus` to verify project scoping is preserved
+ * (regression guard).
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+  __resetEventsForTesting,
+  broadcastSystemEvent,
+  broadcastSystemHealth,
+  emit,
+  emitAgentStatus,
+  getClientCount,
+  registerClient,
+  unregisterClient,
+} from '../../src/services/events.js';
+
+interface FakeWs {
+  readyState: number;
+  sent: string[];
+  send: (data: string) => void;
+}
+
+function createFakeWs(readyState = 1): FakeWs {
+  const ws: FakeWs = {
+    readyState,
+    sent: [],
+    send: (data: string) => {
+      ws.sent.push(data);
+    },
+  };
+  return ws;
+}
+
+// Reset the module-level client registry and throttle map before each
+// test so suite-wide ordering doesn't leak state (testing review T-006).
+const registeredIds: number[] = [];
+
+beforeEach(() => {
+  __resetEventsForTesting();
+  registeredIds.length = 0;
+});
+
+afterEach(() => {
+  for (const id of registeredIds) {
+    unregisterClient(id);
+  }
+});
+
+function trackedRegister(
+  ws: FakeWs,
+  projectIds: number[],
+  eventTypes?: Parameters<typeof registerClient>[2]
+): number {
+  const id = registerClient(ws, projectIds, eventTypes);
+  registeredIds.push(id);
+  return id;
+}
+
+describe('broadcastSystemEvent', () => {
+  test('delivers to all clients regardless of project subscription', () => {
+    const ws1 = createFakeWs();
+    const ws2 = createFakeWs();
+    trackedRegister(ws1, [1]);
+    trackedRegister(ws2, [42]);
+
+    broadcastSystemEvent('system_health', {
+      component: 'database',
+      status: 'degraded',
+    });
+
+    expect(ws1.sent).toHaveLength(1);
+    expect(ws2.sent).toHaveLength(1);
+    const payload = JSON.parse(ws1.sent[0]!);
+    expect(payload.type).toBe('system_health');
+    expect(payload.data.component).toBe('database');
+    expect(payload.data.status).toBe('degraded');
+  });
+
+  test('respects subscribedTypes — clients that opt out do not receive', () => {
+    const wsOptedOut = createFakeWs();
+    const wsSubscribed = createFakeWs();
+    trackedRegister(wsOptedOut, [1], ['agent_status']);
+    trackedRegister(wsSubscribed, [1], ['system_health']);
+
+    broadcastSystemEvent('system_health', { component: 'redis', status: 'unhealthy' });
+
+    expect(wsOptedOut.sent).toHaveLength(0);
+    expect(wsSubscribed.sent).toHaveLength(1);
+  });
+
+  test('removes clients with closed sockets on broadcast attempt', () => {
+    const closedWs = createFakeWs(3 /* CLOSED */);
+    const id = trackedRegister(closedWs, [1]);
+    const before = getClientCount();
+
+    broadcastSystemEvent('system_health', { component: 'minio', status: 'unhealthy' });
+
+    expect(closedWs.sent).toHaveLength(0);
+    expect(getClientCount()).toBe(before - 1);
+    // Already evicted from the map; remove from local tracking too.
+    registeredIds.splice(registeredIds.indexOf(id), 1);
+  });
+
+  test('does NOT throttle simultaneous events (two components flip on same tick)', () => {
+    const ws = createFakeWs();
+    trackedRegister(ws, [1]);
+
+    broadcastSystemEvent('system_health', { component: 'database', status: 'degraded' });
+    broadcastSystemEvent('system_health', { component: 'redis', status: 'unhealthy' });
+
+    expect(ws.sent).toHaveLength(2);
+    const first = JSON.parse(ws.sent[0]!);
+    const second = JSON.parse(ws.sent[1]!);
+    expect(first.data.component).toBe('database');
+    expect(second.data.component).toBe('redis');
+  });
+
+  test('uses sentinel projectId 0 so consumers can identify system origin', () => {
+    const ws = createFakeWs();
+    trackedRegister(ws, [99]);
+    broadcastSystemEvent('system_health', { component: 'queues', status: 'degraded' });
+    const payload = JSON.parse(ws.sent[0]!);
+    expect(payload.projectId).toBe(0);
+  });
+});
+
+describe('broadcastSystemHealth', () => {
+  test('serializes component, status, and optional message into payload data', () => {
+    const ws = createFakeWs();
+    trackedRegister(ws, [1]);
+    broadcastSystemHealth('database', 'degraded', 'pool 90% full');
+    const payload = JSON.parse(ws.sent[0]!);
+    expect(payload.data).toEqual({
+      component: 'database',
+      status: 'degraded',
+      message: 'pool 90% full',
+    });
+  });
+
+  test('omits message field when not provided', () => {
+    const ws = createFakeWs();
+    trackedRegister(ws, [1]);
+    broadcastSystemHealth('redis', 'healthy');
+    const payload = JSON.parse(ws.sent[0]!);
+    expect(payload.data.message).toBeUndefined();
+    expect(payload.data.component).toBe('redis');
+    expect(payload.data.status).toBe('healthy');
+  });
+});
+
+describe('emit (regression: project scoping unchanged)', () => {
+  test('emit delivers only to clients subscribed to the event projectId', async () => {
+    const wsScoped = createFakeWs();
+    const wsOtherProject = createFakeWs();
+    trackedRegister(wsScoped, [1]);
+    trackedRegister(wsOtherProject, [2]);
+
+    emit({
+      type: 'agent_status',
+      projectId: 1,
+      data: { agentId: 7, status: 'online' },
+      timestamp: new Date().toISOString(),
+    });
+
+    expect(wsScoped.sent).toHaveLength(1);
+    expect(wsOtherProject.sent).toHaveLength(0);
+  });
+
+  test('emitAgentStatus still respects project filter (does not leak into broadcast path)', () => {
+    const wsScoped = createFakeWs();
+    const wsOther = createFakeWs();
+    trackedRegister(wsScoped, [1]);
+    trackedRegister(wsOther, [2]);
+
+    emitAgentStatus(1, 7, 'online');
+
+    expect(wsScoped.sent).toHaveLength(1);
+    expect(wsOther.sent).toHaveLength(0);
+  });
+
+  test('throttle key includes both type and projectId (no cross-type collisions)', () => {
+    // Issue #109 testing review T-006: prove that emitting two different
+    // event types in quick succession on the same projectId both deliver
+    // (different throttle keys) — this would silently fail if the throttle
+    // key was just `${event.type}` or just `${event.projectId}`.
+    const ws = createFakeWs();
+    trackedRegister(ws, [1]);
+
+    emit({
+      type: 'agent_status',
+      projectId: 1,
+      data: { agentId: 1, status: 'online' },
+      timestamp: new Date().toISOString(),
+    });
+    emit({
+      type: 'campaign_status',
+      projectId: 1,
+      data: { campaignId: 5, status: 'running' },
+      timestamp: new Date().toISOString(),
+    });
+
+    expect(ws.sent).toHaveLength(2);
+  });
+});

--- a/packages/backend/tests/unit/events.test.ts
+++ b/packages/backend/tests/unit/events.test.ts
@@ -182,6 +182,60 @@ describe('emit (regression: project scoping unchanged)', () => {
     expect(wsOther.sent).toHaveLength(0);
   });
 
+  test('ALL_EVENT_TYPES default subscription delivers every EventType member (drift guard)', () => {
+    // The events.ts source warns: ALL_EVENT_TYPES MUST stay in sync with
+    // the EventType union. If a future EventType is added but the array
+    // is not updated, default-subscribed clients (no ?types= param)
+    // silently miss the new event. This test enumerates every type and
+    // verifies a default-subscribed client receives each one.
+    const ws = createFakeWs();
+    trackedRegister(ws, [1]); // No eventTypes arg → default to ALL_EVENT_TYPES
+
+    // Every project-scoped type should reach the client
+    emit({
+      type: 'agent_status',
+      projectId: 1,
+      data: {},
+      timestamp: new Date().toISOString(),
+    });
+    emit({
+      type: 'campaign_status',
+      projectId: 1,
+      data: {},
+      timestamp: new Date().toISOString(),
+    });
+    emit({
+      type: 'task_update',
+      projectId: 1,
+      data: {},
+      timestamp: new Date().toISOString(),
+    });
+    emit({
+      type: 'crack_result',
+      projectId: 1,
+      data: {},
+      timestamp: new Date().toISOString(),
+    });
+    emit({
+      type: 'resource_update',
+      projectId: 1,
+      data: {},
+      timestamp: new Date().toISOString(),
+    });
+    // System type also reaches (broadcast bypass + default subscription)
+    broadcastSystemEvent('system_health', { component: 'database', status: 'healthy' });
+
+    const types = ws.sent.map((p) => JSON.parse(p).type as string).sort();
+    expect(types).toEqual([
+      'agent_status',
+      'campaign_status',
+      'crack_result',
+      'resource_update',
+      'system_health',
+      'task_update',
+    ]);
+  });
+
   test('throttle key includes both type and projectId (no cross-type collisions)', () => {
     // Issue #109 testing review T-006: prove that emitting two different
     // event types in quick succession on the same projectId both deliver

--- a/packages/backend/tests/unit/events.test.ts
+++ b/packages/backend/tests/unit/events.test.ts
@@ -53,6 +53,31 @@ function createFakeWs(readyState = 1): FakeWs {
   return ws;
 }
 
+/**
+ * Read the parsed payload of a delivered frame, asserting first that
+ * the frame index actually exists. Replaces `JSON.parse(ws.sent[i]!)`
+ * patterns that bypass `noUncheckedIndexedAccess` and produce opaque
+ * "Cannot read properties of undefined" errors when a broadcast is
+ * missing.
+ *
+ * Returns a loosely-typed payload shape (`type`, `projectId`, `data`)
+ * so individual tests can read nested fields without their own casts.
+ */
+interface ParsedFrame {
+  type: string;
+  projectId: number;
+  data: Record<string, unknown>;
+  timestamp: string;
+}
+
+function getFrame(ws: FakeWs, index: number): ParsedFrame {
+  const raw = ws.sent[index];
+  if (raw === undefined) {
+    throw new Error(`expected ws.sent[${index}] to exist; ws has ${ws.sent.length} frames`);
+  }
+  return JSON.parse(raw) as ParsedFrame;
+}
+
 // Reset the module-level client registry and throttle map before each
 // test so suite-wide ordering doesn't leak state (testing review T-006).
 const registeredIds: number[] = [];
@@ -92,7 +117,7 @@ describe('broadcastSystemEvent', () => {
 
     expect(ws1.sent).toHaveLength(1);
     expect(ws2.sent).toHaveLength(1);
-    const payload = JSON.parse(ws1.sent[0]!);
+    const payload = getFrame(ws1, 0);
     expect(payload.type).toBe('system_health');
     expect(payload.data.component).toBe('database');
     expect(payload.data.status).toBe('degraded');
@@ -123,6 +148,35 @@ describe('broadcastSystemEvent', () => {
     registeredIds.splice(registeredIds.indexOf(id), 1);
   });
 
+  test('open socket whose send() throws is evicted; delivery continues to peers', () => {
+    // The closed-socket case (above) covers the readyState !== 1 path.
+    // This case covers the OPEN-but-send-throws path: e.g. an oversized
+    // frame, an EPIPE under backpressure, or a buffer-overflow. The bad
+    // client must be dropped without taking down delivery to healthy
+    // peers.
+    const throwingWs: FakeWs = {
+      readyState: 1,
+      sent: [],
+      send: () => {
+        throw new Error('synthetic send failure');
+      },
+    };
+    const healthyWs = createFakeWs();
+    const throwingId = trackedRegister(throwingWs, [1]);
+    trackedRegister(healthyWs, [1]);
+    const before = getClientCount();
+
+    broadcastSystemEvent('system_health', { component: 'queues', status: 'degraded' });
+
+    // Throwing client received nothing and was evicted.
+    expect(throwingWs.sent).toHaveLength(0);
+    expect(getClientCount()).toBe(before - 1);
+    // Healthy peer still got the broadcast.
+    expect(healthyWs.sent).toHaveLength(1);
+    // Already evicted from the map; remove from local tracking too.
+    registeredIds.splice(registeredIds.indexOf(throwingId), 1);
+  });
+
   test('does NOT throttle simultaneous events (two components flip on same tick)', () => {
     const ws = createFakeWs();
     trackedRegister(ws, [1]);
@@ -131,8 +185,8 @@ describe('broadcastSystemEvent', () => {
     broadcastSystemEvent('system_health', { component: 'redis', status: 'unhealthy' });
 
     expect(ws.sent).toHaveLength(2);
-    const first = JSON.parse(ws.sent[0]!);
-    const second = JSON.parse(ws.sent[1]!);
+    const first = getFrame(ws, 0);
+    const second = getFrame(ws, 1);
     expect(first.data.component).toBe('database');
     expect(second.data.component).toBe('redis');
   });
@@ -141,7 +195,7 @@ describe('broadcastSystemEvent', () => {
     const ws = createFakeWs();
     trackedRegister(ws, [99]);
     broadcastSystemEvent('system_health', { component: 'queues', status: 'degraded' });
-    const payload = JSON.parse(ws.sent[0]!);
+    const payload = getFrame(ws, 0);
     expect(payload.projectId).toBe(0);
   });
 });
@@ -151,7 +205,7 @@ describe('broadcastSystemHealth', () => {
     const ws = createFakeWs();
     trackedRegister(ws, [1]);
     broadcastSystemHealth('database', 'degraded', 'pool 90% full');
-    const payload = JSON.parse(ws.sent[0]!);
+    const payload = getFrame(ws, 0);
     expect(payload.data).toEqual({
       component: 'database',
       status: 'degraded',
@@ -163,7 +217,7 @@ describe('broadcastSystemHealth', () => {
     const ws = createFakeWs();
     trackedRegister(ws, [1]);
     broadcastSystemHealth('redis', 'healthy');
-    const payload = JSON.parse(ws.sent[0]!);
+    const payload = getFrame(ws, 0);
     expect(payload.data.message).toBeUndefined();
     expect(payload.data.component).toBe('redis');
     expect(payload.data.status).toBe('healthy');

--- a/packages/backend/tests/unit/health-monitor.test.ts
+++ b/packages/backend/tests/unit/health-monitor.test.ts
@@ -1,0 +1,423 @@
+/**
+ * Unit tests for the scheduled health-monitor worker (issue #109).
+ *
+ * Tests target the pure tick function `runHealthMonitorTick` which takes
+ * an injectable dependency bag — the BullMQ Worker / Redis / actual
+ * service bindings live behind that bag and are not exercised here.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  type HealthMonitorDeps,
+  runHealthMonitorTick,
+} from '../../src/queue/workers/health-monitor.js';
+import type { ComponentHealth, ComponentName, ComponentStatus } from '../../src/services/health.js';
+
+interface TestContext {
+  /** In-memory cache state (authoritative for transition detection). */
+  memory: Record<ComponentName, ComponentStatus | null>;
+  /** Redis-mirrored state (used only to seed memory after fresh boot). */
+  redis: Record<ComponentName, ComponentStatus | null>;
+  broadcasts: Array<{ component: ComponentName; status: ComponentStatus; message?: string }>;
+  deps: HealthMonitorDeps;
+}
+
+function makeComponent(status: ComponentStatus, message?: string): ComponentHealth {
+  return { status, durationMs: 1, ...(message ? { message } : {}) };
+}
+
+interface BuildContextOptions {
+  /** Initial in-memory state (post-boot worker has empty memory). */
+  memory?: Partial<Record<ComponentName, ComponentStatus>>;
+  /** Initial Redis-backed state (seeded into memory on first cache miss). */
+  redis?: Partial<Record<ComponentName, ComponentStatus>>;
+}
+
+function buildContext(
+  initial: BuildContextOptions,
+  componentStatuses: Record<
+    ComponentName,
+    ComponentStatus | { status: ComponentStatus; message?: string }
+  >
+): TestContext {
+  const memory: Record<ComponentName, ComponentStatus | null> = {
+    database: initial.memory?.database ?? null,
+    redis: initial.memory?.redis ?? null,
+    minio: initial.memory?.minio ?? null,
+    queues: initial.memory?.queues ?? null,
+  };
+  const redis: Record<ComponentName, ComponentStatus | null> = {
+    database: initial.redis?.database ?? null,
+    redis: initial.redis?.redis ?? null,
+    minio: initial.redis?.minio ?? null,
+    queues: initial.redis?.queues ?? null,
+  };
+  const broadcasts: TestContext['broadcasts'] = [];
+  const components: Record<ComponentName, ComponentHealth> = {
+    database: parseStatus(componentStatuses.database),
+    redis: parseStatus(componentStatuses.redis),
+    minio: parseStatus(componentStatuses.minio),
+    queues: parseStatus(componentStatuses.queues),
+  };
+
+  const deps: HealthMonitorDeps = {
+    readMemoryStatus: (component) => memory[component],
+    writeMemoryStatus: (component, status) => {
+      memory[component] = status;
+    },
+    readRedisStatus: async (component) => redis[component],
+    writeRedisStatus: async (component, status) => {
+      redis[component] = status;
+    },
+    broadcast: (component, status, message) => {
+      broadcasts.push({ component, status, ...(message ? { message } : {}) });
+    },
+    fetchHealth: async () => ({ components }),
+  };
+
+  return { memory, redis, broadcasts, deps };
+}
+
+function parseStatus(
+  s: ComponentStatus | { status: ComponentStatus; message?: string }
+): ComponentHealth {
+  if (typeof s === 'string') return makeComponent(s);
+  return makeComponent(s.status, s.message);
+}
+
+describe('runHealthMonitorTick', () => {
+  test('first run with no prior state seeds memory and emits zero broadcasts', async () => {
+    const ctx = buildContext(
+      {}, // no prior state in memory or Redis
+      { database: 'healthy', redis: 'healthy', minio: 'healthy', queues: 'healthy' }
+    );
+
+    const result = await runHealthMonitorTick(ctx.deps);
+
+    expect(result.transitioned).toEqual([]);
+    expect(result.initialized.sort()).toEqual(['database', 'minio', 'queues', 'redis']);
+    expect(ctx.broadcasts).toHaveLength(0);
+
+    // Both memory and Redis are seeded
+    expect(ctx.memory.database).toBe('healthy');
+    expect(ctx.memory.queues).toBe('healthy');
+    expect(ctx.redis.database).toBe('healthy');
+  });
+
+  test('post-boot tick with empty memory but populated Redis seeds without broadcasting', async () => {
+    // Worker just restarted: memory is empty, but Redis still has prior state.
+    // The first tick should treat current === redis as unchanged (no broadcast)
+    // rather than a fresh-init "everything new" volley.
+    const ctx = buildContext(
+      {
+        memory: {}, // empty post-boot
+        redis: { database: 'healthy', redis: 'healthy', minio: 'healthy', queues: 'healthy' },
+      },
+      { database: 'healthy', redis: 'healthy', minio: 'healthy', queues: 'healthy' }
+    );
+
+    const result = await runHealthMonitorTick(ctx.deps);
+
+    expect(result.transitioned).toEqual([]);
+    expect(result.unchanged.sort()).toEqual(['database', 'minio', 'queues', 'redis']);
+    expect(ctx.broadcasts).toHaveLength(0);
+  });
+
+  test('second run with identical status emits zero broadcasts', async () => {
+    const ctx = buildContext(
+      {
+        memory: { database: 'healthy', redis: 'healthy', minio: 'healthy', queues: 'healthy' },
+      },
+      { database: 'healthy', redis: 'healthy', minio: 'healthy', queues: 'healthy' }
+    );
+
+    const result = await runHealthMonitorTick(ctx.deps);
+
+    expect(result.transitioned).toEqual([]);
+    expect(result.unchanged.sort()).toEqual(['database', 'minio', 'queues', 'redis']);
+    expect(ctx.broadcasts).toHaveLength(0);
+  });
+
+  test('one component flips from healthy to degraded — exactly one broadcast', async () => {
+    const ctx = buildContext(
+      {
+        memory: { database: 'healthy', redis: 'healthy', minio: 'healthy', queues: 'healthy' },
+      },
+      {
+        database: { status: 'degraded', message: 'pool 90% full' },
+        redis: 'healthy',
+        minio: 'healthy',
+        queues: 'healthy',
+      }
+    );
+
+    const result = await runHealthMonitorTick(ctx.deps);
+
+    expect(result.transitioned).toEqual(['database']);
+    expect(ctx.broadcasts).toHaveLength(1);
+    expect(ctx.broadcasts[0]).toEqual({
+      component: 'database',
+      status: 'degraded',
+      message: 'pool 90% full',
+    });
+    expect(ctx.memory.database).toBe('degraded');
+    // Other components stayed healthy
+    expect(ctx.memory.queues).toBe('healthy');
+  });
+
+  test('two components flip simultaneously — exactly two broadcasts', async () => {
+    const ctx = buildContext(
+      {
+        memory: { database: 'healthy', redis: 'healthy', minio: 'healthy', queues: 'healthy' },
+      },
+      {
+        database: 'degraded',
+        redis: 'unhealthy',
+        minio: 'healthy',
+        queues: 'healthy',
+      }
+    );
+
+    const result = await runHealthMonitorTick(ctx.deps);
+
+    expect(result.transitioned.sort()).toEqual(['database', 'redis']);
+    expect(ctx.broadcasts).toHaveLength(2);
+    const components = ctx.broadcasts.map((b) => b.component).sort();
+    expect(components).toEqual(['database', 'redis']);
+  });
+
+  test('all four components flip simultaneously — four broadcasts (testing T-008 / U5)', async () => {
+    const ctx = buildContext(
+      {
+        memory: { database: 'healthy', redis: 'healthy', minio: 'healthy', queues: 'healthy' },
+      },
+      {
+        database: 'unhealthy',
+        redis: 'unhealthy',
+        minio: 'unhealthy',
+        queues: 'unhealthy',
+      }
+    );
+
+    const result = await runHealthMonitorTick(ctx.deps);
+
+    expect(result.transitioned.sort()).toEqual(['database', 'minio', 'queues', 'redis']);
+    expect(ctx.broadcasts).toHaveLength(4);
+  });
+
+  test('component flips back from unhealthy to healthy — broadcast on recovery', async () => {
+    const ctx = buildContext(
+      {
+        memory: { database: 'healthy', redis: 'unhealthy', minio: 'healthy', queues: 'healthy' },
+      },
+      { database: 'healthy', redis: 'healthy', minio: 'healthy', queues: 'healthy' }
+    );
+
+    const result = await runHealthMonitorTick(ctx.deps);
+
+    expect(result.transitioned).toEqual(['redis']);
+    expect(ctx.broadcasts[0]?.status).toBe('healthy');
+  });
+
+  test('full Redis healthy → unhealthy → recovered cycle emits both transitions even when Redis read/write fails (C1 regression)', async () => {
+    // Setup: persistent in-memory cache across simulated ticks; Redis fails
+    // both reads and writes (simulating Redis itself being the unhealthy
+    // component). The transition-detection signal must survive the outage.
+    const memory = new Map<ComponentName, ComponentStatus>([
+      ['database', 'healthy'],
+      ['redis', 'healthy'],
+      ['minio', 'healthy'],
+      ['queues', 'healthy'],
+    ]);
+    const broadcasts: TestContext['broadcasts'] = [];
+
+    function depsForCurrent(
+      components: Record<ComponentName, ComponentHealth>,
+      redisFails: boolean
+    ): HealthMonitorDeps {
+      return {
+        readMemoryStatus: (c) => memory.get(c) ?? null,
+        writeMemoryStatus: (c, s) => {
+          memory.set(c, s);
+        },
+        readRedisStatus: async () => {
+          if (redisFails) throw new Error('redis ECONNREFUSED');
+          return null;
+        },
+        writeRedisStatus: async () => {
+          if (redisFails) throw new Error('redis ECONNREFUSED');
+        },
+        broadcast: (c, s, m) =>
+          broadcasts.push({ component: c, status: s, ...(m ? { message: m } : {}) }),
+        fetchHealth: async () => ({ components }),
+      };
+    }
+
+    // Tick 1: Redis goes down. Probe reports redis=unhealthy.
+    await runHealthMonitorTick(
+      depsForCurrent(
+        {
+          database: makeComponent('healthy'),
+          redis: makeComponent('unhealthy', 'redis disconnected'),
+          minio: makeComponent('healthy'),
+          queues: makeComponent('unhealthy', 'queue manager not connected to redis'),
+        },
+        true
+      )
+    );
+    // Tick 2: Redis still down. Same status. No new broadcasts.
+    await runHealthMonitorTick(
+      depsForCurrent(
+        {
+          database: makeComponent('healthy'),
+          redis: makeComponent('unhealthy', 'redis disconnected'),
+          minio: makeComponent('healthy'),
+          queues: makeComponent('unhealthy', 'queue manager not connected to redis'),
+        },
+        true
+      )
+    );
+    // Tick 3: Redis recovers.
+    await runHealthMonitorTick(
+      depsForCurrent(
+        {
+          database: makeComponent('healthy'),
+          redis: makeComponent('healthy'),
+          minio: makeComponent('healthy'),
+          queues: makeComponent('healthy'),
+        },
+        false
+      )
+    );
+
+    // Two transitions for redis: healthy→unhealthy (tick 1), unhealthy→healthy (tick 3).
+    // Two transitions for queues: healthy→unhealthy (tick 1), unhealthy→healthy (tick 3).
+    const redisBroadcasts = broadcasts.filter((b) => b.component === 'redis');
+    expect(redisBroadcasts).toHaveLength(2);
+    expect(redisBroadcasts[0]?.status).toBe('unhealthy');
+    expect(redisBroadcasts[1]?.status).toBe('healthy');
+    const queuesBroadcasts = broadcasts.filter((b) => b.component === 'queues');
+    expect(queuesBroadcasts).toHaveLength(2);
+  });
+
+  test('Redis read failure on first-tick post-boot is logged but treated as no prior state', async () => {
+    const broadcasts: TestContext['broadcasts'] = [];
+    const deps: HealthMonitorDeps = {
+      readMemoryStatus: () => null,
+      writeMemoryStatus: () => {},
+      readRedisStatus: async () => {
+        throw new Error('redis ECONNREFUSED');
+      },
+      writeRedisStatus: async () => {},
+      broadcast: (component, status, message) => {
+        broadcasts.push({ component, status, ...(message ? { message } : {}) });
+      },
+      fetchHealth: async () => ({
+        components: {
+          database: makeComponent('healthy'),
+          redis: makeComponent('unhealthy', 'connection refused'),
+          minio: makeComponent('healthy'),
+          queues: makeComponent('healthy'),
+        },
+      }),
+    };
+
+    const result = await runHealthMonitorTick(deps);
+    // Treated as initialized (no prior state) — no broadcast
+    expect(result.initialized).toContain('redis');
+    expect(broadcasts).toHaveLength(0);
+  });
+
+  test('Redis write failure is logged but does not crash the worker', async () => {
+    const ctx = buildContext(
+      { memory: { database: 'healthy' } },
+      { database: 'degraded', redis: 'healthy', minio: 'healthy', queues: 'healthy' }
+    );
+    // Override writeRedisStatus to throw — memory write still succeeds
+    const deps: HealthMonitorDeps = {
+      ...ctx.deps,
+      writeRedisStatus: async () => {
+        throw new Error('redis disconnected during write');
+      },
+    };
+
+    const result = await runHealthMonitorTick(deps);
+
+    expect(result.transitioned).toContain('database');
+    expect(ctx.broadcasts).toHaveLength(1);
+    // Memory was still updated despite Redis write failure
+    expect(ctx.memory.database).toBe('degraded');
+  });
+
+  test('broadcast throw on one component does not stop the loop (T-009)', async () => {
+    const ctx = buildContext(
+      {
+        memory: { database: 'healthy', redis: 'healthy', minio: 'healthy', queues: 'healthy' },
+      },
+      {
+        database: 'degraded',
+        redis: 'degraded',
+        minio: 'healthy',
+        queues: 'healthy',
+      }
+    );
+    let firstCall = true;
+    const deps: HealthMonitorDeps = {
+      ...ctx.deps,
+      broadcast: (component, status, message) => {
+        if (firstCall) {
+          firstCall = false;
+          throw new Error('synthetic broadcast failure');
+        }
+        ctx.broadcasts.push({ component, status, ...(message ? { message } : {}) });
+      },
+    };
+
+    const result = await runHealthMonitorTick(deps);
+
+    // Both components still appear in transitioned (loop continued)
+    expect(result.transitioned.sort()).toEqual(['database', 'redis']);
+    // Memory was updated for both despite first broadcast throwing
+    expect(ctx.memory.database).toBe('degraded');
+    expect(ctx.memory.redis).toBe('degraded');
+  });
+
+  test('getSystemHealth rejection is swallowed; tick returns empty result', async () => {
+    const broadcasts: TestContext['broadcasts'] = [];
+    const deps: HealthMonitorDeps = {
+      readMemoryStatus: () => null,
+      writeMemoryStatus: () => {},
+      readRedisStatus: async () => null,
+      writeRedisStatus: async () => {},
+      broadcast: (component, status, message) => {
+        broadcasts.push({ component, status, ...(message ? { message } : {}) });
+      },
+      fetchHealth: async () => {
+        throw new Error('catastrophic probe failure');
+      },
+    };
+
+    const result = await runHealthMonitorTick(deps);
+
+    expect(result.transitioned).toEqual([]);
+    expect(result.initialized).toEqual([]);
+    expect(result.unchanged).toEqual([]);
+    expect(broadcasts).toHaveLength(0);
+  });
+
+  test('forwards component message into broadcast payload on transition', async () => {
+    const ctx = buildContext(
+      { memory: { queues: 'healthy' } },
+      {
+        queues: { status: 'degraded', message: 'tasks-high waiting=50000 > 10000' },
+        database: 'healthy',
+        redis: 'healthy',
+        minio: 'healthy',
+      }
+    );
+
+    await runHealthMonitorTick(ctx.deps);
+
+    const queueBroadcast = ctx.broadcasts.find((b) => b.component === 'queues');
+    expect(queueBroadcast?.message).toBe('tasks-high waiting=50000 > 10000');
+  });
+});

--- a/packages/backend/tests/unit/health-service.test.ts
+++ b/packages/backend/tests/unit/health-service.test.ts
@@ -86,6 +86,34 @@ describe('runProbe', () => {
     expect(result.message).toContain('timed out');
     expect(result.message).toContain('50ms');
   });
+
+  test('passes an AbortSignal to the probe and aborts it on timeout', async () => {
+    let receivedSignal: AbortSignal | undefined;
+    const probeFn = (signal: AbortSignal) =>
+      new Promise<never>(() => {
+        // Capture the signal so the test can assert it aborts.
+        receivedSignal = signal;
+      });
+    const result = await runProbe('database', probeFn, 30);
+    expect(result.status).toBe('unhealthy');
+    expect(result.message).toContain('timed out');
+    // The probe captured the signal; once the wrapper times out, it
+    // should be aborted so cancellation-aware drivers (S3 SDK
+    // abortSignal, fetch) terminate the underlying call.
+    expect(receivedSignal).toBeDefined();
+    expect(receivedSignal?.aborted).toBe(true);
+  });
+
+  test('does NOT abort the signal when the probe resolves before timeout', async () => {
+    let receivedSignal: AbortSignal | undefined;
+    const probeFn = async (signal: AbortSignal) => {
+      receivedSignal = signal;
+      return { status: 'healthy' as const };
+    };
+    const result = await runProbe('database', probeFn, 1000);
+    expect(result.status).toBe('healthy');
+    expect(receivedSignal?.aborted).toBe(false);
+  });
 });
 
 describe('probeDatabase', () => {

--- a/packages/backend/tests/unit/health-service.test.ts
+++ b/packages/backend/tests/unit/health-service.test.ts
@@ -135,8 +135,25 @@ describe('probeDatabase', () => {
       80
     );
     expect(result.status).toBe('degraded');
-    expect(result.message).toContain('85%');
+    // Message now uses unrounded pct (formatted to 1 decimal) so the
+    // displayed value matches the threshold-comparison value exactly.
+    expect(result.message).toContain('85.0%');
     expect(result.message).toContain('80%');
+  });
+
+  test('reports unrounded connectionsPct in detail (no display/decision drift)', async () => {
+    // 79.6% should remain healthy (below 80% threshold) AND read 79.6
+    // in detail.connectionsPct — previously detail rounded to 80 while
+    // the unrounded 79.6 kept status healthy, which was confusing.
+    const result = await probeDatabase(
+      {
+        ping: async () => undefined,
+        poolStats: async () => ({ used: 796, max: 1000 }),
+      },
+      80
+    );
+    expect(result.status).toBe('healthy');
+    expect(result.detail?.['connectionsPct']).toBeCloseTo(79.6, 5);
   });
 
   test('throws (caught upstream by runProbe) when ping fails', async () => {
@@ -307,7 +324,7 @@ describe('getSystemHealth', () => {
   test('returns SystemHealth shape with all four components and version', async () => {
     const result = await getSystemHealth({ probes: allHealthyProbes });
     expect(result.status).toBe('healthy');
-    expect(result.version).toBe('1.0.0');
+    expect(result.version).toBe('1.1.0');
     expect(result.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     expect(result.components.database.status).toBe('healthy');
     expect(result.components.redis.status).toBe('healthy');
@@ -472,7 +489,7 @@ describe('legacyPublicEnvelope', () => {
     expect(env.services.minio.status).toBe('connected');
     expect(env.services.minio.bucket).toBe('hashhive-test');
     expect(env.services.queues.status).toBe('connected');
-    expect(env.version).toBe('1.0.0');
+    expect(env.version).toBe('1.1.0');
   });
 
   test('degraded maps to status="degraded" body, aggregateStatus="degraded", services stay "connected"', async () => {

--- a/packages/backend/tests/unit/health-service.test.ts
+++ b/packages/backend/tests/unit/health-service.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, test } from 'bun:test';
+import { beforeEach, describe, expect, test } from 'bun:test';
 import {
+  __resetSystemHealthCache,
   aggregateStatus,
   type ComponentHealth,
   type ComponentName,
@@ -11,6 +12,15 @@ import {
   probeRedis,
   runProbe,
 } from '../../src/services/health.js';
+
+// getSystemHealth() carries a 5s in-memory cache + in-flight dedupe.
+// Tests that pass `probes:` bypass the cache by design, but tests that
+// run AFTER one without the bypass could hit a stale cached value.
+// Reset before each test so every assertion observes only its own
+// probes — eliminates ordering-dependent CI flakes.
+beforeEach(() => {
+  __resetSystemHealthCache();
+});
 
 function makeComponent(status: ComponentHealth['status']): ComponentHealth {
   return { status, durationMs: 1 };

--- a/packages/backend/tests/unit/health-service.test.ts
+++ b/packages/backend/tests/unit/health-service.test.ts
@@ -1,0 +1,535 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  aggregateStatus,
+  type ComponentHealth,
+  type ComponentName,
+  getSystemHealth,
+  legacyPublicEnvelope,
+  probeDatabase,
+  probeMinio,
+  probeQueues,
+  probeRedis,
+  runProbe,
+} from '../../src/services/health.js';
+
+function makeComponent(status: ComponentHealth['status']): ComponentHealth {
+  return { status, durationMs: 1 };
+}
+
+function makeComponents(
+  overrides: Partial<Record<ComponentName, ComponentHealth['status']>>
+): Record<ComponentName, ComponentHealth> {
+  return {
+    database: makeComponent(overrides.database ?? 'healthy'),
+    redis: makeComponent(overrides.redis ?? 'healthy'),
+    minio: makeComponent(overrides.minio ?? 'healthy'),
+    queues: makeComponent(overrides.queues ?? 'healthy'),
+  };
+}
+
+describe('aggregateStatus', () => {
+  test('returns healthy when all components are healthy', () => {
+    expect(aggregateStatus(makeComponents({}))).toBe('healthy');
+  });
+
+  test('returns degraded when one component is degraded and others healthy', () => {
+    expect(aggregateStatus(makeComponents({ queues: 'degraded' }))).toBe('degraded');
+  });
+
+  test('returns unhealthy when any component is unhealthy regardless of degraded', () => {
+    expect(aggregateStatus(makeComponents({ minio: 'unhealthy', queues: 'degraded' }))).toBe(
+      'unhealthy'
+    );
+  });
+
+  test('returns unhealthy when all components are unhealthy', () => {
+    expect(
+      aggregateStatus(
+        makeComponents({
+          database: 'unhealthy',
+          redis: 'unhealthy',
+          minio: 'unhealthy',
+          queues: 'unhealthy',
+        })
+      )
+    ).toBe('unhealthy');
+  });
+});
+
+describe('runProbe', () => {
+  test('attaches durationMs to a successful probe result', async () => {
+    const result = await runProbe('database', async () => ({ status: 'healthy' as const }), 1000);
+    expect(result.status).toBe('healthy');
+    expect(typeof result.durationMs).toBe('number');
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  test('coerces a thrown error into unhealthy with the error message', async () => {
+    const result = await runProbe(
+      'database',
+      async () => {
+        throw new Error('boom');
+      },
+      1000
+    );
+    expect(result.status).toBe('unhealthy');
+    expect(result.message).toBe('boom');
+  });
+
+  test('coerces a probe that exceeds the timeout into unhealthy with timeout message', async () => {
+    const result = await runProbe(
+      'database',
+      () => new Promise(() => {}), // never resolves
+      50
+    );
+    expect(result.status).toBe('unhealthy');
+    expect(result.message).toContain('timed out');
+    expect(result.message).toContain('50ms');
+  });
+});
+
+describe('probeDatabase', () => {
+  test('returns healthy when pool usage is below warn threshold', async () => {
+    const result = await probeDatabase(
+      {
+        ping: async () => undefined,
+        poolStats: async () => ({ used: 10, max: 100 }),
+      },
+      80
+    );
+    expect(result.status).toBe('healthy');
+    expect(result.detail?.['connectionsUsed']).toBe(10);
+    expect(result.detail?.['connectionsMax']).toBe(100);
+  });
+
+  test('returns degraded at exactly the warn threshold (inclusive boundary)', async () => {
+    // Issue #109 (C5): "warn at 80%" fires when pool reaches 80%. Strictly-
+    // greater-than would silently let the boundary value pass.
+    const result = await probeDatabase(
+      {
+        ping: async () => undefined,
+        poolStats: async () => ({ used: 80, max: 100 }),
+      },
+      80
+    );
+    expect(result.status).toBe('degraded');
+  });
+
+  test('returns healthy just below the warn threshold', async () => {
+    const result = await probeDatabase(
+      {
+        ping: async () => undefined,
+        poolStats: async () => ({ used: 79, max: 100 }),
+      },
+      80
+    );
+    expect(result.status).toBe('healthy');
+  });
+
+  test('returns degraded when pool usage exceeds warn threshold', async () => {
+    const result = await probeDatabase(
+      {
+        ping: async () => undefined,
+        poolStats: async () => ({ used: 85, max: 100 }),
+      },
+      80
+    );
+    expect(result.status).toBe('degraded');
+    expect(result.message).toContain('85%');
+    expect(result.message).toContain('80%');
+  });
+
+  test('throws (caught upstream by runProbe) when ping fails', async () => {
+    await expect(
+      probeDatabase(
+        {
+          ping: async () => {
+            throw new Error('connection refused');
+          },
+          poolStats: async () => ({ used: 0, max: 100 }),
+        },
+        80
+      )
+    ).rejects.toThrow('connection refused');
+  });
+});
+
+describe('probeRedis', () => {
+  test('returns healthy when status reports connected', async () => {
+    const result = await probeRedis({ status: () => 'connected' });
+    expect(result.status).toBe('healthy');
+  });
+
+  test('returns unhealthy when status reports disconnected', async () => {
+    const result = await probeRedis({ status: () => 'disconnected' });
+    expect(result.status).toBe('unhealthy');
+    expect(result.message).toContain('not ready');
+  });
+});
+
+describe('probeMinio', () => {
+  test('returns healthy when bucket is connected', async () => {
+    const result = await probeMinio({
+      check: async () => ({ status: 'connected', bucket: 'hashhive' }),
+    });
+    expect(result.status).toBe('healthy');
+    expect(result.detail?.['bucket']).toBe('hashhive');
+  });
+
+  test('returns unhealthy when bucket is unreachable', async () => {
+    const result = await probeMinio({
+      check: async () => ({ status: 'disconnected', bucket: 'hashhive' }),
+    });
+    expect(result.status).toBe('unhealthy');
+    expect(result.message).toContain('hashhive');
+  });
+});
+
+describe('probeQueues', () => {
+  test('returns healthy when all queues are within thresholds', async () => {
+    const result = await probeQueues(
+      {
+        health: async () => ({
+          status: 'connected',
+          queues: {
+            'tasks-high': { waiting: 5, active: 1, failed: 0 },
+            'tasks-normal': { waiting: 100, active: 5, failed: 2 },
+          },
+        }),
+      },
+      10_000,
+      100
+    );
+    expect(result.status).toBe('healthy');
+    expect((result.detail?.['queues'] as Record<string, unknown>)['tasks-high']).toBeDefined();
+  });
+
+  test('returns degraded with offender queue named when waiting exceeds threshold', async () => {
+    const result = await probeQueues(
+      {
+        health: async () => ({
+          status: 'connected',
+          queues: {
+            'tasks-high': { waiting: 50_000, active: 1, failed: 0 },
+            'tasks-normal': { waiting: 5, active: 5, failed: 2 },
+          },
+        }),
+      },
+      10_000,
+      100
+    );
+    expect(result.status).toBe('degraded');
+    expect(result.message).toContain('tasks-high');
+    expect(result.message).toContain('50000');
+  });
+
+  test('returns degraded when failed count exceeds threshold', async () => {
+    const result = await probeQueues(
+      {
+        health: async () => ({
+          status: 'connected',
+          queues: {
+            'jobs-task-generation': { waiting: 0, active: 0, failed: 500 },
+          },
+        }),
+      },
+      10_000,
+      100
+    );
+    expect(result.status).toBe('degraded');
+    expect(result.message).toContain('jobs-task-generation');
+    expect(result.message).toContain('failed=500');
+  });
+
+  test('returns degraded at exactly the waiting threshold (inclusive boundary)', async () => {
+    // Issue #109 (C5): "warn at 10000" means 10000 is already the warn state.
+    const result = await probeQueues(
+      {
+        health: async () => ({
+          status: 'connected',
+          queues: { q: { waiting: 10_000, active: 0, failed: 0 } },
+        }),
+      },
+      10_000,
+      100
+    );
+    expect(result.status).toBe('degraded');
+    expect(result.message).toContain('q waiting=10000');
+  });
+
+  test('returns healthy just below the waiting threshold', async () => {
+    const result = await probeQueues(
+      {
+        health: async () => ({
+          status: 'connected',
+          queues: { q: { waiting: 9_999, active: 0, failed: 0 } },
+        }),
+      },
+      10_000,
+      100
+    );
+    expect(result.status).toBe('healthy');
+  });
+
+  test('returns unhealthy when redis is disconnected', async () => {
+    const result = await probeQueues(
+      {
+        health: async () => ({ status: 'disconnected', queues: {} }),
+      },
+      10_000,
+      100
+    );
+    expect(result.status).toBe('unhealthy');
+    expect(result.message).toContain('not connected');
+  });
+});
+
+describe('getSystemHealth', () => {
+  const allHealthyProbes = {
+    database: {
+      ping: async () => undefined,
+      poolStats: async () => ({ used: 1, max: 100 }),
+    },
+    redis: {
+      status: () => 'connected' as const,
+    },
+    minio: {
+      check: async () => ({ status: 'connected' as const, bucket: 'test' }),
+    },
+    queues: {
+      health: async () => ({
+        status: 'connected' as const,
+        queues: { 'tasks-normal': { waiting: 1, active: 0, failed: 0 } },
+      }),
+    },
+  };
+
+  test('returns SystemHealth shape with all four components and version', async () => {
+    const result = await getSystemHealth({ probes: allHealthyProbes });
+    expect(result.status).toBe('healthy');
+    expect(result.version).toBe('1.0.0');
+    expect(result.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(result.components.database.status).toBe('healthy');
+    expect(result.components.redis.status).toBe('healthy');
+    expect(result.components.minio.status).toBe('healthy');
+    expect(result.components.queues.status).toBe('healthy');
+  });
+
+  test('aggregates degraded when one probe reports degraded', async () => {
+    const result = await getSystemHealth({
+      probes: {
+        ...allHealthyProbes,
+        queues: {
+          health: async () => ({
+            status: 'connected',
+            queues: { q: { waiting: 999_999, active: 0, failed: 0 } },
+          }),
+        },
+      },
+    });
+    expect(result.status).toBe('degraded');
+    expect(result.components.queues.status).toBe('degraded');
+    expect(result.components.database.status).toBe('healthy');
+  });
+
+  test('aggregates unhealthy when one probe throws (parallel execution does not short-circuit)', async () => {
+    const result = await getSystemHealth({
+      probes: {
+        ...allHealthyProbes,
+        minio: {
+          check: async () => {
+            throw new Error('minio down');
+          },
+        },
+      },
+    });
+    expect(result.status).toBe('unhealthy');
+    expect(result.components.minio.status).toBe('unhealthy');
+    expect(result.components.minio.message).toBe('minio down');
+    // Other components still healthy — parallel probes did not short-circuit
+    expect(result.components.database.status).toBe('healthy');
+    expect(result.components.redis.status).toBe('healthy');
+    expect(result.components.queues.status).toBe('healthy');
+  });
+
+  test('three async probes hanging simultaneously do not serialize wall-clock (parallelism proof, T-008)', async () => {
+    // The redis probe's status() is synchronous so it can't hang on a
+    // timeout — instead it reports unhealthy immediately. The three
+    // async probes (database, minio, queues) all hang and must time
+    // out in parallel, not one-after-another.
+    const hangingProbe = () => new Promise<never>(() => {});
+    const start = Date.now();
+    const result = await getSystemHealth({
+      probes: {
+        database: {
+          ping: hangingProbe,
+          poolStats: async () => ({ used: 0, max: 100 }),
+        },
+        redis: { status: () => 'disconnected' },
+        minio: { check: hangingProbe },
+        queues: { health: hangingProbe },
+      },
+      thresholds: { probeTimeoutMs: 50 },
+    });
+    const elapsed = Date.now() - start;
+    expect(result.status).toBe('unhealthy');
+    expect(result.components.database.message).toContain('timed out');
+    expect(result.components.minio.message).toContain('timed out');
+    expect(result.components.queues.message).toContain('timed out');
+    // Parallel execution: total wall-clock should be roughly one probe's
+    // timeout, not three times it. Allow generous margin for CI.
+    expect(elapsed).toBeLessThan(200);
+  });
+
+  test('coerces probe timeout to unhealthy without affecting other components', async () => {
+    const result = await getSystemHealth({
+      probes: {
+        ...allHealthyProbes,
+        database: {
+          ping: () => new Promise(() => {}), // never resolves
+          poolStats: async () => ({ used: 0, max: 100 }),
+        },
+      },
+      thresholds: { probeTimeoutMs: 50 },
+    });
+    expect(result.components.database.status).toBe('unhealthy');
+    expect(result.components.database.message).toContain('timed out');
+    expect(result.components.redis.status).toBe('healthy');
+  });
+
+  test('every component has a numeric durationMs', async () => {
+    const result = await getSystemHealth({ probes: allHealthyProbes });
+    for (const c of Object.values(result.components)) {
+      expect(typeof c.durationMs).toBe('number');
+      expect(Number.isFinite(c.durationMs)).toBe(true);
+      expect(c.durationMs).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  test('respects custom thresholds passed via opts', async () => {
+    const result = await getSystemHealth({
+      probes: {
+        ...allHealthyProbes,
+        database: {
+          ping: async () => undefined,
+          poolStats: async () => ({ used: 50, max: 100 }),
+        },
+      },
+      thresholds: { dbConnectionWarnPct: 40 },
+    });
+    expect(result.components.database.status).toBe('degraded');
+  });
+});
+
+describe('legacyPublicEnvelope', () => {
+  async function makeHealth(
+    overrides: Partial<{
+      db: ComponentHealth['status'];
+      redis: ComponentHealth['status'];
+      minio: ComponentHealth['status'];
+      queues: ComponentHealth['status'];
+    }> = {}
+  ): Promise<ReturnType<typeof getSystemHealth> extends Promise<infer T> ? T : never> {
+    return getSystemHealth({
+      probes: {
+        database: {
+          ping: async () => {
+            if (overrides.db === 'unhealthy') throw new Error('SECRET_DB_ERROR_should_not_leak');
+          },
+          poolStats: async () => ({
+            used: overrides.db === 'degraded' ? 95 : 1,
+            max: 100,
+          }),
+        },
+        redis: {
+          status: () => (overrides.redis === 'unhealthy' ? 'disconnected' : 'connected'),
+        },
+        minio: {
+          check: async () => ({
+            status: overrides.minio === 'unhealthy' ? 'disconnected' : 'connected',
+            bucket: 'hashhive-test',
+          }),
+        },
+        queues: {
+          health: async () => ({
+            status: 'connected',
+            queues:
+              overrides.queues === 'degraded'
+                ? { q: { waiting: 999_999, active: 0, failed: 0 } }
+                : { q: { waiting: 1, active: 0, failed: 0 } },
+          }),
+        },
+      },
+    });
+  }
+
+  test('healthy maps to status="ok", aggregateStatus="healthy", and all services="connected"', async () => {
+    const env = legacyPublicEnvelope(await makeHealth({}));
+    expect(env.status).toBe('ok');
+    expect(env.aggregateStatus).toBe('healthy');
+    expect(env.services.database.status).toBe('connected');
+    expect(env.services.redis.status).toBe('connected');
+    expect(env.services.minio.status).toBe('connected');
+    expect(env.services.minio.bucket).toBe('hashhive-test');
+    expect(env.services.queues.status).toBe('connected');
+    expect(env.version).toBe('1.0.0');
+  });
+
+  test('degraded maps to status="degraded" body, aggregateStatus="degraded", services stay "connected"', async () => {
+    const env = legacyPublicEnvelope(await makeHealth({ queues: 'degraded' }));
+    expect(env.status).toBe('degraded');
+    expect(env.aggregateStatus).toBe('degraded');
+    expect(env.services.redis.status).toBe('connected');
+    expect(env.services.database.status).toBe('connected');
+    // Queue still connected (degraded != disconnected)
+    expect(env.services.queues.status).toBe('connected');
+  });
+
+  test('unhealthy component maps to body status="degraded" but aggregateStatus="unhealthy" (api-contract-4)', async () => {
+    // The body's coarse `status` collapses to 'degraded' for backward compat,
+    // but the new `aggregateStatus` field carries the full three-tier value
+    // so JSON-only monitors can distinguish degraded from unhealthy.
+    const env = legacyPublicEnvelope(await makeHealth({ minio: 'unhealthy' }));
+    expect(env.status).toBe('degraded');
+    expect(env.aggregateStatus).toBe('unhealthy');
+    expect(env.services.minio.status).toBe('disconnected');
+  });
+
+  test('exposes services.queues.queues map with per-queue stats (api-contract-3)', async () => {
+    const env = legacyPublicEnvelope(await makeHealth({}));
+    expect(env.services.queues.queues).toBeDefined();
+    expect(env.services.queues.queues['q']).toEqual({ waiting: 1, active: 0, failed: 0 });
+  });
+
+  test('omits per-component detail to avoid leaking infra info', async () => {
+    const env = legacyPublicEnvelope(await makeHealth({}));
+    // The legacy envelope intentionally does not have a `components` key.
+    expect((env as Record<string, unknown>)['components']).toBeUndefined();
+    // And no `detail` on per-service entries.
+    for (const svc of Object.values(env.services)) {
+      expect((svc as Record<string, unknown>)['detail']).toBeUndefined();
+    }
+  });
+
+  test('strips per-component message so probe error text never reaches anonymous callers (security)', async () => {
+    // Issue #109 security review: verify a probe error message containing a
+    // sentinel string never appears in the legacy envelope.
+    const env = legacyPublicEnvelope(await makeHealth({ db: 'unhealthy' }));
+    const serialized = JSON.stringify(env);
+    expect(serialized).not.toContain('SECRET_DB_ERROR_should_not_leak');
+    // Per-service entries must not carry a 'message' field.
+    for (const svc of Object.values(env.services)) {
+      expect((svc as Record<string, unknown>)['message']).toBeUndefined();
+    }
+  });
+
+  test('strips per-component connection counts so DB pool details never reach anonymous callers (security)', async () => {
+    // The internal SystemHealth.detail.connectionsUsed/Max would leak infra
+    // capacity — verify it is gone from the envelope.
+    const env = legacyPublicEnvelope(await makeHealth({ db: 'degraded' }));
+    const serialized = JSON.stringify(env);
+    expect(serialized).not.toContain('connectionsUsed');
+    expect(serialized).not.toContain('connectionsMax');
+    expect(serialized).not.toContain('connectionsPct');
+  });
+});

--- a/packages/backend/tests/unit/health.test.ts
+++ b/packages/backend/tests/unit/health.test.ts
@@ -15,12 +15,19 @@ mock.module('../../src/config/storage.js', () => ({
 import { app } from '../../src/index.js';
 
 describe('GET /health', () => {
-  it('should return health status', async () => {
+  // Issue #109: /health now returns 503 when the system is unhealthy
+  // (e.g. Redis disconnected because the queue manager isn't initialized
+  // in unit-test mode), 200 otherwise. The body shape is identical in
+  // both cases so older probes that only read the body keep working.
+  const VALID_HTTP_STATUSES = [200, 503];
+
+  it('should return health envelope with all expected fields', async () => {
     const res = await app.request('/health');
-    expect(res.status).toBe(200);
+    expect(VALID_HTTP_STATUSES).toContain(res.status);
 
     const body = await res.json();
     expect(['ok', 'degraded']).toContain(body['status']);
+    expect(['healthy', 'degraded', 'unhealthy']).toContain(body['aggregateStatus']);
     expect(body['version']).toBe('1.0.0');
     expect(body['timestamp']).toBeDefined();
     expect(body['services']['database']).toBeDefined();
@@ -29,7 +36,7 @@ describe('GET /health', () => {
 
   it('should include MinIO health status', async () => {
     const res = await app.request('/health');
-    expect(res.status).toBe(200);
+    expect(VALID_HTTP_STATUSES).toContain(res.status);
 
     const body = await res.json();
     const minio = body['services']['minio'];
@@ -37,6 +44,30 @@ describe('GET /health', () => {
     expect(minio['status']).toBe('connected');
     expect(typeof minio['bucket']).toBe('string');
     expect(minio['bucket'].length).toBeGreaterThan(0);
+  });
+
+  it('should expose services.queues.queues map (api-contract-3)', async () => {
+    const res = await app.request('/health');
+    expect(VALID_HTTP_STATUSES).toContain(res.status);
+
+    const body = await res.json();
+    expect(body['services']['queues']).toBeDefined();
+    expect(body['services']['queues']['queues']).toBeDefined();
+    // queues map may be empty when queue manager is unavailable; type check is enough.
+    expect(typeof body['services']['queues']['queues']).toBe('object');
+  });
+
+  it('returns 503 when the body reports aggregateStatus=unhealthy (T-004)', async () => {
+    // Force a deterministic unhealthy outcome by importing the service
+    // and calling getSystemHealth with all-unhealthy synthetic probes;
+    // then drive the same envelope through the public route.
+    const res = await app.request('/health');
+    const body = await res.json();
+    if (body['aggregateStatus'] === 'unhealthy') {
+      expect(res.status).toBe(503);
+    } else {
+      expect(res.status).toBe(200);
+    }
   });
 });
 

--- a/packages/backend/tests/unit/health.test.ts
+++ b/packages/backend/tests/unit/health.test.ts
@@ -28,7 +28,7 @@ describe('GET /health', () => {
     const body = await res.json();
     expect(['ok', 'degraded']).toContain(body['status']);
     expect(['healthy', 'degraded', 'unhealthy']).toContain(body['aggregateStatus']);
-    expect(body['version']).toBe('1.0.0');
+    expect(body['version']).toBe('1.1.0');
     expect(body['timestamp']).toBeDefined();
     expect(body['services']['database']).toBeDefined();
     expect(['connected', 'disconnected']).toContain(body['services']['database']['status']);
@@ -57,10 +57,14 @@ describe('GET /health', () => {
     expect(typeof body['services']['queues']['queues']).toBe('object');
   });
 
-  it('returns 503 when the body reports aggregateStatus=unhealthy (T-004)', async () => {
-    // Force a deterministic unhealthy outcome by importing the service
-    // and calling getSystemHealth with all-unhealthy synthetic probes;
-    // then drive the same envelope through the public route.
+  it('HTTP status mirrors body.aggregateStatus (200/503 contract)', async () => {
+    // This test runs against whatever state the unit env happens to be
+    // in (no QueueManager → typically unhealthy); it verifies the
+    // *invariant* between body.aggregateStatus and the HTTP status, not
+    // the 503 path on its own. Deterministic 200/503 path coverage —
+    // forced by mocking getSystemHealth — lives in
+    // tests/integration/health-deterministic.test.ts so the contract
+    // is not at the mercy of unit-env state.
     const res = await app.request('/health');
     const body = await res.json();
     if (body['aggregateStatus'] === 'unhealthy') {

--- a/packages/frontend/src/components/features/system-health-card.tsx
+++ b/packages/frontend/src/components/features/system-health-card.tsx
@@ -43,14 +43,21 @@ const AGGREGATE_LABEL: Record<ComponentStatus, string> = {
  * Renders an error from an unknown reject value. Plain-string and
  * plain-object rejections (from custom fetch wrappers) need a fallback
  * description so the user sees something more actionable than a bare
- * "Failed to load system health".
+ * "Failed to load system health". The property access is wrapped in
+ * try/catch because adversarial inputs may define `message` as a getter
+ * that throws — we never want describeError to itself throw during
+ * render and blank the card.
  */
 function describeError(err: unknown): string {
   if (err instanceof Error) return err.message;
   if (typeof err === 'string') return err;
   if (err && typeof err === 'object' && 'message' in err) {
-    const msg = (err as { message: unknown }).message;
-    if (typeof msg === 'string') return msg;
+    try {
+      const msg = (err as { message: unknown }).message;
+      if (typeof msg === 'string') return msg;
+    } catch {
+      // Fall through: getter threw, treat as unknown.
+    }
   }
   return 'unknown error';
 }

--- a/packages/frontend/src/components/features/system-health-card.tsx
+++ b/packages/frontend/src/components/features/system-health-card.tsx
@@ -185,9 +185,16 @@ export function SystemHealthCard() {
       <div>
         {isLoading || !data
           ? COMPONENT_ORDER.map((name) => <SkeletonRow key={name} label={COMPONENT_LABELS[name]} />)
-          : COMPONENT_ORDER.map((name) => (
-              <ComponentRow key={name} name={name} health={data.components[name]} />
-            ))}
+          : COMPONENT_ORDER.map((name) => {
+              // Record<ComponentName, ComponentHealth> returns
+              // ComponentHealth | undefined under noUncheckedIndexedAccess;
+              // skip the row instead of crashing if the backend ever
+              // omits a component (defensive — current contract requires
+              // all four).
+              const health = data.components[name];
+              if (!health) return null;
+              return <ComponentRow key={name} name={name} health={health} />;
+            })}
       </div>
     </section>
   );

--- a/packages/frontend/src/components/features/system-health-card.tsx
+++ b/packages/frontend/src/components/features/system-health-card.tsx
@@ -1,0 +1,178 @@
+/**
+ * System health card (issue #109).
+ *
+ * Renders the four-component health snapshot (database, redis, minio,
+ * queues) with status dots and per-component messages on degraded /
+ * unhealthy. Click a row to expand its raw `detail` payload.
+ *
+ * Aria: aggregate status uses role="status" + aria-live="polite" so
+ * screen readers announce changes. Status dots respect
+ * prefers-reduced-motion (no pulse on unhealthy).
+ */
+import { useState } from 'react';
+import {
+  type ComponentHealth,
+  type ComponentName,
+  type ComponentStatus,
+  useSystemHealth,
+} from '../../hooks/use-system-health';
+import { cn } from '../../lib/utils';
+
+const COMPONENT_LABELS: Record<ComponentName, string> = {
+  database: 'Database',
+  redis: 'Redis',
+  minio: 'Object Storage',
+  queues: 'Job Queues',
+};
+
+const COMPONENT_ORDER: ComponentName[] = ['database', 'redis', 'minio', 'queues'];
+
+const STATUS_DOT: Record<ComponentStatus, string> = {
+  healthy: 'bg-success',
+  degraded: 'bg-warning',
+  unhealthy: 'bg-destructive',
+};
+
+const AGGREGATE_LABEL: Record<ComponentStatus, string> = {
+  healthy: 'All systems healthy',
+  degraded: 'Degraded',
+  unhealthy: 'Unhealthy',
+};
+
+interface StatusDotProps {
+  status: ComponentStatus;
+  pulse?: boolean;
+}
+
+function StatusDot({ status, pulse = false }: StatusDotProps) {
+  return (
+    <span className="relative flex h-2.5 w-2.5 shrink-0" aria-hidden="true">
+      {pulse && status !== 'healthy' && (
+        // motion-reduce:hidden honors prefers-reduced-motion via Tailwind.
+        <span
+          className={cn(
+            'absolute inline-flex h-full w-full animate-ping rounded-full opacity-60 motion-reduce:hidden',
+            STATUS_DOT[status]
+          )}
+        />
+      )}
+      <span className={cn('relative inline-flex h-2.5 w-2.5 rounded-full', STATUS_DOT[status])} />
+    </span>
+  );
+}
+
+interface ComponentRowProps {
+  name: ComponentName;
+  health: ComponentHealth;
+}
+
+function ComponentRow({ name, health }: ComponentRowProps) {
+  const [expanded, setExpanded] = useState(false);
+  const hasDetail = !!health.detail && Object.keys(health.detail).length > 0;
+  const showMessage = health.status !== 'healthy' && !!health.message;
+
+  const rowContent = (
+    <div className="flex items-center gap-3">
+      <StatusDot status={health.status} />
+      <span className="text-sm font-medium text-foreground">{COMPONENT_LABELS[name]}</span>
+      <span className="ml-auto font-mono text-xs uppercase tracking-wider text-muted-foreground">
+        {health.status}
+      </span>
+    </div>
+  );
+
+  return (
+    <div className="border-b border-surface-0 last:border-b-0">
+      {hasDetail ? (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+          aria-label={`${COMPONENT_LABELS[name]} status: ${health.status}. Click to ${expanded ? 'hide' : 'show'} details.`}
+          className="block w-full px-3 py-2 text-left transition-colors hover:bg-surface-0/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {rowContent}
+        </button>
+      ) : (
+        // No detail to expand → static row. The visible label + status
+        // text inside `rowContent` is sufficient for screen readers; an
+        // additional aria-label on a div is rejected by lint anyway.
+        <div className="block w-full px-3 py-2">{rowContent}</div>
+      )}
+      {showMessage && <p className="px-3 pb-2 text-xs text-muted-foreground">{health.message}</p>}
+      {expanded && hasDetail && (
+        <pre className="overflow-x-auto border-t border-surface-0 bg-surface-0/30 px-3 py-2 font-mono text-xs text-muted-foreground">
+          {JSON.stringify(health.detail, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+interface SkeletonRowProps {
+  label: string;
+}
+
+function SkeletonRow({ label }: SkeletonRowProps) {
+  return (
+    <div className="flex items-center gap-3 border-b border-surface-0 px-3 py-2 last:border-b-0">
+      <span className="h-2.5 w-2.5 shrink-0 rounded-full bg-surface-0" aria-hidden="true" />
+      <span className="text-sm font-medium text-muted-foreground">{label}</span>
+      <span className="ml-auto font-mono text-xs uppercase tracking-wider text-muted-foreground">
+        --
+      </span>
+    </div>
+  );
+}
+
+export function SystemHealthCard() {
+  const { data, isLoading, isError, error } = useSystemHealth();
+
+  return (
+    <section
+      className="rounded-md border border-surface-0 bg-surface-0/40"
+      aria-labelledby="system-health-title"
+    >
+      <header className="flex items-center justify-between border-b border-surface-0 px-3 py-2">
+        <h2
+          id="system-health-title"
+          className="text-xs font-medium uppercase tracking-wider text-muted-foreground"
+        >
+          System Health
+        </h2>
+        {data ? (
+          <div
+            className="flex items-center gap-2"
+            role="status"
+            aria-live="polite"
+            aria-label={`System status: ${AGGREGATE_LABEL[data.status]}`}
+          >
+            <StatusDot status={data.status} pulse />
+            <span className="text-xs font-medium text-foreground">
+              {AGGREGATE_LABEL[data.status]}
+            </span>
+          </div>
+        ) : (
+          <span className="text-xs text-muted-foreground">--</span>
+        )}
+      </header>
+
+      {isError && (
+        <div
+          role="alert"
+          className="border-b border-destructive/20 bg-destructive/5 px-3 py-2 text-xs text-destructive"
+        >
+          Failed to load system health{error instanceof Error ? `: ${error.message}` : ''}
+        </div>
+      )}
+
+      <div>
+        {isLoading || !data
+          ? COMPONENT_ORDER.map((name) => <SkeletonRow key={name} label={COMPONENT_LABELS[name]} />)
+          : COMPONENT_ORDER.map((name) => (
+              <ComponentRow key={name} name={name} health={data.components[name]} />
+            ))}
+      </div>
+    </section>
+  );
+}

--- a/packages/frontend/src/components/features/system-health-card.tsx
+++ b/packages/frontend/src/components/features/system-health-card.tsx
@@ -48,6 +48,10 @@ const AGGREGATE_LABEL: Record<ComponentStatus, string> = {
 function describeError(err: unknown): string {
   if (err instanceof Error) return err.message;
   if (typeof err === 'string') return err;
+  if (err && typeof err === 'object' && 'message' in err) {
+    const msg = (err as { message: unknown }).message;
+    if (typeof msg === 'string') return msg;
+  }
   return 'unknown error';
 }
 

--- a/packages/frontend/src/components/features/system-health-card.tsx
+++ b/packages/frontend/src/components/features/system-health-card.tsx
@@ -6,8 +6,10 @@
  * unhealthy. Click a row to expand its raw `detail` payload.
  *
  * Aria: aggregate status uses role="status" + aria-live="polite" so
- * screen readers announce changes. Status dots respect
- * prefers-reduced-motion (no pulse on unhealthy).
+ * screen readers announce changes. The aggregate status dot pulses
+ * when the system is degraded or unhealthy (signals "needs attention").
+ * Pulse animation is suppressed via `motion-reduce:hidden` when the
+ * user has `prefers-reduced-motion` set.
  */
 import { useState } from 'react';
 import {

--- a/packages/frontend/src/components/features/system-health-card.tsx
+++ b/packages/frontend/src/components/features/system-health-card.tsx
@@ -39,6 +39,18 @@ const AGGREGATE_LABEL: Record<ComponentStatus, string> = {
   unhealthy: 'Unhealthy',
 };
 
+/**
+ * Renders an error from an unknown reject value. Plain-string and
+ * plain-object rejections (from custom fetch wrappers) need a fallback
+ * description so the user sees something more actionable than a bare
+ * "Failed to load system health".
+ */
+function describeError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  return 'unknown error';
+}
+
 interface StatusDotProps {
   status: ComponentStatus;
   pulse?: boolean;
@@ -162,7 +174,7 @@ export function SystemHealthCard() {
           role="alert"
           className="border-b border-destructive/20 bg-destructive/5 px-3 py-2 text-xs text-destructive"
         >
-          Failed to load system health{error instanceof Error ? `: ${error.message}` : ''}
+          Failed to load system health: {describeError(error)}
         </div>
       )}
 

--- a/packages/frontend/src/hooks/use-events.ts
+++ b/packages/frontend/src/hooks/use-events.ts
@@ -8,7 +8,8 @@ export type EventType =
   | 'campaign_status'
   | 'task_update'
   | 'crack_result'
-  | 'resource_update';
+  | 'resource_update'
+  | 'system_health';
 
 export interface AppEvent {
   type: EventType;
@@ -66,6 +67,7 @@ export function useEvents(options: UseEventsOptions = {}) {
         reconnectAttemptsRef.current = 0;
       };
 
+      // Project-scoped query keys: invalidated with [key, selectedProjectId].
       const invalidationKeys: Record<string, string[]> = {
         agent_status: ['agents', 'dashboard-stats'],
         campaign_status: ['campaigns', 'dashboard-stats'],
@@ -80,15 +82,30 @@ export function useEvents(options: UseEventsOptions = {}) {
         resource_update: ['hash-lists', 'wordlists', 'rulelists', 'masklists'],
       };
 
+      // System-scoped query keys: invalidated with just [key], no project.
+      // Issue #109: system_health is system-wide; the query key has no
+      // projectId component, so the project-scoped invalidation path
+      // would never match it.
+      const systemInvalidationKeys: Record<string, string[]> = {
+        system_health: ['system-health'],
+      };
+
       ws.onmessage = (event) => {
         try {
           const data = JSON.parse(event.data) as Record<string, unknown>;
           if (data['type'] === 'connected' || data['type'] === 'pong') return;
 
-          const keys = invalidationKeys[data['type'] as string];
-          if (keys) {
-            for (const key of keys) {
+          const eventType = data['type'] as string;
+          const projectKeys = invalidationKeys[eventType];
+          if (projectKeys) {
+            for (const key of projectKeys) {
               queryClient.invalidateQueries({ queryKey: [key, selectedProjectId] });
+            }
+          }
+          const systemKeys = systemInvalidationKeys[eventType];
+          if (systemKeys) {
+            for (const key of systemKeys) {
+              queryClient.invalidateQueries({ queryKey: [key] });
             }
           }
 

--- a/packages/frontend/src/hooks/use-events.ts
+++ b/packages/frontend/src/hooks/use-events.ts
@@ -110,8 +110,12 @@ export function useEvents(options: UseEventsOptions = {}) {
           }
 
           onEventRef.current?.(data as unknown as AppEvent);
-        } catch {
-          // Ignore malformed messages
+        } catch (err) {
+          // Surface schema drift between server and client to console.
+          // Silently dropping the frame would mask backend events from
+          // the dashboard with no diagnostic signal.
+          // biome-ignore lint/suspicious/noConsole: client-side observability has no structured logger
+          console.warn('[useEvents] dropped malformed WS frame', err);
         }
       };
 

--- a/packages/frontend/src/hooks/use-events.ts
+++ b/packages/frontend/src/hooks/use-events.ts
@@ -92,7 +92,21 @@ export function useEvents(options: UseEventsOptions = {}) {
 
       ws.onmessage = (event) => {
         try {
-          const data = JSON.parse(event.data) as Record<string, unknown>;
+          // Validate envelope shape before any cast or invalidation.
+          // Without this guard, a non-object payload or one missing a
+          // string `type` would still flow through the casts below and
+          // hit invalidateQueries / onEvent with malformed data.
+          const parsed: unknown = JSON.parse(event.data);
+          if (
+            typeof parsed !== 'object' ||
+            parsed === null ||
+            typeof (parsed as Record<string, unknown>)['type'] !== 'string'
+          ) {
+            // biome-ignore lint/suspicious/noConsole: client-side observability has no structured logger
+            console.warn('[useEvents] dropped malformed WS frame: invalid envelope');
+            return;
+          }
+          const data = parsed as Record<string, unknown>;
           if (data['type'] === 'connected' || data['type'] === 'pong') return;
 
           const eventType = data['type'] as string;

--- a/packages/frontend/src/hooks/use-events.ts
+++ b/packages/frontend/src/hooks/use-events.ts
@@ -109,6 +109,22 @@ export function useEvents(options: UseEventsOptions = {}) {
           const data = parsed as Record<string, unknown>;
           if (data['type'] === 'connected' || data['type'] === 'pong') return;
 
+          // Validate the rest of the envelope before invalidation /
+          // callback dispatch. The type guard above only pinned `type`;
+          // a frame with `type: 'agent_status'` but missing
+          // `projectId`/`timestamp`/`data` would still cast through to
+          // AppEvent without these checks.
+          if (
+            typeof data['projectId'] !== 'number' ||
+            typeof data['timestamp'] !== 'string' ||
+            typeof data['data'] !== 'object' ||
+            data['data'] === null
+          ) {
+            // biome-ignore lint/suspicious/noConsole: client-side observability has no structured logger
+            console.warn('[useEvents] dropped malformed WS frame: invalid event payload');
+            return;
+          }
+
           const eventType = data['type'] as string;
           const projectKeys = invalidationKeys[eventType];
           if (projectKeys) {
@@ -123,7 +139,12 @@ export function useEvents(options: UseEventsOptions = {}) {
             }
           }
 
-          onEventRef.current?.(data as unknown as AppEvent);
+          onEventRef.current?.({
+            type: data['type'] as EventType,
+            projectId: data['projectId'] as number,
+            data: data['data'] as Record<string, unknown>,
+            timestamp: data['timestamp'] as string,
+          });
         } catch (err) {
           // Surface schema drift between server and client to console.
           // Silently dropping the frame would mask backend events from

--- a/packages/frontend/src/hooks/use-system-health.ts
+++ b/packages/frontend/src/hooks/use-system-health.ts
@@ -37,7 +37,7 @@ export function useSystemHealth() {
     retry: 1,
     // The card's job is to *report* outages — keep showing the last good
     // snapshot during a transient fetch failure rather than flipping the
-    // UI to a loading or error state. Issue #109 reliability review (rel-6).
+    // UI to a loading or error state.
     placeholderData: keepPreviousData,
     staleTime: 15_000,
   });

--- a/packages/frontend/src/hooks/use-system-health.ts
+++ b/packages/frontend/src/hooks/use-system-health.ts
@@ -1,0 +1,44 @@
+/**
+ * System health query hook (issue #109).
+ *
+ * Polls the dashboard health endpoint every 30s. The query key is NOT
+ * project-scoped (system_health is system-wide); the WebSocket
+ * `system_health` event is wired to invalidate this key in `useEvents`.
+ */
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { api } from '../lib/api';
+
+export type ComponentStatus = 'healthy' | 'degraded' | 'unhealthy';
+
+export type ComponentName = 'database' | 'redis' | 'minio' | 'queues';
+
+export interface ComponentHealth {
+  status: ComponentStatus;
+  message?: string;
+  detail?: Record<string, unknown>;
+  durationMs: number;
+}
+
+export interface SystemHealth {
+  status: ComponentStatus;
+  timestamp: string;
+  version: string;
+  components: Record<ComponentName, ComponentHealth>;
+}
+
+export const SYSTEM_HEALTH_QUERY_KEY = ['system-health'] as const;
+
+export function useSystemHealth() {
+  return useQuery<SystemHealth>({
+    queryKey: SYSTEM_HEALTH_QUERY_KEY,
+    queryFn: () => api.get<SystemHealth>('/dashboard/health'),
+    refetchInterval: 30_000,
+    // Tolerate occasional probe blips without flipping the UI to "error".
+    retry: 1,
+    // The card's job is to *report* outages — keep showing the last good
+    // snapshot during a transient fetch failure rather than flipping the
+    // UI to a loading or error state. Issue #109 reliability review (rel-6).
+    placeholderData: keepPreviousData,
+    staleTime: 15_000,
+  });
+}

--- a/packages/frontend/src/pages/dashboard.tsx
+++ b/packages/frontend/src/pages/dashboard.tsx
@@ -1,5 +1,6 @@
 import { ConnectionIndicator } from '../components/features/connection-indicator';
 import { StatCard } from '../components/features/stat-card';
+import { SystemHealthCard } from '../components/features/system-health-card';
 import { EmptyState } from '../components/ui/empty-state';
 import { PageHeader } from '../components/ui/page-header';
 import { useDashboardStats } from '../hooks/use-dashboard';
@@ -63,6 +64,8 @@ export function DashboardPage() {
           accent="--success"
         />
       </div>
+
+      <SystemHealthCard />
     </div>
   );
 }

--- a/packages/frontend/tests/components/system-health-card.test.tsx
+++ b/packages/frontend/tests/components/system-health-card.test.tsx
@@ -7,7 +7,7 @@ import type { SystemHealth } from '../../src/hooks/use-system-health';
 import { mockFetch, restoreFetch } from '../mocks/fetch';
 import { cleanupAll, fireEvent, renderWithProviders, screen, waitFor } from '../test-utils';
 
-let fetchMock: ReturnType<typeof mockFetch>;
+let fetchMock: ReturnType<typeof mockFetch> | undefined;
 
 afterEach(() => {
   cleanupAll();
@@ -15,7 +15,7 @@ afterEach(() => {
 });
 
 beforeEach(() => {
-  fetchMock = undefined as unknown as ReturnType<typeof mockFetch>;
+  fetchMock = undefined;
 });
 
 function buildHealth(overrides: Partial<SystemHealth> = {}): SystemHealth {

--- a/packages/frontend/tests/components/system-health-card.test.tsx
+++ b/packages/frontend/tests/components/system-health-card.test.tsx
@@ -119,18 +119,37 @@ describe('SystemHealthCard', () => {
 
   it('per-component status text reflects the component status (not just aggregate)', async () => {
     // Issue #109 (PR review C-2): a regression that mapped every dot to
-    // bg-success would still pass the aggregate-label test. Pin the
-    // per-component status text so the card's primary signal is locked in.
+    // bg-success would pass an aggregate-label-only test. Pin the
+    // per-row status text via the existing aria-label (`<COMPONENT>
+    // status: <status>...`) so a row-shuffle regression that put the
+    // wrong status next to the wrong row also fails. All four fixture
+    // components include a `detail` payload so each row renders as a
+    // button (the row scoping needs the aria-label, which only the
+    // expandable button form provides).
     fetchMock = mockFetch({
       '/dashboard/health': {
         status: 200,
         body: buildHealth({
           status: 'unhealthy',
           components: {
-            database: { status: 'unhealthy', message: 'pool exhausted', durationMs: 4 },
-            redis: { status: 'degraded', message: 'high latency', durationMs: 2 },
+            database: {
+              status: 'unhealthy',
+              message: 'pool exhausted',
+              durationMs: 4,
+              detail: { connectionsUsed: 100, connectionsMax: 100 },
+            },
+            redis: {
+              status: 'degraded',
+              message: 'high latency',
+              durationMs: 2,
+              detail: { latencyMs: 800 },
+            },
             minio: { status: 'healthy', durationMs: 8, detail: { bucket: 'hashhive' } },
-            queues: { status: 'healthy', durationMs: 12 },
+            queues: {
+              status: 'healthy',
+              durationMs: 12,
+              detail: { queues: { 'tasks-normal': { waiting: 1, active: 0, failed: 0 } } },
+            },
           },
         }),
       },
@@ -141,15 +160,29 @@ describe('SystemHealthCard', () => {
       expect(screen.getByText('Unhealthy')).toBeDefined();
     });
 
-    // The per-component row shows the literal status string. Two
-    // components are non-healthy → both their messages render too.
+    // Per-row scoping: each row's status is wired into its aria-label
+    // (e.g. "Database status: unhealthy. Click to show details.").
+    // A row-shuffle regression would map the wrong status to the wrong
+    // row's label and fail these assertions — unlike a global
+    // `getAllByText('healthy').length >= 1` which can't catch shuffles.
+    const dbRow = screen
+      .getAllByRole('button')
+      .find((b) => b.getAttribute('aria-label')?.startsWith('Database status:'));
+    expect(dbRow?.getAttribute('aria-label')).toContain('unhealthy');
+
+    const redisRow = screen
+      .getAllByRole('button')
+      .find((b) => b.getAttribute('aria-label')?.startsWith('Redis status:'));
+    expect(redisRow?.getAttribute('aria-label')).toContain('degraded');
+
+    const minioRow = screen
+      .getAllByRole('button')
+      .find((b) => b.getAttribute('aria-label')?.startsWith('Object Storage status:'));
+    expect(minioRow?.getAttribute('aria-label')).toContain('healthy');
+
+    // Per-component messages render adjacent to their row.
     expect(screen.getByText('pool exhausted')).toBeDefined();
     expect(screen.getByText('high latency')).toBeDefined();
-    // The status text appears on each row — at least one 'healthy',
-    // one 'degraded', one 'unhealthy' must all be visible somewhere.
-    expect(screen.getAllByText('healthy').length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText('degraded').length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText('unhealthy').length).toBeGreaterThanOrEqual(1);
   });
 
   it('expands per-component detail on click when detail is present', async () => {

--- a/packages/frontend/tests/components/system-health-card.test.tsx
+++ b/packages/frontend/tests/components/system-health-card.test.tsx
@@ -22,7 +22,7 @@ function buildHealth(overrides: Partial<SystemHealth> = {}): SystemHealth {
   return {
     status: 'healthy',
     timestamp: '2026-05-06T12:00:00.000Z',
-    version: '1.0.0',
+    version: '1.1.0',
     components: {
       database: { status: 'healthy', durationMs: 4 },
       redis: { status: 'healthy', durationMs: 2 },
@@ -239,13 +239,15 @@ describe('SystemHealthCard', () => {
     expect(screen.getByRole('alert').textContent).toMatch(/Failed to load system health/);
   });
 
-  // Issue #109 testing review T-007. Asserting the row is a native
-  // `<button>` is what makes the keyboard-operability claim real:
-  // browsers fire click on Enter/Space for native buttons but not for
-  // a `<div role="button">` without an explicit onKeyDown. The test
-  // then dispatches the click that Enter would produce; this is the
-  // happy-dom-friendly equivalent of pressing Enter.
-  it('component row is a native <button> so Enter/Space activate it', async () => {
+  // Issue #109 testing review T-007. The keyboard-operability claim
+  // ("Enter/Space activate the row") rests on the row being a native
+  // `<button>` — browsers translate Enter/Space presses into click on
+  // native buttons, but not on `<div role="button">` without an
+  // explicit onKeyDown. We pin the native-button tag here and exercise
+  // the click handler that Enter would produce; happy-dom doesn't
+  // synthesize the Enter→click translation, so a real keyDown event
+  // would be testing happy-dom rather than our component.
+  it('component row is a native <button> tag (gives Enter/Space activation for free)', async () => {
     fetchMock = mockFetch({
       '/dashboard/health': {
         status: 200,
@@ -290,15 +292,21 @@ describe('SystemHealthCard', () => {
     });
     renderWithProviders(<SystemHealthCard />);
 
-    // Before the fetch resolves we should have exactly one skeleton row
-    // per component label. A regression that dropped a row would fail
-    // here because the loaded text "Database" / "Redis" / etc. is
-    // unique to the skeleton and the loaded view alike — so checking
-    // the four labels are present is the most direct signal that all
-    // four rows rendered.
+    // While the fetch is pending we should have exactly one row per
+    // component. The four component labels render in both skeleton and
+    // loaded states, so they're insufficient on their own to pin "we're
+    // in the skeleton state". The skeleton-only signal is the `--`
+    // status placeholder rendered by SkeletonRow — count those to
+    // confirm the loading branch fired (one per component, possibly
+    // plus one in the header).
     expect(screen.getByText('Database')).toBeDefined();
     expect(screen.getByText('Redis')).toBeDefined();
     expect(screen.getByText('Object Storage')).toBeDefined();
     expect(screen.getByText('Job Queues')).toBeDefined();
+    // Skeleton-specific assertion: 4 rows × `--` placeholder, plus the
+    // header `--` when no data is loaded yet (5 total, but allow >= 4
+    // in case the header placeholder is suppressed).
+    const placeholders = screen.getAllByText('--');
+    expect(placeholders.length).toBeGreaterThanOrEqual(4);
   });
 });

--- a/packages/frontend/tests/components/system-health-card.test.tsx
+++ b/packages/frontend/tests/components/system-health-card.test.tsx
@@ -117,6 +117,41 @@ describe('SystemHealthCard', () => {
     expect(statusEl.getAttribute('aria-live')).toBe('polite');
   });
 
+  it('per-component status text reflects the component status (not just aggregate)', async () => {
+    // Issue #109 (PR review C-2): a regression that mapped every dot to
+    // bg-success would still pass the aggregate-label test. Pin the
+    // per-component status text so the card's primary signal is locked in.
+    fetchMock = mockFetch({
+      '/dashboard/health': {
+        status: 200,
+        body: buildHealth({
+          status: 'unhealthy',
+          components: {
+            database: { status: 'unhealthy', message: 'pool exhausted', durationMs: 4 },
+            redis: { status: 'degraded', message: 'high latency', durationMs: 2 },
+            minio: { status: 'healthy', durationMs: 8, detail: { bucket: 'hashhive' } },
+            queues: { status: 'healthy', durationMs: 12 },
+          },
+        }),
+      },
+    });
+    renderWithProviders(<SystemHealthCard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Unhealthy')).toBeDefined();
+    });
+
+    // The per-component row shows the literal status string. Two
+    // components are non-healthy → both their messages render too.
+    expect(screen.getByText('pool exhausted')).toBeDefined();
+    expect(screen.getByText('high latency')).toBeDefined();
+    // The status text appears on each row — at least one 'healthy',
+    // one 'degraded', one 'unhealthy' must all be visible somewhere.
+    expect(screen.getAllByText('healthy').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('degraded').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('unhealthy').length).toBeGreaterThanOrEqual(1);
+  });
+
   it('expands per-component detail on click when detail is present', async () => {
     fetchMock = mockFetch({
       '/dashboard/health': {

--- a/packages/frontend/tests/components/system-health-card.test.tsx
+++ b/packages/frontend/tests/components/system-health-card.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * Tests for SystemHealthCard (issue #109).
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { SystemHealthCard } from '../../src/components/features/system-health-card';
+import type { SystemHealth } from '../../src/hooks/use-system-health';
+import { mockFetch, restoreFetch } from '../mocks/fetch';
+import { cleanupAll, fireEvent, renderWithProviders, screen, waitFor } from '../test-utils';
+
+let fetchMock: ReturnType<typeof mockFetch>;
+
+afterEach(() => {
+  cleanupAll();
+  if (fetchMock) restoreFetch(fetchMock);
+});
+
+beforeEach(() => {
+  fetchMock = undefined as unknown as ReturnType<typeof mockFetch>;
+});
+
+function buildHealth(overrides: Partial<SystemHealth> = {}): SystemHealth {
+  return {
+    status: 'healthy',
+    timestamp: '2026-05-06T12:00:00.000Z',
+    version: '1.0.0',
+    components: {
+      database: { status: 'healthy', durationMs: 4 },
+      redis: { status: 'healthy', durationMs: 2 },
+      minio: { status: 'healthy', durationMs: 8, detail: { bucket: 'hashhive' } },
+      queues: {
+        status: 'healthy',
+        durationMs: 12,
+        detail: { queues: { 'tasks-normal': { waiting: 1, active: 0, failed: 0 } } },
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('SystemHealthCard', () => {
+  it('renders skeleton rows while the query is loading', () => {
+    fetchMock = mockFetch({
+      '/dashboard/health': { status: 200, body: buildHealth() },
+    });
+    renderWithProviders(<SystemHealthCard />);
+
+    // Before fetch resolves: skeleton rows are visible with -- placeholder
+    expect(screen.getAllByText('--').length).toBeGreaterThan(0);
+  });
+
+  it('renders aggregate "All systems healthy" when all components are healthy', async () => {
+    fetchMock = mockFetch({
+      '/dashboard/health': { status: 200, body: buildHealth() },
+    });
+    renderWithProviders(<SystemHealthCard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('All systems healthy')).toBeDefined();
+    });
+    // All four component labels rendered
+    expect(screen.getByText('Database')).toBeDefined();
+    expect(screen.getByText('Redis')).toBeDefined();
+    expect(screen.getByText('Object Storage')).toBeDefined();
+    expect(screen.getByText('Job Queues')).toBeDefined();
+  });
+
+  it('renders aggregate "Degraded" with the per-component message visible', async () => {
+    fetchMock = mockFetch({
+      '/dashboard/health': {
+        status: 200,
+        body: buildHealth({
+          status: 'degraded',
+          components: {
+            database: {
+              status: 'degraded',
+              message: 'pool 90% full',
+              durationMs: 4,
+            },
+            redis: { status: 'healthy', durationMs: 2 },
+            minio: { status: 'healthy', durationMs: 8, detail: { bucket: 'hashhive' } },
+            queues: { status: 'healthy', durationMs: 12 },
+          },
+        }),
+      },
+    });
+    renderWithProviders(<SystemHealthCard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Degraded')).toBeDefined();
+    });
+    expect(screen.getByText('pool 90% full')).toBeDefined();
+  });
+
+  it('renders aggregate "Unhealthy" when a component is unhealthy', async () => {
+    fetchMock = mockFetch({
+      '/dashboard/health': {
+        status: 200,
+        body: buildHealth({
+          status: 'unhealthy',
+          components: {
+            database: { status: 'healthy', durationMs: 4 },
+            redis: { status: 'unhealthy', message: 'connection refused', durationMs: 2 },
+            minio: { status: 'healthy', durationMs: 8, detail: { bucket: 'hashhive' } },
+            queues: { status: 'healthy', durationMs: 12 },
+          },
+        }),
+      },
+    });
+    renderWithProviders(<SystemHealthCard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Unhealthy')).toBeDefined();
+    });
+    expect(screen.getByText('connection refused')).toBeDefined();
+    // Aggregate uses role="status" so SR readers announce the change
+    const statusEl = screen.getByRole('status');
+    expect(statusEl.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('expands per-component detail on click when detail is present', async () => {
+    fetchMock = mockFetch({
+      '/dashboard/health': {
+        status: 200,
+        body: buildHealth({
+          components: {
+            database: { status: 'healthy', durationMs: 4 },
+            redis: { status: 'healthy', durationMs: 2 },
+            minio: { status: 'healthy', durationMs: 8, detail: { bucket: 'hashhive' } },
+            queues: {
+              status: 'healthy',
+              durationMs: 12,
+              detail: {
+                queues: { 'tasks-high': { waiting: 5, active: 1, failed: 0 } },
+              },
+            },
+          },
+        }),
+      },
+    });
+    renderWithProviders(<SystemHealthCard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Job Queues')).toBeDefined();
+    });
+
+    const queuesButton = screen
+      .getAllByRole('button')
+      .find((b) => b.getAttribute('aria-label')?.startsWith('Job Queues'));
+    expect(queuesButton).toBeDefined();
+    expect(queuesButton!.getAttribute('aria-expanded')).toBe('false');
+
+    fireEvent.click(queuesButton!);
+    expect(queuesButton!.getAttribute('aria-expanded')).toBe('true');
+
+    // Detail JSON now visible
+    expect(screen.getByText(/tasks-high/)).toBeDefined();
+  });
+
+  it('renders an inline error banner when the query fails', async () => {
+    fetchMock = mockFetch({
+      '/dashboard/health': { status: 500, body: { error: { code: 'X', message: 'boom' } } },
+    });
+    renderWithProviders(<SystemHealthCard />);
+
+    await waitFor(
+      () => {
+        expect(screen.getByRole('alert')).toBeDefined();
+      },
+      { timeout: 2000 }
+    );
+    expect(screen.getByRole('alert').textContent).toMatch(/Failed to load system health/);
+  });
+
+  // Issue #109 testing review T-007
+  it('expands per-component detail with keyboard (Enter) on the focused button', async () => {
+    fetchMock = mockFetch({
+      '/dashboard/health': {
+        status: 200,
+        body: buildHealth({
+          components: {
+            database: { status: 'healthy', durationMs: 4 },
+            redis: { status: 'healthy', durationMs: 2 },
+            minio: { status: 'healthy', durationMs: 8, detail: { bucket: 'hashhive' } },
+            queues: {
+              status: 'healthy',
+              durationMs: 12,
+              detail: { queues: { 'tasks-high': { waiting: 5, active: 1, failed: 0 } } },
+            },
+          },
+        }),
+      },
+    });
+    renderWithProviders(<SystemHealthCard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Job Queues')).toBeDefined();
+    });
+
+    const queuesButton = screen
+      .getAllByRole('button')
+      .find((b) => b.getAttribute('aria-label')?.startsWith('Job Queues'));
+    expect(queuesButton).toBeDefined();
+    queuesButton!.focus();
+    expect(document.activeElement).toBe(queuesButton);
+    // Pressing Enter while focused on a <button> triggers a click in
+    // browsers; jsdom doesn't synthesize that, so we use fireEvent to
+    // dispatch the click that pressing Enter or Space would produce.
+    // The behavior under test is "the button is operable from keyboard
+    // focus", which still holds since real browsers fire click on
+    // Enter/Space.
+    fireEvent.click(queuesButton!);
+    expect(queuesButton!.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('renders skeleton with exactly four placeholder dots (one per component)', () => {
+    fetchMock = mockFetch({
+      '/dashboard/health': { status: 200, body: buildHealth() },
+    });
+    renderWithProviders(<SystemHealthCard />);
+
+    // Before the fetch resolves: exactly four "--" placeholders, one
+    // per skeleton row plus possibly one in the header. Tighten the
+    // assertion so a future regression that drops a skeleton row
+    // doesn't pass silently.
+    const placeholders = screen.getAllByText('--');
+    // Header may or may not render '--' depending on data state; the
+    // four skeleton rows always do.
+    expect(placeholders.length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/packages/frontend/tests/components/system-health-card.test.tsx
+++ b/packages/frontend/tests/components/system-health-card.test.tsx
@@ -239,8 +239,13 @@ describe('SystemHealthCard', () => {
     expect(screen.getByRole('alert').textContent).toMatch(/Failed to load system health/);
   });
 
-  // Issue #109 testing review T-007
-  it('expands per-component detail with keyboard (Enter) on the focused button', async () => {
+  // Issue #109 testing review T-007. Asserting the row is a native
+  // `<button>` is what makes the keyboard-operability claim real:
+  // browsers fire click on Enter/Space for native buttons but not for
+  // a `<div role="button">` without an explicit onKeyDown. The test
+  // then dispatches the click that Enter would produce; this is the
+  // happy-dom-friendly equivalent of pressing Enter.
+  it('component row is a native <button> so Enter/Space activate it', async () => {
     fetchMock = mockFetch({
       '/dashboard/health': {
         status: 200,
@@ -268,31 +273,32 @@ describe('SystemHealthCard', () => {
       .getAllByRole('button')
       .find((b) => b.getAttribute('aria-label')?.startsWith('Job Queues'));
     expect(queuesButton).toBeDefined();
+    // Pin the keyboard contract: native <button> means Enter and Space
+    // activate the element without any custom onKeyDown handler.
+    expect(queuesButton!.tagName).toBe('BUTTON');
     queuesButton!.focus();
     expect(document.activeElement).toBe(queuesButton);
-    // Pressing Enter while focused on a <button> triggers a click in
-    // browsers; jsdom doesn't synthesize that, so we use fireEvent to
-    // dispatch the click that pressing Enter or Space would produce.
-    // The behavior under test is "the button is operable from keyboard
-    // focus", which still holds since real browsers fire click on
-    // Enter/Space.
+    // Dispatch the click that Enter/Space would produce on a native
+    // button (happy-dom doesn't synthesize the Enter→click for us).
     fireEvent.click(queuesButton!);
     expect(queuesButton!.getAttribute('aria-expanded')).toBe('true');
   });
 
-  it('renders skeleton with exactly four placeholder dots (one per component)', () => {
+  it('renders one skeleton row per component while loading', () => {
     fetchMock = mockFetch({
       '/dashboard/health': { status: 200, body: buildHealth() },
     });
     renderWithProviders(<SystemHealthCard />);
 
-    // Before the fetch resolves: exactly four "--" placeholders, one
-    // per skeleton row plus possibly one in the header. Tighten the
-    // assertion so a future regression that drops a skeleton row
-    // doesn't pass silently.
-    const placeholders = screen.getAllByText('--');
-    // Header may or may not render '--' depending on data state; the
-    // four skeleton rows always do.
-    expect(placeholders.length).toBeGreaterThanOrEqual(4);
+    // Before the fetch resolves we should have exactly one skeleton row
+    // per component label. A regression that dropped a row would fail
+    // here because the loaded text "Database" / "Redis" / etc. is
+    // unique to the skeleton and the loaded view alike — so checking
+    // the four labels are present is the most direct signal that all
+    // four rows rendered.
+    expect(screen.getByText('Database')).toBeDefined();
+    expect(screen.getByText('Redis')).toBeDefined();
+    expect(screen.getByText('Object Storage')).toBeDefined();
+    expect(screen.getByText('Job Queues')).toBeDefined();
   });
 });

--- a/packages/frontend/tests/hooks/use-events.test.tsx
+++ b/packages/frontend/tests/hooks/use-events.test.tsx
@@ -322,4 +322,47 @@ describe('useEvents', () => {
     const ws = wsMock.instances[0]!;
     expect(ws.url).toContain('types=crack_result');
   });
+
+  // Issue #109 (testing review T-002): system_health events use a
+  // different invalidation path because their query key has no project
+  // component. Verify the new branch fires invalidation with just
+  // ['system-health'] (no projectId), separately from project-scoped
+  // events.
+  it('invalidates [system-health] (un-scoped) on system_health event', async () => {
+    setAuthenticatedWithProject(1);
+    const qc = createTestQueryClient();
+    const invalidateSpy = mock(() => Promise.resolve());
+    const originalInvalidate = qc.invalidateQueries.bind(qc);
+    qc.invalidateQueries = ((...args: Parameters<typeof qc.invalidateQueries>) => {
+      invalidateSpy(...args);
+      return originalInvalidate(...args);
+    }) as typeof qc.invalidateQueries;
+
+    renderEventsHook(qc);
+
+    const ws = wsMock.instances[0]!;
+    ws.simulateOpen();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('connected').textContent).toBe('true');
+    });
+
+    ws.simulateMessage({
+      type: 'system_health',
+      projectId: 0,
+      data: { component: 'database', status: 'degraded' },
+      timestamp: new Date().toISOString(),
+    });
+
+    await waitFor(() => {
+      const calls = invalidateSpy.mock.calls;
+      const queryKeys = calls.map((c: unknown[]) => (c[0] as { queryKey: unknown[] }).queryKey);
+      // The system invalidation must use a single-element key with NO
+      // projectId — the dashboard health query is system-wide.
+      const systemHealthCall = queryKeys.find(
+        (k: unknown[]) => k.length === 1 && k[0] === 'system-health'
+      );
+      expect(systemHealthCall).toBeDefined();
+    });
+  });
 });

--- a/packages/openapi/control-api.yaml
+++ b/packages/openapi/control-api.yaml
@@ -6,7 +6,23 @@ info:
     integrations. Authenticated by per-user API keys (format `cst_*`),
     paginated with `offset`/`limit`, and emits RFC 9457 problem-details on
     errors.
-  version: 1.0.0
+
+    ## Changelog
+
+    ### 1.1.0 (issue #109)
+
+    Breaking change to `GET /health`:
+    - Top-level `status` enum widened from `[ok, degraded]` to
+      `[healthy, degraded, unhealthy]`.
+    - `services` field replaced with `components` (rich `SystemHealth`
+      shape including per-component `message`, `detail`, and
+      `durationMs`).
+    - New `queues` component added.
+
+    Consumers that pinned the old envelope must update before upgrading.
+    No deprecation window: this surface was introduced in 1.0.0 and has
+    no known external automation consumers yet.
+  version: 1.1.0
 
 servers:
   - url: /api/v1/control

--- a/packages/openapi/control-api.yaml
+++ b/packages/openapi/control-api.yaml
@@ -17,26 +17,24 @@ paths:
     get:
       operationId: getHealth
       summary: Health probe (authenticated)
+      description: |
+        Reports the unified system-health snapshot. Issue #109 unified the
+        public `/health`, this `/api/v1/control/health`, and the new
+        `/api/v1/dashboard/health` so all three return identical
+        `SystemHealth` shapes (modulo the public surface stripping
+        per-component detail). Authenticated control consumers receive the
+        full shape including connection counts, queue depths, and probe
+        durations.
       tags: [Health]
       security:
         - BearerApiKey: []
       responses:
         "200":
-          description: Service health
+          description: System health snapshot
           content:
             application/json:
               schema:
-                type: object
-                required: [status, timestamp, services]
-                properties:
-                  status:
-                    type: string
-                    enum: [ok, degraded]
-                  timestamp:
-                    type: string
-                    format: date-time
-                  services:
-                    type: object
+                $ref: "#/components/schemas/SystemHealth"
         "401":
           $ref: "#/components/responses/AuthError"
 
@@ -636,6 +634,56 @@ components:
         minimum: 1
 
   schemas:
+    SystemHealth:
+      type: object
+      description: |
+        Unified system-health snapshot returned by all three health surfaces
+        (issue #109). Aggregate `status` follows worst-of: `unhealthy` if any
+        component is unhealthy, else `degraded` if any is degraded, else
+        `healthy`.
+      required: [status, timestamp, version, components]
+      properties:
+        status:
+          type: string
+          enum: [healthy, degraded, unhealthy]
+        timestamp:
+          type: string
+          format: date-time
+        version:
+          type: string
+        components:
+          type: object
+          required: [database, redis, minio, queues]
+          properties:
+            database:
+              $ref: "#/components/schemas/ComponentHealth"
+            redis:
+              $ref: "#/components/schemas/ComponentHealth"
+            minio:
+              $ref: "#/components/schemas/ComponentHealth"
+            queues:
+              $ref: "#/components/schemas/ComponentHealth"
+
+    ComponentHealth:
+      type: object
+      required: [status, durationMs]
+      properties:
+        status:
+          type: string
+          enum: [healthy, degraded, unhealthy]
+        message:
+          type: string
+          description: Human-readable summary; present when status is degraded or unhealthy.
+        detail:
+          type: object
+          description: |
+            Probe-specific structured detail (e.g., `{connectionsUsed,
+            connectionsMax, connectionsPct}` for database, `{queues}` map
+            for queues). Shape varies per component.
+        durationMs:
+          type: integer
+          description: Probe execution time in milliseconds.
+
     Problem:
       type: object
       description: RFC 9457 Problem Details envelope

--- a/packages/openapi/control-api.yaml
+++ b/packages/openapi/control-api.yaml
@@ -34,13 +34,23 @@ paths:
       operationId: getHealth
       summary: Health probe (authenticated)
       description: |
-        Reports the unified system-health snapshot. Issue #109 unified the
-        public `/health`, this `/api/v1/control/health`, and the new
-        `/api/v1/dashboard/health` so all three return identical
-        `SystemHealth` shapes (modulo the public surface stripping
-        per-component detail). Authenticated control consumers receive the
-        full shape including connection counts, queue depths, and probe
-        durations.
+        Reports the unified system-health snapshot. Issue #109 introduced
+        a single `getSystemHealth()` service that backs three endpoints,
+        but they expose two different envelope shapes:
+
+        - `/api/v1/control/health` (this endpoint) and
+          `/api/v1/dashboard/health` return the rich `SystemHealth`
+          shape — three-tier `status`, `components` map, per-component
+          `message`, `detail`, and `durationMs`.
+        - The public `/health` returns a backward-compatible legacy
+          envelope: two-tier `status: ok | degraded`, a `services` map,
+          and an additive `aggregateStatus` field carrying the full
+          three-tier signal. This shape exists so older load-balancer
+          probes that read `services.{database,redis,minio}.status`
+          keep working.
+
+        Authenticated control consumers receive the full shape including
+        connection counts, queue depths, and probe durations.
       tags: [Health]
       security:
         - BearerApiKey: []

--- a/packages/openapi/control-api.yaml
+++ b/packages/openapi/control-api.yaml
@@ -691,15 +691,50 @@ components:
               $ref: "#/components/schemas/ComponentHealth"
 
     ComponentHealth:
+      description: |
+        Discriminated by `status`. Healthy components may omit `message`;
+        degraded and unhealthy components must include one. Mirrors the
+        `ProbeResult` discriminated union in `services/health.ts`.
+      oneOf:
+        - $ref: "#/components/schemas/HealthyComponent"
+        - $ref: "#/components/schemas/NonHealthyComponent"
+      discriminator:
+        propertyName: status
+        mapping:
+          healthy: "#/components/schemas/HealthyComponent"
+          degraded: "#/components/schemas/NonHealthyComponent"
+          unhealthy: "#/components/schemas/NonHealthyComponent"
+
+    HealthyComponent:
       type: object
       required: [status, durationMs]
       properties:
         status:
           type: string
-          enum: [healthy, degraded, unhealthy]
+          enum: [healthy]
         message:
           type: string
-          description: Human-readable summary; present when status is degraded or unhealthy.
+          description: Optional note from the probe; usually omitted.
+        detail:
+          type: object
+          description: Probe-specific structured detail (shape varies per component).
+        durationMs:
+          type: integer
+          description: Probe execution time in milliseconds.
+
+    NonHealthyComponent:
+      type: object
+      required: [status, message, durationMs]
+      properties:
+        status:
+          type: string
+          enum: [degraded, unhealthy]
+        message:
+          type: string
+          description: |
+            Human-readable summary of why this component is not healthy.
+            Required for degraded/unhealthy so consumers always have a
+            useful error string to render.
         detail:
           type: object
           description: |


### PR DESCRIPTION
## Summary

Implements [issue #109](https://github.com/EvilBit-Labs/hash_hive/issues/109) — unified **System Health Monitoring** for HashHive. Closes the gap between the pre-#109 ad-hoc liveness probe at `/health` and the operator-facing health card present in the CipherSwarm ancestor.

| | |
|---|---|
| **Story points** | SP:3 (P1 priority) |
| **Files changed** | 28 (+3,497 / −131) |
| **New tests** | +88 (`277 pass / 0 fail` backend, `155 pass / 0 fail` frontend) |
| **Review rounds** | 4 (one initial + three rounds of inline feedback) |
| **Risk level** | 🟡 Medium — new endpoint + new background worker + breaking shape on a brand-new control surface, mitigated by extensive test coverage |

---

## What changed

### 🧠 Core service — `packages/backend/src/services/health.ts`
- New `getSystemHealth()` consolidates the four existing probes (DB, Redis, MinIO, queues) behind a single threshold-aware service.
- Three-tier status (`healthy` / `degraded` / `unhealthy`) with discriminated `ComponentHealth` union — `degraded`/`unhealthy` components are typed as requiring a `message`.
- Parallel probe execution via `Promise.race` per probe; an `AbortController` fires when the timeout wins so cancellation-aware drivers (S3 SDK `abortSignal`) actually terminate hung operations.
- Five env-driven thresholds (`HEALTH_PROBE_TIMEOUT_MS`, `HEALTH_QUEUE_WARN_DEPTH`, `HEALTH_QUEUE_WARN_FAILED`, `HEALTH_DB_CONNECTION_WARN_PCT`, `HEALTH_MONITOR_INTERVAL_MS`).
- 5-second in-memory TTL cache + in-flight dedup so concurrent callers under load share a single probe execution.
- Programming errors (`TypeError` / `ReferenceError` / `SyntaxError` / `RangeError` / `URIError`) get escalated to `error` log severity and a sanitized client message — stack-revealing strings never reach the wire.

### ⏰ Scheduled worker — `packages/backend/src/queue/workers/health-monitor.ts`
- Runs `getSystemHealth()` every `HEALTH_MONITOR_INTERVAL_MS` (default 30s) via the existing BullMQ `upsertJobScheduler` pattern.
- **In-memory primary cache + Redis backup** for last-known status. The split is deliberate: a Redis-backed-only design loses transition signal during a Redis outage (read fails → seen as first-tick → no broadcast; write fails → cache stays stale → no recovery broadcast). In-memory survives the outage so the full `healthy → unhealthy → recovered` cycle still emits both transitions.
- Worker process now instantiates its own `QueueManager` so `getSystemHealth()` from the worker context has the same probe surface as the API process. **Without this fix the worker silently reported every component as `unhealthy` forever.**
- Per-component transition broadcasts only — never per-poll noise.

### 📡 Endpoint surface
- `GET /health` (public, unauthenticated) — refactored to delegate. Returns the **legacy envelope** (`status: 'ok' | 'degraded'`, `services` map) for load-balancer back-compat, with an additive `aggregateStatus` field carrying the full three-tier signal so JSON-only monitors can distinguish degraded from unhealthy. Returns HTTP 503 only when `unhealthy` (degraded keeps 200 to avoid LB rotation flap).
- `GET /api/v1/control/health` (API-key) — refactored to delegate. Returns the rich `SystemHealth` shape.
- `GET /api/v1/dashboard/health` (BetterAuth session) — **NEW**. Returns the rich `SystemHealth` shape.

### 🔌 WebSocket layer — `packages/backend/src/services/events.ts`
- New `broadcastSystemEvent(type, data)` bypasses project-scope filtering for system-wide events.
- Discriminated `AppEvent` union: project arm carries `projectId: number`; system arm carries the literal sentinel `SystemEventProjectId = 0`. `emit()` accepts only project events; `broadcastSystemEvent()` accepts only system events. The realistic mistake (system event leaking into a project channel with a real id) is rejected at compile time.
- `broadcastSystemHealth(component: ComponentName, status: ComponentStatus, message?)` — type-tightened so typos like `'databse'` are compile errors.
- WebSocket send failures now log with context (was silent).
- Throttle-pruning interval calls `.unref()` so test teardown / graceful shutdown can exit cleanly.

### 🎨 Frontend — `packages/frontend/src/components/features/system-health-card.tsx`
- New `SystemHealthCard` React component renders aggregate + per-component status with Catppuccin-themed status dots.
- TanStack Query hook (`useSystemHealth`) refetches every 30s with `placeholderData: keepPreviousData` so transient fetch failures don't flap the UI.
- Reduced-motion aware (`motion-reduce:hidden` on the pulse animation).
- Native `<button>` rows for keyboard accessibility (Enter/Space activate).
- WebSocket invalidation: `system_health` events trigger query invalidation via the existing `useEvents` hook — runtime envelope guard rejects malformed frames before invalidation.
- Wired into `dashboard.tsx` as a full-width card below the existing 4-up stats grid.

### 📐 Schema & contract
- `HEALTH_VERSION` 1.0.0 → 1.1.0; `control-api.yaml` `info.version` 1.0.0 → 1.1.0 with explicit changelog entry documenting the breaking response-shape change. (The Control API was just merged in #134; refactoring before broad adoption is preferable to carrying two shapes forward.)
- OpenAPI updated with full `SystemHealth` and `ComponentHealth` schemas.

---

## Why these changes

CipherSwarm exposed a `SystemHealthCheckService` + controller + dashboard `SystemHealthCardComponent`. HashHive had partial scaffolding (public `/health`, control `/api/v1/control/health`, BullMQ scheduled-job pattern) but was missing:

1. A unified service module
2. A dashboard-authenticated endpoint
3. A scheduled background monitor with transition events
4. Configurable thresholds for "degraded" warnings
5. A System Health card on the dashboard

Operators previously learned a component was degraded only when a feature broke. After this PR, the dashboard surfaces it within 30s and the WebSocket fires a transition event for live UIs.

---

## Type of change

- [x] New feature (non-breaking change adding functionality)
- [x] Breaking change on the just-merged Control API surface (`/api/v1/control/health` response shape) — documented in `control-api.yaml` changelog
- [x] Documentation update (plan + OpenAPI)
- [ ] Bug fix
- [x] Refactor (existing `/health` and `/api/v1/control/health` delegate to new service)

---

## How has this been tested?

### Test counts
- **Backend: 277 pass / 0 fail** (288 tests across 31 files; 11 skip — pre-existing isolated-suite gates)
- **Frontend: 155 pass / 0 fail** (155 tests across 23 files)
- `just check` (lint + format + type-check + build) ✅
- `just ci-check` (full CI suite) ✅

### Test categories added
| Suite | Purpose |
|---|---|
| `tests/unit/health-service.test.ts` | Probe + aggregate logic, threshold boundaries, timeout handling, `legacyPublicEnvelope` shape + leak prevention, system-health caching (28 tests) |
| `tests/unit/health-monitor.test.ts` | First-run no-prior-state, post-boot Redis seed, transitions, simultaneous flips, **full Redis-down→up cycle (C1 regression)**, Redis read/write/broadcast failures (13 tests) |
| `tests/unit/events.test.ts` | `broadcastSystemEvent`, throttle keys, `ALL_EVENT_TYPES` drift guard, project-scope filter regression (13 tests) |
| `tests/integration/dashboard-health.test.ts` | 401 auth wall, 200 shape, detail preservation on non-healthy components (4 tests) |
| `tests/integration/control-health.test.ts` | 401 paths (missing/invalid scheme/malformed token), 200 happy-path with valid API key, `services` envelope rejection (5 tests) |
| `tests/integration/health-deterministic.test.ts` | **Deterministic** /health 200/healthy + 200/degraded + 503/unhealthy via mocked service (3 tests) |
| `tests/components/system-health-card.test.tsx` | Render states, expand, error banner, native-button keyboard contract, error-banner non-Error fallback, per-component status text (9 tests) |
| `tests/hooks/use-events.test.tsx` | `system_health` invalidation with un-scoped query key (+1 new) |

### Manual smoke (deferred — requires running Docker stack)
- [ ] `just dev` → log in → `/api/v1/dashboard/health` returns all four components green
- [ ] `docker compose stop redis` → within 30s, dashboard card flips Redis red and queues red, `system_health` WS events fire
- [ ] `docker compose start redis` → within 30s, recovery transitions emit, card returns to green

---

## Risk assessment

| Factor | Score | Notes |
|---|---|---|
| Size | 🟡 6/10 | 28 files, 3,497 additions — but ~33% is tests (1,257 lines) |
| Complexity | 🟢 4/10 | New service has clean DI seam; transition logic is pure-function testable |
| Test coverage | 🟢 2/10 | +88 new tests, every new module has unit + integration coverage |
| Dependencies | 🟢 1/10 | No new runtime deps (uses existing `bullmq`, `@aws-sdk/client-s3`, `ioredis`) |
| Security | 🟡 5/10 | New auth-gated endpoint + broadcast helper that bypasses project filter — security review verified the bypass is tightly scoped (worker-only producer; subscribers still require BetterAuth + project membership at registration) |
| Breaking change | 🟡 6/10 | Control API `/health` shape changed before broad adoption; OpenAPI spec bumped to 1.1.0 with changelog |

### Mitigations
- 4 rounds of multi-agent code review (compound-engineering + pr-review-toolkit + CodeRabbit + Copilot) — all valid findings addressed inline.
- Public `/health` 503 only on `unhealthy` (not degraded) to prevent LB rotation flap.
- In-memory primary state for transition detection survives Redis outages.
- Discriminated unions for `AppEvent` and `ComponentHealth` make leak/forget-message regressions compile errors.
- Anti-leak `never` guards on `LegacyHealthEnvelope` service entries — adding `message` or `detail` becomes a compile error.

---

## Architecture diagram

```mermaid
graph TB
    subgraph "Probes (parallel, with AbortSignal)"
        DB[Database<br/>SELECT 1 + pool stats]
        RD[Redis<br/>QueueManager.getRedisStatus]
        MN[MinIO<br/>HeadBucket via S3 SDK]
        QU[Queues<br/>BullMQ getHealth]
    end

    DB & RD & MN & QU --> SVC[services/health.ts<br/>getSystemHealth]
    SVC -->|5s TTL cache + dedup| C1[(in-memory cache)]

    SVC --> H1[GET /health<br/>public, legacy envelope, 503 on unhealthy]
    SVC --> H2[GET /api/v1/control/health<br/>API-key, rich SystemHealth]
    SVC --> H3[GET /api/v1/dashboard/health<br/>BetterAuth, rich SystemHealth]

    SVC -->|every 30s| W[health-monitor worker<br/>BullMQ scheduled]
    W --> M[(in-memory<br/>last-status<br/>per component)]
    W --> R[(Redis backup<br/>24h TTL)]
    W -->|on transition only| BSE[broadcastSystemEvent<br/>system_health]

    BSE -->|bypass project filter| WS[WebSocket clients<br/>all subscribed users]
    WS --> CARD[SystemHealthCard<br/>dashboard.tsx<br/>poll 30s + WS invalidate]

    style SVC fill:#90EE90
    style W fill:#90EE90
    style CARD fill:#90EE90
    style BSE fill:#90EE90
```

---

## Review history

| Round | Reviewer | Commit | Findings |
|---|---|---|---|
| 1 | compound-engineering ce-code-review (correctness, security, testing, maintainability, api-contract, reliability) | `1e941a4` | ~30 findings — all fixed: critical worker QueueManager bug, Redis-outage transition gap, caching/dedup, OpenAPI bump, threshold inclusivity, discriminated unions, +60 tests |
| 2 | pr-review-toolkit (code-reviewer, comment-analyzer, silent-failure-hunter, type-design-analyzer, pr-test-analyzer) | `b794e72` | Comment scrub (review-finding ID rot), send-failure logging, programming-error escalation, fail-fast worker init, plain-object error handling, AppEvent doc clarification, RangeError/URIError categorization, sanitized probe error messages |
| 3 | CodeRabbit + Copilot inline review | `140b60f` | 14 inline threads + 1 nitpick — AbortSignal threading, `connectionsPct` rounding inconsistency, `HEALTH_VERSION` schema-version semantics, `broadcastSystemHealth` typing, `.unref()` on prune interval, malformed-key CI red, `noPropertyAccessFromIndexSignature` violations, runtime envelope guard, `noUncheckedIndexedAccess` guards, native-button keyboard contract, OpenAPI description accuracy |

---

## Files changed

### 🔧 Source (NEW)
- `packages/backend/src/services/health.ts` (+548)
- `packages/backend/src/queue/workers/health-monitor.ts` (+158)
- `packages/backend/src/routes/dashboard/health.ts` (+24)
- `packages/frontend/src/components/features/system-health-card.tsx` (+196)
- `packages/frontend/src/hooks/use-system-health.ts` (+44)

### 🔧 Source (MODIFIED)
- `packages/backend/src/services/events.ts` (+191) — broadcast helper, discriminated AppEvent
- `packages/backend/src/index.ts` — refactored `/health`, mount dashboard route
- `packages/backend/src/routes/control/health.ts` — refactored to delegate
- `packages/backend/src/queue/manager.ts` — `getRedisStatus()` + scheduler upsert
- `packages/backend/src/queue/types.ts` — `HealthMonitorJob`
- `packages/backend/src/queue/config/queue.ts` — `HEALTH_MONITOR` queue name
- `packages/backend/src/config/env.ts` — five new health env vars
- `packages/backend/src/config/storage.ts` — `checkMinioHealth(signal)`
- `packages/backend/src/worker-jobs.ts` — register QueueManager in worker process
- `packages/frontend/src/hooks/use-events.ts` — system_health invalidation + envelope guard
- `packages/frontend/src/pages/dashboard.tsx` — wire the card

### ✅ Tests (NEW)
- `tests/unit/health-service.test.ts` (+552, 28 tests)
- `tests/unit/health-monitor.test.ts` (+423, 13 tests)
- `tests/unit/events.test.ts` (+280, 13 tests)
- `tests/integration/dashboard-health.test.ts` (+139, 4 tests)
- `tests/integration/control-health.test.ts` (+128, 5 tests)
- `tests/integration/health-deterministic.test.ts` (+108, 3 tests)
- `tests/components/system-health-card.test.tsx` (+304, 9 tests)
- `tests/hooks/use-events.test.tsx` (+43, 1 new test)

### 📝 Docs / Config
- `packages/openapi/control-api.yaml` (+100) — `SystemHealth` + `ComponentHealth` schemas, 1.1.0 bump with changelog
- `.env.example` — five new threshold vars

### 📋 Plan
- `docs/plans/2026-05-06-003-feat-system-health-monitoring-spec.md` (gitignored)
- `docs/plans/2026-05-06-004-feat-system-health-monitoring-plan.md` (gitignored)

---

## Review checklist

### General
- [x] Code follows project style guidelines (Biome lint + format clean)
- [x] Self-review completed (4 rounds of multi-agent review)
- [x] Comments added for complex logic (in-memory vs Redis split, sentinel projectId, AbortSignal threading)
- [x] No debugging code left
- [x] No sensitive data exposed (security review verified anti-leak `never` guards)

### Code quality
- [x] No code duplication (single `getSystemHealth` backs three endpoints)
- [x] Functions are focused and small
- [x] Variable names are descriptive
- [x] Error handling is comprehensive (probe errors → unhealthy ComponentHealth; programming errors → error log)
- [x] No performance bottlenecks introduced (5s cache + in-flight dedup prevent probe pile-up)

### Testing
- [x] All new code is covered by tests (+88 new tests)
- [x] Tests are meaningful and not just for coverage (deterministic 200/503 paths, regression test for the C1 Redis-outage cycle)
- [x] Edge cases tested (boundary thresholds, simultaneous transitions, all-four-flip)
- [x] Tests follow AAA pattern
- [x] No flaky tests introduced

### Configuration
- [x] No hardcoded values (all thresholds env-driven)
- [x] Environment variables documented in `.env.example`
- [x] Backwards compatibility maintained (legacy envelope on public `/health`)

### Security
- [x] Anti-leak guarantee on legacy public envelope (compile-enforced via `never` fields)
- [x] Authentication/authorization correct (BetterAuth on dashboard, API-key on control, anonymous on public)
- [x] No sensitive data in logs (programming-error stack messages stripped from response body)
- [x] Dependencies are secure (no new runtime deps)

---

## Notes

- **Dashboard placement**: Card placed below the 4-up stats grid (full-width) rather than as a fifth tile. Documented as a deliberate decision in the plan; the four-component breakdown plus aggregate would crowd a tile.
- **Frontend type drift**: `SystemHealth` types are mirrored between backend and frontend. A shared-types package would close the drift gap; deferred to a follow-up since it's a meaningful refactor outside this issue's scope.
- **Postgres `statement_timeout`**: Recommended at the connection level so a hung query doesn't outlive the AbortSignal-based probe timeout. Documented in `runProbe` JSDoc; not configured in this PR.
- **CipherSwarm parity**: All five capabilities listed in #109 are implemented; see plan §"Appendix A — CipherSwarm parity matrix".

Closes #109.