### PR TITLE
feat(agent): heartbeat & error handling with audit log

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -10,7 +10,7 @@
     "start": "bun dist/index.js",
     "worker:tasks": "bun src/worker-task-generation.ts",
     "worker:jobs": "bun src/worker-jobs.ts",
-    "test": "TASKS_TEST_ISOLATED=1 bun test --preload ./tests/preload.ts tests/unit/tasks.test.ts && QUEUE_MANAGER_TEST_ISOLATED=1 bun test --preload ./tests/preload.ts tests/unit/queue-manager.test.ts && CONTROL_RBAC_TEST_ISOLATED=1 bun test --preload ./tests/preload.ts tests/unit/control-routes-rbac.test.ts && HEALTH_DETERMINISTIC_TEST_ISOLATED=1 bun test --preload ./tests/preload.ts tests/integration/health-deterministic.test.ts && bun test --preload ./tests/preload.ts",
+    "test": "TASKS_TEST_ISOLATED=1 bun test --preload ./tests/preload.ts tests/unit/tasks.test.ts && QUEUE_MANAGER_TEST_ISOLATED=1 bun test --preload ./tests/preload.ts tests/unit/queue-manager.test.ts && CONTROL_RBAC_TEST_ISOLATED=1 bun test --preload ./tests/preload.ts tests/unit/control-routes-rbac.test.ts && HEALTH_DETERMINISTIC_TEST_ISOLATED=1 bun test --preload ./tests/preload.ts tests/integration/health-deterministic.test.ts && AGENT_HEARTBEAT_TEST_ISOLATED=1 bun test --preload ./tests/preload.ts tests/integration/agent-heartbeat.test.ts && bun test --preload ./tests/preload.ts",
     "lint": "biome check ./src",
     "type-check": "tsc --noEmit",
     "db:generate": "drizzle-kit generate",

--- a/packages/backend/src/middleware/auth.ts
+++ b/packages/backend/src/middleware/auth.ts
@@ -50,36 +50,67 @@ export const requireSession = createMiddleware<AppEnv>(async (c, next) => {
 });
 
 /**
- * Agent auth middleware — validates pre-shared token from Authorization: Bearer header.
- * Queries the agents table directly and sets agent context (agentId, projectId, capabilities).
+ * Build an agent-token middleware. Validates the `Authorization: Bearer`
+ * pre-shared token against the agents table and sets agent context.
+ *
+ * `allowErroredAgent` controls what happens when the agent's row is in
+ * `status='error'`. Work endpoints (`/tasks/*`, `/errors`, `/benchmark`,
+ * `/resources/*`, `/cracker/*`) keep the default (reject), so a broken
+ * agent can't pick up new tasks. The heartbeat endpoint flips it to
+ * `true` so the agent can announce recovery — a clean heartbeat
+ * transitions the agent back to `online` via `processHeartbeat`, which
+ * is the only programmatic recovery path the agent has.
  */
-export const requireAgentToken = createMiddleware<AppEnv>(async (c, next) => {
-  const authHeader = c.req.header('authorization');
-  if (!authHeader?.startsWith('Bearer ')) {
-    throw authError('Bearer token required');
-  }
+function createAgentTokenMiddleware(opts: { allowErroredAgent: boolean }) {
+  return createMiddleware<AppEnv>(async (c, next) => {
+    const authHeader = c.req.header('authorization');
+    if (!authHeader?.startsWith('Bearer ')) {
+      throw authError('Bearer token required');
+    }
 
-  const token = authHeader.slice(7);
+    const token = authHeader.slice(7);
 
-  const [agent] = await db
-    .select({
-      id: agents.id,
-      projectId: agents.projectId,
-      status: agents.status,
-      capabilities: agents.capabilities,
-    })
-    .from(agents)
-    .where(eq(agents.authToken, token))
-    .limit(1);
+    const [agent] = await db
+      .select({
+        id: agents.id,
+        projectId: agents.projectId,
+        status: agents.status,
+        capabilities: agents.capabilities,
+      })
+      .from(agents)
+      .where(eq(agents.authToken, token))
+      .limit(1);
 
-  if (!agent || agent.status === 'error') {
-    throw authError('Invalid or expired agent token');
-  }
+    if (!agent) {
+      throw authError('Invalid or expired agent token');
+    }
+    if (agent.status === 'error' && !opts.allowErroredAgent) {
+      throw authError('Invalid or expired agent token');
+    }
 
-  c.set('agent', {
-    agentId: agent.id,
-    projectId: agent.projectId,
-    capabilities: (agent.capabilities ?? {}) as Record<string, unknown>,
+    c.set('agent', {
+      agentId: agent.id,
+      projectId: agent.projectId,
+      capabilities: (agent.capabilities ?? {}) as Record<string, unknown>,
+    });
+    await next();
   });
-  await next();
+}
+
+/**
+ * Strict agent auth — rejects agents whose row is in `status='error'`.
+ * Use this on work endpoints; a broken agent should not be picking up
+ * new tasks or posting benchmarks until it sends a recovery heartbeat.
+ */
+export const requireAgentToken = createAgentTokenMiddleware({ allowErroredAgent: false });
+
+/**
+ * Recovery-friendly agent auth — accepts agents whose row is in
+ * `status='error'` so they can post a recovery heartbeat. Use ONLY on
+ * `POST /api/v1/agent/heartbeat`; the heartbeat handler is responsible
+ * for transitioning the agent back to `online` (or keeping it in
+ * `error` if the recovery heartbeat itself reports a fatal error).
+ */
+export const requireAgentTokenAllowRecovery = createAgentTokenMiddleware({
+  allowErroredAgent: true,
 });

--- a/packages/backend/src/middleware/auth.ts
+++ b/packages/backend/src/middleware/auth.ts
@@ -111,6 +111,6 @@ export const requireAgentToken = createAgentTokenMiddleware({ allowErroredAgent:
  * for transitioning the agent back to `online` (or keeping it in
  * `error` if the recovery heartbeat itself reports a fatal error).
  */
-export const requireAgentTokenAllowRecovery = createAgentTokenMiddleware({
+export const requireAgentTokenForHeartbeatRecovery = createAgentTokenMiddleware({
   allowErroredAgent: true,
 });

--- a/packages/backend/src/routes/agent/index.ts
+++ b/packages/backend/src/routes/agent/index.ts
@@ -6,7 +6,9 @@ import {
   HEARTBEAT_ERROR_MESSAGE_MAX,
 } from '@hashhive/shared';
 import { zValidator } from '@hono/zod-validator';
+import type { Context } from 'hono';
 import { Hono } from 'hono';
+import type { ZodIssue } from 'zod';
 import { z } from 'zod';
 import { logger } from '../../config/logger.js';
 import { requireAgentToken } from '../../middleware/auth.js';
@@ -27,6 +29,26 @@ import {
 } from '../../services/tasks.js';
 import type { AppEnv } from '../../types.js';
 
+/**
+ * Map a zValidator failure to the documented Agent API error envelope
+ * (`{error: {code, message}}`). `@hono/zod-validator` otherwise returns
+ * its own `{success, error, data}` shape, which drifts from the contract
+ * the rest of this surface uses (see the 401 handler in
+ * `middleware/auth.ts` and AGENTS.md "API Surfaces"). Centralizing the
+ * mapping here also gives contract tests a single stable assertion
+ * target.
+ */
+function agentValidationHook(
+  result: { success: boolean; error?: { issues?: ZodIssue[] } },
+  c: Context
+) {
+  if (result.success) return;
+  const first = result.error?.issues?.[0];
+  const path = first?.path?.length ? first.path.join('.') : 'body';
+  const message = first?.message ? `${path}: ${first.message}` : 'Invalid request body';
+  return c.json({ error: { code: 'VALIDATION_ERROR', message } }, 400);
+}
+
 const agentRoutes = new Hono<AppEnv>();
 
 // ─── Authenticated agent endpoints ──────────────────────────────────
@@ -40,15 +62,19 @@ agentRoutes.use('/cracker/*', requireAgentToken);
 
 // ─── POST /heartbeat — agent heartbeat ──────────────────────────────
 
-agentRoutes.post('/heartbeat', zValidator('json', agentHeartbeatSchema), async (c) => {
-  const { agentId } = c.get('agent');
-  const data = c.req.valid('json');
-  const result = await processHeartbeat(agentId, data);
-  return c.json({
-    acknowledged: true,
-    ...(result.hasHighPriorityTasks ? { hasHighPriorityTasks: true } : {}),
-  });
-});
+agentRoutes.post(
+  '/heartbeat',
+  zValidator('json', agentHeartbeatSchema, agentValidationHook),
+  async (c) => {
+    const { agentId } = c.get('agent');
+    const data = c.req.valid('json');
+    const result = await processHeartbeat(agentId, data);
+    return c.json({
+      acknowledged: true,
+      ...(result.hasHighPriorityTasks ? { hasHighPriorityTasks: true } : {}),
+    });
+  }
+);
 
 // ─── POST /tasks/next — request next task ───────────────────────────
 
@@ -95,50 +121,54 @@ const taskReportSchema = z.object({
   errors: z.array(z.string()).optional(),
 });
 
-agentRoutes.post('/tasks/:id/report', zValidator('json', taskReportSchema), async (c) => {
-  const { agentId } = c.get('agent');
-  const taskId = Number(c.req.param('id'));
+agentRoutes.post(
+  '/tasks/:id/report',
+  zValidator('json', taskReportSchema, agentValidationHook),
+  async (c) => {
+    const { agentId } = c.get('agent');
+    const taskId = Number(c.req.param('id'));
 
-  if (Number.isNaN(taskId) || taskId <= 0) {
-    return c.json({ error: { code: 'VALIDATION_ERROR', message: 'Invalid task ID' } }, 400);
-  }
+    if (Number.isNaN(taskId) || taskId <= 0) {
+      return c.json({ error: { code: 'VALIDATION_ERROR', message: 'Invalid task ID' } }, 400);
+    }
 
-  const data = c.req.valid('json');
+    const data = c.req.valid('json');
 
-  // Log any errors reported by the agent
-  if (data.errors && data.errors.length > 0) {
-    for (const errorMessage of data.errors) {
-      await logAgentError({
-        agentId,
-        severity: 'error',
-        message: errorMessage,
+    // Log any errors reported by the agent
+    if (data.errors && data.errors.length > 0) {
+      for (const errorMessage of data.errors) {
+        await logAgentError({
+          agentId,
+          severity: 'error',
+          message: errorMessage,
+          taskId,
+        });
+      }
+    }
+
+    // Handle failure with retry logic
+    if (data.status === 'failed') {
+      const failResult = await handleTaskFailure(
         taskId,
-      });
+        agentId,
+        data.errors?.[0] ?? 'Unknown failure'
+      );
+      if ('error' in failResult) {
+        return c.json({ error: { code: 'TASK_ERROR', message: failResult.error } }, 400);
+      }
+      return c.json({ acknowledged: true, retried: failResult.retried ?? false });
     }
-  }
 
-  // Handle failure with retry logic
-  if (data.status === 'failed') {
-    const failResult = await handleTaskFailure(
-      taskId,
-      agentId,
-      data.errors?.[0] ?? 'Unknown failure'
-    );
-    if ('error' in failResult) {
-      return c.json({ error: { code: 'TASK_ERROR', message: failResult.error } }, 400);
+    // Update task progress and insert cracked results
+    const result = await updateTaskProgress(taskId, agentId, data);
+
+    if ('error' in result) {
+      return c.json({ error: { code: 'TASK_ERROR', message: result.error } }, 400);
     }
-    return c.json({ acknowledged: true, retried: failResult.retried ?? false });
+
+    return c.json({ acknowledged: true });
   }
-
-  // Update task progress and insert cracked results
-  const result = await updateTaskProgress(taskId, agentId, data);
-
-  if ('error' in result) {
-    return c.json({ error: { code: 'TASK_ERROR', message: result.error } }, 400);
-  }
-
-  return c.json({ acknowledged: true });
-});
+);
 
 // ─── GET /tasks/:id/zaps — cracked hashes for a task ────────────────
 
@@ -150,23 +180,27 @@ const zapQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(10_000).default(10_000),
 });
 
-agentRoutes.get('/tasks/:id/zaps', zValidator('query', zapQuerySchema), async (c) => {
-  const { agentId, projectId } = c.get('agent');
-  const taskId = Number(c.req.param('id'));
+agentRoutes.get(
+  '/tasks/:id/zaps',
+  zValidator('query', zapQuerySchema, agentValidationHook),
+  async (c) => {
+    const { agentId, projectId } = c.get('agent');
+    const taskId = Number(c.req.param('id'));
 
-  if (Number.isNaN(taskId) || taskId <= 0) {
-    return c.json({ error: { code: 'VALIDATION_ERROR', message: 'Invalid task ID' } }, 400);
+    if (Number.isNaN(taskId) || taskId <= 0) {
+      return c.json({ error: { code: 'VALIDATION_ERROR', message: 'Invalid task ID' } }, 400);
+    }
+
+    const { since, limit } = c.req.valid('query');
+    const result = await getZapsForTask(taskId, agentId, projectId, { since, limit });
+
+    if ('error' in result) {
+      return c.json({ error: { code: 'TASK_NOT_FOUND', message: result.error } }, 404);
+    }
+
+    return c.json(result);
   }
-
-  const { since, limit } = c.req.valid('query');
-  const result = await getZapsForTask(taskId, agentId, projectId, { since, limit });
-
-  if ('error' in result) {
-    return c.json({ error: { code: 'TASK_NOT_FOUND', message: result.error } }, 404);
-  }
-
-  return c.json(result);
-});
+);
 
 // ─── POST /errors — log an agent error ──────────────────────────────
 
@@ -190,29 +224,40 @@ const agentErrorSchema = z.object({
   taskId: z.number().int().positive().optional(),
 });
 
-agentRoutes.post('/errors', zValidator('json', agentErrorSchema), async (c) => {
-  const { agentId } = c.get('agent');
-  const data = c.req.valid('json');
-  await logAgentError({ ...data, agentId });
-  return c.json({ acknowledged: true });
-});
+agentRoutes.post(
+  '/errors',
+  zValidator('json', agentErrorSchema, agentValidationHook),
+  async (c) => {
+    const { agentId } = c.get('agent');
+    const data = c.req.valid('json');
+    await logAgentError({ ...data, agentId });
+    return c.json({ acknowledged: true });
+  }
+);
 
 // ─── POST /benchmark — submit hashcat benchmark results ─────────────
 
-agentRoutes.post('/benchmark', zValidator('json', benchmarkSubmissionSchema), async (c) => {
-  const { agentId } = c.get('agent');
-  const data = c.req.valid('json');
-  try {
-    await submitBenchmarks(agentId, data.entries, data.crackerVersion);
-    return c.json({ acknowledged: true });
-  } catch (err: unknown) {
-    logger.error({ err, agentId, entryCount: data.entries.length }, 'Benchmark submission failed');
-    return c.json(
-      { error: { code: 'BENCHMARK_ERROR', message: 'Failed to store benchmark results' } },
-      500
-    );
+agentRoutes.post(
+  '/benchmark',
+  zValidator('json', benchmarkSubmissionSchema, agentValidationHook),
+  async (c) => {
+    const { agentId } = c.get('agent');
+    const data = c.req.valid('json');
+    try {
+      await submitBenchmarks(agentId, data.entries, data.crackerVersion);
+      return c.json({ acknowledged: true });
+    } catch (err: unknown) {
+      logger.error(
+        { err, agentId, entryCount: data.entries.length },
+        'Benchmark submission failed'
+      );
+      return c.json(
+        { error: { code: 'BENCHMARK_ERROR', message: 'Failed to store benchmark results' } },
+        500
+      );
+    }
   }
-});
+);
 
 // ─── GET /resources/:type/:id/download-url — presigned download ─────
 
@@ -253,7 +298,7 @@ agentRoutes.get('/resources/:type/:id/download-url', async (c) => {
  */
 agentRoutes.post(
   '/cracker/check-update',
-  zValidator('json', crackerCheckUpdateRequestSchema),
+  zValidator('json', crackerCheckUpdateRequestSchema, agentValidationHook),
   async (c) => {
     const data = c.req.valid('json');
     const engine = normalizeEngineName(data.engine);

--- a/packages/backend/src/routes/agent/index.ts
+++ b/packages/backend/src/routes/agent/index.ts
@@ -11,7 +11,7 @@ import { Hono } from 'hono';
 import type { ZodIssue } from 'zod';
 import { z } from 'zod';
 import { logger } from '../../config/logger.js';
-import { requireAgentToken } from '../../middleware/auth.js';
+import { requireAgentToken, requireAgentTokenAllowRecovery } from '../../middleware/auth.js';
 import { logAgentError, processHeartbeat, submitBenchmarks } from '../../services/agents.js';
 import {
   compareCrackerVersions,
@@ -53,7 +53,13 @@ const agentRoutes = new Hono<AppEnv>();
 
 // ─── Authenticated agent endpoints ──────────────────────────────────
 
-agentRoutes.use('/heartbeat', requireAgentToken);
+// /heartbeat uses the recovery-friendly variant so an agent whose row
+// is in status='error' (set by a prior fatal-error heartbeat) can post
+// a clean heartbeat to announce it's healthy again. processHeartbeat
+// will transition the agent back to 'online'. Every other agent
+// endpoint uses the strict variant — a broken agent must not pick up
+// new work until it has recovered via /heartbeat first.
+agentRoutes.use('/heartbeat', requireAgentTokenAllowRecovery);
 agentRoutes.use('/tasks/*', requireAgentToken);
 agentRoutes.use('/errors', requireAgentToken);
 agentRoutes.use('/benchmark', requireAgentToken);

--- a/packages/backend/src/routes/agent/index.ts
+++ b/packages/backend/src/routes/agent/index.ts
@@ -2,6 +2,8 @@ import {
   agentHeartbeatSchema,
   benchmarkSubmissionSchema,
   crackerCheckUpdateRequestSchema,
+  HEARTBEAT_ERROR_CONTEXT_MAX_CHARS,
+  HEARTBEAT_ERROR_MESSAGE_MAX,
 } from '@hashhive/shared';
 import { zValidator } from '@hono/zod-validator';
 import { Hono } from 'hono';
@@ -168,10 +170,23 @@ agentRoutes.get('/tasks/:id/zaps', zValidator('query', zapQuerySchema), async (c
 
 // ─── POST /errors — log an agent error ──────────────────────────────
 
+// Same size caps as agentHeartbeatErrorSchema (in @hashhive/shared) so the
+// standalone error channel can't be used to bypass the bound. severity stays
+// wider (warning|error|fatal) for back-compat with agents that have not
+// adopted the heartbeat-borne error block yet.
 const agentErrorSchema = z.object({
   severity: z.enum(['warning', 'error', 'fatal']),
-  message: z.string().min(1),
-  context: z.record(z.string(), z.unknown()).optional(),
+  message: z.string().min(1).max(HEARTBEAT_ERROR_MESSAGE_MAX),
+  context: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .refine(
+      (value) =>
+        value === undefined || JSON.stringify(value).length <= HEARTBEAT_ERROR_CONTEXT_MAX_CHARS,
+      {
+        message: `context exceeds ${HEARTBEAT_ERROR_CONTEXT_MAX_CHARS} characters when serialized`,
+      }
+    ),
   taskId: z.number().int().positive().optional(),
 });
 

--- a/packages/backend/src/routes/agent/index.ts
+++ b/packages/backend/src/routes/agent/index.ts
@@ -6,12 +6,10 @@ import {
   HEARTBEAT_ERROR_MESSAGE_MAX,
 } from '@hashhive/shared';
 import { zValidator } from '@hono/zod-validator';
-import type { Context } from 'hono';
 import { Hono } from 'hono';
-import type { ZodIssue } from 'zod';
 import { z } from 'zod';
 import { logger } from '../../config/logger.js';
-import { requireAgentToken, requireAgentTokenAllowRecovery } from '../../middleware/auth.js';
+import { requireAgentToken, requireAgentTokenForHeartbeatRecovery } from '../../middleware/auth.js';
 import { logAgentError, processHeartbeat, submitBenchmarks } from '../../services/agents.js';
 import {
   compareCrackerVersions,
@@ -37,15 +35,38 @@ import type { AppEnv } from '../../types.js';
  * `middleware/auth.ts` and AGENTS.md "API Surfaces"). Centralizing the
  * mapping here also gives contract tests a single stable assertion
  * target.
+ *
+ * The hook walks every zod issue, joining each into the response
+ * message so union-refinement failures (which surface in nested
+ * issues, not the top-level issue) are not silently dropped. The
+ * param shape mirrors `@hono/zod-validator` 0.7.6's `Hook<...>`
+ * signature (kept structural so the hook stays reusable across
+ * heterogeneous schemas without re-parameterizing each call site).
  */
+type ZodIssueLite = { path?: ReadonlyArray<PropertyKey>; message?: string };
+type ZodErrorLike = { issues?: ReadonlyArray<ZodIssueLite> };
+
+function formatValidationMessage(error: ZodErrorLike | undefined): string {
+  const issues = error?.issues;
+  if (!issues || issues.length === 0) return 'Invalid request body';
+  return issues
+    .map((issue) => {
+      const path = issue.path && issue.path.length > 0 ? issue.path.map(String).join('.') : 'body';
+      return issue.message ? `${path}: ${issue.message}` : path;
+    })
+    .join('; ');
+}
+
+import type { Context } from 'hono';
+
 function agentValidationHook(
-  result: { success: boolean; error?: { issues?: ZodIssue[] } },
+  result:
+    | { success: true; data: unknown; target: string }
+    | { success: false; error: ZodErrorLike; data: unknown; target: string },
   c: Context
-) {
-  if (result.success) return;
-  const first = result.error?.issues?.[0];
-  const path = first?.path?.length ? first.path.join('.') : 'body';
-  const message = first?.message ? `${path}: ${first.message}` : 'Invalid request body';
+): Response | undefined {
+  if (result.success) return undefined;
+  const message = formatValidationMessage(result.error);
   return c.json({ error: { code: 'VALIDATION_ERROR', message } }, 400);
 }
 
@@ -59,7 +80,7 @@ const agentRoutes = new Hono<AppEnv>();
 // will transition the agent back to 'online'. Every other agent
 // endpoint uses the strict variant — a broken agent must not pick up
 // new work until it has recovered via /heartbeat first.
-agentRoutes.use('/heartbeat', requireAgentTokenAllowRecovery);
+agentRoutes.use('/heartbeat', requireAgentTokenForHeartbeatRecovery);
 agentRoutes.use('/tasks/*', requireAgentToken);
 agentRoutes.use('/errors', requireAgentToken);
 agentRoutes.use('/benchmark', requireAgentToken);

--- a/packages/backend/src/services/agents.ts
+++ b/packages/backend/src/services/agents.ts
@@ -1,6 +1,7 @@
 import type {
   AgentCurrentTask,
   AgentHeartbeat,
+  AgentHeartbeatError,
   AgentWorstSeverity,
   SelectAgentBenchmark,
 } from '@hashhive/shared';
@@ -284,10 +285,8 @@ async function fetchCurrentTasks(
  */
 export type StatusTransitionReason = 'fatal_error' | 'heartbeat_status';
 
-// Mirrors the `agentHeartbeatSchema.status` enum so the service layer
-// cannot drift from the zod boundary. If the schema gains a new literal,
-// this union has to widen too — a typo at a call site is a compile error
-// instead of a runtime artifact.
+// Anchored to `AgentHeartbeat['status']` so the service layer cannot
+// drift from the zod boundary.
 type HeartbeatStatusLiteral = AgentHeartbeat['status'];
 type ResolvedStatusLiteral = HeartbeatStatusLiteral | 'error';
 
@@ -310,16 +309,17 @@ export interface HeartbeatTransition {
  */
 export function decideHeartbeatTransition(input: {
   payloadStatus: HeartbeatStatusLiteral;
-  errorSeverity?: 'warning' | 'fatal' | undefined;
+  errorSeverity?: AgentHeartbeatError['severity'] | undefined;
   priorStatus: string | null;
 }): HeartbeatTransition {
   const isFatalError = input.errorSeverity === 'fatal';
   const effectiveStatus: ResolvedStatusLiteral = isFatalError ? 'error' : input.payloadStatus;
 
   // Audit-log only real transitions. No-op heartbeats (status unchanged)
-  // happen every ~30s per agent — logging them would dominate volume.
-  // A null priorStatus (agent row missing) is treated as no-op since the
-  // update will fail anyway.
+  // happen on every agent heartbeat poll — logging them would dominate
+  // log volume. A null priorStatus (agent row missing) is treated as
+  // no-op since the caller's UPDATE will match zero rows; the
+  // missing-row case is surfaced by processHeartbeat instead.
   const shouldLogTransition = input.priorStatus !== null && input.priorStatus !== effectiveStatus;
 
   const reason: StatusTransitionReason | null = !shouldLogTransition
@@ -371,10 +371,8 @@ export async function processHeartbeat(agentId: number, data: AgentHeartbeat) {
   // Persist heartbeat-borne errors to agent_errors regardless of severity.
   // Warnings are recorded but do not change status or fail the running
   // task; fatals are recorded AND drive the status/task transitions
-  // below. Heartbeats and the standalone POST /errors endpoint are
-  // intentionally non-redundant channels — an agent posts via one or the
-  // other for a given event, never both, because the server has no
-  // idempotency key to dedupe across channels.
+  // below. The non-redundant-channel contract (heartbeat vs POST /errors)
+  // is documented on the Heartbeat schema in packages/openapi/agent-api.yaml.
   if (data.error) {
     await logAgentError({
       agentId,
@@ -406,21 +404,33 @@ export async function processHeartbeat(agentId: number, data: AgentHeartbeat) {
   if (updated) {
     emitAgentStatus(updated.projectId, updated.id, effectiveStatus);
 
-    if (transition.shouldLogTransition && transition.reason && priorStatus) {
+    // `priorStatus` is non-null whenever `shouldLogTransition` is true
+    // (see decideHeartbeatTransition); the assertion below keeps TS happy
+    // without re-checking at runtime.
+    if (transition.shouldLogTransition && transition.reason) {
       logStatusTransition({
         agentId: updated.id,
         projectId: updated.projectId,
-        fromStatus: priorStatus,
+        fromStatus: priorStatus as string,
         toStatus: effectiveStatus,
         reason: transition.reason,
       });
     }
+  } else {
+    // Auth middleware verified the agent's bearer token, so the row was
+    // present a moment ago. A vanishing row mid-heartbeat means it was
+    // deleted concurrently. Surface it so an operator can correlate
+    // bursts of "ghost heartbeat" warnings with cleanup actions.
+    logger.warn(
+      { agentId, status: effectiveStatus },
+      'Heartbeat for an agent row that no longer exists'
+    );
   }
 
   // On fatal error, fail the agent's current tasks. `handleTaskFailure`
-  // applies the up-to-3-retry policy defined in the ticket; rolling a
-  // parallel path here would diverge. Dynamic import preserves the
-  // existing tasks.ts <-> agents.ts circular-import workaround.
+  // owns the retry policy; rolling a parallel path here would diverge.
+  // Dynamic import preserves the existing tasks.ts <-> agents.ts
+  // circular-import workaround.
   if (isFatalError) {
     const activeTasks = await db
       .select({ id: tasks.id })
@@ -517,7 +527,24 @@ export async function logAgentError(data: {
     }
     if (projectId !== undefined) {
       emitAgentError(projectId, data.agentId, data.severity);
+    } else {
+      // The row was persisted but we can't route the SSE event without a
+      // projectId — should only happen if the agent row was deleted
+      // between the insert and the lookup. Log so operators can correlate
+      // missing dashboard events with cleanup activity.
+      logger.warn(
+        { agentId: data.agentId, severity: data.severity },
+        'Agent error persisted but project lookup failed; SSE event skipped'
+      );
     }
+  } else {
+    // An INSERT that returns no row means RETURNING was suppressed —
+    // RLS, a trigger, or a future schema change. The insert may or may
+    // not have succeeded; surface it so a regression isn't silent.
+    logger.error(
+      { agentId: data.agentId, severity: data.severity },
+      'agent_errors insert returned no row; downstream event skipped'
+    );
   }
 
   return error ?? null;

--- a/packages/backend/src/services/agents.ts
+++ b/packages/backend/src/services/agents.ts
@@ -284,8 +284,15 @@ async function fetchCurrentTasks(
  */
 export type StatusTransitionReason = 'fatal_error' | 'heartbeat_status';
 
+// Mirrors the `agentHeartbeatSchema.status` enum so the service layer
+// cannot drift from the zod boundary. If the schema gains a new literal,
+// this union has to widen too — a typo at a call site is a compile error
+// instead of a runtime artifact.
+type HeartbeatStatusLiteral = AgentHeartbeat['status'];
+type ResolvedStatusLiteral = HeartbeatStatusLiteral | 'error';
+
 export interface HeartbeatTransition {
-  effectiveStatus: string;
+  effectiveStatus: ResolvedStatusLiteral;
   isFatalError: boolean;
   shouldLogTransition: boolean;
   reason: StatusTransitionReason | null;
@@ -302,12 +309,12 @@ export interface HeartbeatTransition {
  * `processHeartbeat` is just the wiring around this decision.
  */
 export function decideHeartbeatTransition(input: {
-  payloadStatus: string;
+  payloadStatus: HeartbeatStatusLiteral;
   errorSeverity?: 'warning' | 'fatal' | undefined;
   priorStatus: string | null;
 }): HeartbeatTransition {
   const isFatalError = input.errorSeverity === 'fatal';
-  const effectiveStatus = isFatalError ? 'error' : input.payloadStatus;
+  const effectiveStatus: ResolvedStatusLiteral = isFatalError ? 'error' : input.payloadStatus;
 
   // Audit-log only real transitions. No-op heartbeats (status unchanged)
   // happen every ~30s per agent — logging them would dominate volume.
@@ -375,6 +382,9 @@ export async function processHeartbeat(agentId: number, data: AgentHeartbeat) {
       message: data.error.message,
       context: data.error.context,
       taskId: data.currentTask?.taskId,
+      // Skip the redundant SELECT inside logAgentError — we already
+      // have projectId from priorRow.
+      projectId: priorRow?.projectId,
     });
   }
 
@@ -471,6 +481,12 @@ export async function logAgentError(data: {
   message: string;
   context?: Record<string, unknown> | undefined;
   taskId?: number | undefined;
+  // Optional projectId pass-through: hot-path callers (processHeartbeat)
+  // already know it and pass it in to avoid an extra SELECT on every
+  // error-bearing heartbeat. Callers that don't have it (e.g., the
+  // standalone POST /api/v1/agent/errors handler, which only has agentId)
+  // can omit it and the function falls back to a DB lookup.
+  projectId?: number | undefined;
 }) {
   const [error] = await db
     .insert(agentErrors)
@@ -490,13 +506,17 @@ export async function logAgentError(data: {
   // projectId)`, so reusing `agent_status` would silently drop a new
   // error event if a heartbeat just fired for the same project.
   if (error) {
-    const [agent] = await db
-      .select({ projectId: agents.projectId })
-      .from(agents)
-      .where(eq(agents.id, data.agentId))
-      .limit(1);
-    if (agent) {
-      emitAgentError(agent.projectId, data.agentId, data.severity);
+    let projectId = data.projectId;
+    if (projectId === undefined) {
+      const [agent] = await db
+        .select({ projectId: agents.projectId })
+        .from(agents)
+        .where(eq(agents.id, data.agentId))
+        .limit(1);
+      projectId = agent?.projectId;
+    }
+    if (projectId !== undefined) {
+      emitAgentError(projectId, data.agentId, data.severity);
     }
   }
 

--- a/packages/backend/src/services/agents.ts
+++ b/packages/backend/src/services/agents.ts
@@ -342,6 +342,24 @@ export function decideHeartbeatTransition(input: {
   };
 }
 
+/**
+ * Lazy reference to `handleTaskFailure` from `./tasks.js`. The static
+ * import path is blocked by the circular dependency between
+ * `services/agents.ts` and `services/tasks.ts` (tasks imports
+ * `getAgentBenchmarkForMode` from this module). We resolve the module
+ * once on first use and cache the function reference so every
+ * subsequent fatal heartbeat skips the import-resolution roundtrip.
+ */
+let cachedHandleTaskFailure: typeof import('./tasks.js').handleTaskFailure | null = null;
+
+async function getHandleTaskFailure(): Promise<typeof import('./tasks.js').handleTaskFailure> {
+  if (cachedHandleTaskFailure === null) {
+    const mod = await import('./tasks.js');
+    cachedHandleTaskFailure = mod.handleTaskFailure;
+  }
+  return cachedHandleTaskFailure;
+}
+
 function logStatusTransition(opts: {
   agentId: number;
   projectId: number;
@@ -362,17 +380,72 @@ function logStatusTransition(opts: {
 }
 
 /**
- * Keys whose values should never reach `agent_errors.context`. An agent
- * may inadvertently serialize `process.env`, HTTP headers, or
- * exception-augmented `cause` chains that carry tokens/passwords;
- * scrub them server-side so operators with dashboard access cannot
- * read secrets that should have stayed on the agent host. The match
- * is case-insensitive and substring-based so `API_KEY`, `apiKey`,
- * `x-auth-token`, and `customer_secret` all redact.
+ * Whole-word secret-name set used by `isSecretKey`. Keys that normalize
+ * to one of these names — or that end in `_<secret>` after
+ * normalization — are redacted before persistence. The list covers the
+ * obvious credential-bearing field names and a few common compounds
+ * (e.g., `access_token`, `set_cookie`); add new entries when an agent
+ * is observed to spill a different field shape, but keep the matching
+ * boundary-aware so descriptive names like `tokenCount` or
+ * `cookieDomain` are not falsely redacted.
  */
-const SECRET_KEY_PATTERN = /token|password|secret|api[_-]?key|authorization|cookie|bearer/i;
+const SECRET_KEY_NAMES = new Set([
+  'token',
+  'tokens',
+  'password',
+  'passwords',
+  'passwd',
+  'pwd',
+  'secret',
+  'secrets',
+  'api_key',
+  'api_keys',
+  'apikey',
+  'apikeys',
+  'authorization',
+  'auth',
+  'cookie',
+  'cookies',
+  'set_cookie',
+  'bearer',
+  'credential',
+  'credentials',
+  'access_token',
+  'refresh_token',
+  'id_token',
+  'session_token',
+  'x_auth_token',
+  'x_api_key',
+  'x_access_token',
+]);
 const SCRUBBED_VALUE = '[REDACTED]';
 const SCRUB_MAX_DEPTH = 6;
+
+/**
+ * Decide whether a key carries a secret value and must be redacted.
+ * Normalizes `apiKey` / `API_KEY` / `api-key` / `api_key` to a single
+ * snake_case form, then checks whole-word membership in the set above
+ * or `<...>_<secret>` suffix. The earlier substring-based regex was
+ * too aggressive — descriptive names like `tokenCount`, `cookieDomain`,
+ * and `bearerHostname` were being redacted along with the values
+ * operators actually need for debugging.
+ *
+ * Exported for direct unit testing alongside `scrubAgentErrorContext`.
+ */
+export function isSecretKey(key: string): boolean {
+  const normalized = key
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .toLowerCase()
+    .replace(/[-\s]+/g, '_');
+  if (SECRET_KEY_NAMES.has(normalized)) return true;
+  // Trailing-secret suffix: `db_password`, `customer_secret`,
+  // `x_auth_token` etc. Match only when the last underscore-separated
+  // word is a known secret name; this keeps `password_age` (a duration
+  // counter, not the password itself) out of scope.
+  const parts = normalized.split('_');
+  const last = parts[parts.length - 1];
+  return !!last && SECRET_KEY_NAMES.has(last);
+}
 
 /**
  * Walk an arbitrary jsonb-compatible value, redacting any object key
@@ -393,7 +466,7 @@ export function scrubAgentErrorContext(value: unknown, depth = 0): unknown {
   }
   const out: Record<string, unknown> = {};
   for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
-    if (SECRET_KEY_PATTERN.test(key)) {
+    if (isSecretKey(key)) {
       out[key] = SCRUBBED_VALUE;
     } else {
       out[key] = scrubAgentErrorContext(raw, depth + 1);
@@ -409,16 +482,24 @@ export function scrubAgentErrorContext(value: unknown, depth = 0): unknown {
  * error without the task linkage instead of attributing it to another
  * agent's task. Emits a `logger.warn` on mismatch so operators can
  * detect compromised tokens trying to corrupt audit trails.
+ *
+ * Accepts a drizzle client so the verification can run inside the same
+ * transaction as the agent_errors insert; the `for: 'update'` lock on
+ * the task row closes the window where a concurrent reassignment
+ * between verify and insert could let an error row reference a task
+ * the agent no longer owns.
  */
 async function verifyTaskOwnership(
+  dbClient: DbClient,
   agentId: number,
   taskId: number | undefined
 ): Promise<number | undefined> {
   if (taskId === undefined) return undefined;
-  const [row] = await db
+  const [row] = await dbClient
     .select({ id: tasks.id })
     .from(tasks)
     .where(and(eq(tasks.id, taskId), eq(tasks.agentId, agentId)))
+    .for('update')
     .limit(1);
   if (row) return row.id;
   logger.warn(
@@ -429,18 +510,15 @@ async function verifyTaskOwnership(
 }
 
 export async function processHeartbeat(agentId: number, data: AgentHeartbeat) {
-  // Verify the agent owns currentTask.taskId before the transaction
-  // opens. Done outside the tx so the read-only check can use the main
-  // pool and not extend lock duration on the agents row below.
-  const ownedTaskId = await verifyTaskOwnership(agentId, data.currentTask?.taskId);
-
-  // Atomic block: lock the agent row, capture the prior status, persist
-  // the heartbeat-borne error row, and update the agent's status in a
-  // single transaction. The FOR UPDATE lock closes the TOCTOU race
-  // where two concurrent heartbeats would both observe the same prior
-  // status (per GOTCHAS.md "atomic status guards"). Emits and the
-  // fatal-task-failure loop are deferred until after commit so SSE
-  // clients never see a status that was rolled back.
+  // Atomic block: lock the agent row, capture the prior status, verify
+  // `currentTask.taskId` ownership (with a row lock so a concurrent
+  // reassignment cannot land between the verify and the insert),
+  // persist the heartbeat-borne error row, and update the agent's
+  // status in a single transaction. The FOR UPDATE locks close the
+  // TOCTOU race where two concurrent heartbeats would both observe
+  // the same prior status (per GOTCHAS.md "atomic status guards").
+  // Emits and the fatal-task-failure loop are deferred until after
+  // commit so SSE clients never see a status that was rolled back.
   const txResult = await db.transaction(async (tx) => {
     const [priorRow] = await tx
       .select({ status: agents.status, projectId: agents.projectId })
@@ -456,6 +534,8 @@ export async function processHeartbeat(agentId: number, data: AgentHeartbeat) {
       errorSeverity: data.error?.severity,
       priorStatus,
     });
+
+    const ownedTaskId = await verifyTaskOwnership(tx, agentId, data.currentTask?.taskId);
 
     if (data.error) {
       await logAgentError(
@@ -539,7 +619,7 @@ export async function processHeartbeat(agentId: number, data: AgentHeartbeat) {
       .from(tasks)
       .where(and(eq(tasks.agentId, agentId), sql`${tasks.status} IN ('assigned', 'running')`));
 
-    const { handleTaskFailure } = await import('./tasks.js');
+    const handleTaskFailure = await getHandleTaskFailure();
     let failed = 0;
     for (const activeTask of activeTasks) {
       try {
@@ -558,7 +638,6 @@ export async function processHeartbeat(agentId: number, data: AgentHeartbeat) {
   // Check if there are high-priority pending tasks for this agent's project
   let hasHighPriorityTasks = false;
   if (updated) {
-    const { campaigns } = await import('@hashhive/shared');
     const [highPriority] = await db
       .select({ id: tasks.id })
       .from(tasks)

--- a/packages/backend/src/services/agents.ts
+++ b/packages/backend/src/services/agents.ts
@@ -290,12 +290,21 @@ export type StatusTransitionReason = 'fatal_error' | 'heartbeat_status';
 type HeartbeatStatusLiteral = AgentHeartbeat['status'];
 type ResolvedStatusLiteral = HeartbeatStatusLiteral | 'error';
 
-export interface HeartbeatTransition {
-  effectiveStatus: ResolvedStatusLiteral;
-  isFatalError: boolean;
-  shouldLogTransition: boolean;
-  reason: StatusTransitionReason | null;
-}
+/**
+ * Discriminated union: a heartbeat either resolves to a no-op transition
+ * (status unchanged) or a real transition that needs an audit-log line.
+ * Using a `kind` discriminant forces call sites to handle both arms and
+ * makes `fromStatus` / `reason` available only when they're meaningful.
+ */
+export type HeartbeatTransition =
+  | { kind: 'noop'; effectiveStatus: ResolvedStatusLiteral; isFatalError: boolean }
+  | {
+      kind: 'transition';
+      effectiveStatus: ResolvedStatusLiteral;
+      isFatalError: boolean;
+      reason: StatusTransitionReason;
+      fromStatus: string;
+    };
 
 /**
  * Pure decision: given the payload status, optional error severity, and
@@ -320,15 +329,17 @@ export function decideHeartbeatTransition(input: {
   // log volume. A null priorStatus (agent row missing) is treated as
   // no-op since the caller's UPDATE will match zero rows; the
   // missing-row case is surfaced by processHeartbeat instead.
-  const shouldLogTransition = input.priorStatus !== null && input.priorStatus !== effectiveStatus;
+  if (input.priorStatus === null || input.priorStatus === effectiveStatus) {
+    return { kind: 'noop', effectiveStatus, isFatalError };
+  }
 
-  const reason: StatusTransitionReason | null = !shouldLogTransition
-    ? null
-    : isFatalError
-      ? 'fatal_error'
-      : 'heartbeat_status';
-
-  return { effectiveStatus, isFatalError, shouldLogTransition, reason };
+  return {
+    kind: 'transition',
+    effectiveStatus,
+    isFatalError,
+    reason: isFatalError ? 'fatal_error' : 'heartbeat_status',
+    fromStatus: input.priorStatus,
+  };
 }
 
 function logStatusTransition(opts: {
@@ -350,97 +361,198 @@ function logStatusTransition(opts: {
   );
 }
 
-export async function processHeartbeat(agentId: number, data: AgentHeartbeat) {
-  // Read the prior status before we mutate the row so the audit log can
-  // record the actual transition (the UPDATE ... RETURNING below only
-  // exposes the post-update state).
-  const [priorRow] = await db
-    .select({ status: agents.status, projectId: agents.projectId })
-    .from(agents)
-    .where(eq(agents.id, agentId))
+/**
+ * Keys whose values should never reach `agent_errors.context`. An agent
+ * may inadvertently serialize `process.env`, HTTP headers, or
+ * exception-augmented `cause` chains that carry tokens/passwords;
+ * scrub them server-side so operators with dashboard access cannot
+ * read secrets that should have stayed on the agent host. The match
+ * is case-insensitive and substring-based so `API_KEY`, `apiKey`,
+ * `x-auth-token`, and `customer_secret` all redact.
+ */
+const SECRET_KEY_PATTERN = /token|password|secret|api[_-]?key|authorization|cookie|bearer/i;
+const SCRUBBED_VALUE = '[REDACTED]';
+const SCRUB_MAX_DEPTH = 6;
+
+/**
+ * Walk an arbitrary jsonb-compatible value, redacting any object key
+ * whose name matches the secret pattern. Returns a deep copy so the
+ * caller's object is not mutated. Depth-capped to defend against
+ * pathological agent payloads (the schema already caps overall
+ * serialized size, but a deeply-nested cycle would still be expensive
+ * to walk).
+ *
+ * Exported so unit tests can pin the policy without staging a real
+ * agent_errors row.
+ */
+export function scrubAgentErrorContext(value: unknown, depth = 0): unknown {
+  if (depth > SCRUB_MAX_DEPTH) return SCRUBBED_VALUE;
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) {
+    return value.map((item) => scrubAgentErrorContext(item, depth + 1));
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
+    if (SECRET_KEY_PATTERN.test(key)) {
+      out[key] = SCRUBBED_VALUE;
+    } else {
+      out[key] = scrubAgentErrorContext(raw, depth + 1);
+    }
+  }
+  return out;
+}
+
+/**
+ * Verify that a heartbeat-supplied `currentTask.taskId` belongs to the
+ * calling agent. Returns the taskId when ownership checks out,
+ * `undefined` when it doesn't — `processHeartbeat` then persists the
+ * error without the task linkage instead of attributing it to another
+ * agent's task. Emits a `logger.warn` on mismatch so operators can
+ * detect compromised tokens trying to corrupt audit trails.
+ */
+async function verifyTaskOwnership(
+  agentId: number,
+  taskId: number | undefined
+): Promise<number | undefined> {
+  if (taskId === undefined) return undefined;
+  const [row] = await db
+    .select({ id: tasks.id })
+    .from(tasks)
+    .where(and(eq(tasks.id, taskId), eq(tasks.agentId, agentId)))
     .limit(1);
-  const priorStatus = priorRow?.status ?? null;
+  if (row) return row.id;
+  logger.warn(
+    { agentId, taskId },
+    'Heartbeat referenced currentTask.taskId not owned by this agent; dropping task linkage'
+  );
+  return undefined;
+}
 
-  const transition = decideHeartbeatTransition({
-    payloadStatus: data.status,
-    errorSeverity: data.error?.severity,
-    priorStatus,
-  });
-  const { effectiveStatus, isFatalError } = transition;
+export async function processHeartbeat(agentId: number, data: AgentHeartbeat) {
+  // Verify the agent owns currentTask.taskId before the transaction
+  // opens. Done outside the tx so the read-only check can use the main
+  // pool and not extend lock duration on the agents row below.
+  const ownedTaskId = await verifyTaskOwnership(agentId, data.currentTask?.taskId);
 
-  // Persist heartbeat-borne errors to agent_errors regardless of severity.
-  // Warnings are recorded but do not change status or fail the running
-  // task; fatals are recorded AND drive the status/task transitions
-  // below. The non-redundant-channel contract (heartbeat vs POST /errors)
-  // is documented on the Heartbeat schema in packages/openapi/agent-api.yaml.
-  if (data.error) {
-    await logAgentError({
-      agentId,
-      severity: data.error.severity,
-      message: data.error.message,
-      context: data.error.context,
-      taskId: data.currentTask?.taskId,
-      // Skip the redundant SELECT inside logAgentError — we already
-      // have projectId from priorRow.
-      projectId: priorRow?.projectId,
+  // Atomic block: lock the agent row, capture the prior status, persist
+  // the heartbeat-borne error row, and update the agent's status in a
+  // single transaction. The FOR UPDATE lock closes the TOCTOU race
+  // where two concurrent heartbeats would both observe the same prior
+  // status (per GOTCHAS.md "atomic status guards"). Emits and the
+  // fatal-task-failure loop are deferred until after commit so SSE
+  // clients never see a status that was rolled back.
+  const txResult = await db.transaction(async (tx) => {
+    const [priorRow] = await tx
+      .select({ status: agents.status, projectId: agents.projectId })
+      .from(agents)
+      .where(eq(agents.id, agentId))
+      .for('update')
+      .limit(1);
+
+    const priorStatus = priorRow?.status ?? null;
+
+    const transition = decideHeartbeatTransition({
+      payloadStatus: data.status,
+      errorSeverity: data.error?.severity,
+      priorStatus,
     });
-  }
 
-  const updates: Record<string, unknown> = {
-    status: effectiveStatus,
-    lastSeenAt: new Date(),
-    updatedAt: new Date(),
-  };
+    if (data.error) {
+      await logAgentError(
+        {
+          agentId,
+          severity: data.error.severity,
+          message: data.error.message,
+          context: scrubAgentErrorContext(data.error.context) as
+            | Record<string, unknown>
+            | undefined,
+          taskId: ownedTaskId,
+          // Skip the redundant SELECT inside logAgentError — priorRow
+          // already has projectId.
+          projectId: priorRow?.projectId,
+          // emitAgentError defers until after commit; suppress here.
+          suppressEvent: true,
+        },
+        tx
+      );
+    }
 
-  if (data.capabilities) {
-    updates['capabilities'] = data.capabilities;
-  }
-  if (data.deviceInfo) {
-    updates['hardwareProfile'] = data.deviceInfo;
-  }
+    const updates: Record<string, unknown> = {
+      status: transition.effectiveStatus,
+      lastSeenAt: new Date(),
+      updatedAt: new Date(),
+    };
+    if (data.capabilities) updates['capabilities'] = data.capabilities;
+    if (data.deviceInfo) updates['hardwareProfile'] = data.deviceInfo;
 
-  const [updated] = await db.update(agents).set(updates).where(eq(agents.id, agentId)).returning();
+    const [updated] = await tx
+      .update(agents)
+      .set(updates)
+      .where(eq(agents.id, agentId))
+      .returning();
 
+    return { updated, transition, priorStatus };
+  });
+
+  const { updated, transition } = txResult;
+
+  // Post-commit emits + audit log. If the transaction rolled back,
+  // none of these fire and SSE listeners stay consistent.
   if (updated) {
-    emitAgentStatus(updated.projectId, updated.id, effectiveStatus);
+    if (data.error) {
+      emitAgentError(updated.projectId, updated.id, data.error.severity);
+    }
+    emitAgentStatus(updated.projectId, updated.id, transition.effectiveStatus);
 
-    // `priorStatus` is non-null whenever `shouldLogTransition` is true
-    // (see decideHeartbeatTransition); the assertion below keeps TS happy
-    // without re-checking at runtime.
-    if (transition.shouldLogTransition && transition.reason) {
+    if (transition.kind === 'transition') {
       logStatusTransition({
         agentId: updated.id,
         projectId: updated.projectId,
-        fromStatus: priorStatus as string,
-        toStatus: effectiveStatus,
+        fromStatus: transition.fromStatus,
+        toStatus: transition.effectiveStatus,
         reason: transition.reason,
       });
     }
   } else {
     // Auth middleware verified the agent's bearer token, so the row was
     // present a moment ago. A vanishing row mid-heartbeat means it was
-    // deleted concurrently. Surface it so an operator can correlate
+    // deleted concurrently — surface it so an operator can correlate
     // bursts of "ghost heartbeat" warnings with cleanup actions.
     logger.warn(
-      { agentId, status: effectiveStatus },
+      { agentId, status: transition.effectiveStatus },
       'Heartbeat for an agent row that no longer exists'
     );
   }
 
-  // On fatal error, fail the agent's current tasks. `handleTaskFailure`
-  // owns the retry policy; rolling a parallel path here would diverge.
-  // Dynamic import preserves the existing tasks.ts <-> agents.ts
-  // circular-import workaround.
-  if (isFatalError) {
+  // Fail the agent's active tasks on fatal-error heartbeats. Each task
+  // runs in its own try/catch so a single failure does not strand
+  // sibling tasks; partial failures are logged and surfaced in the
+  // return shape so callers / monitoring can detect them. Runs AFTER
+  // the agent-row tx commits because handleTaskFailure does its own
+  // DB work (including transactional retries) and nesting drizzle
+  // transactions inside the same connection produces savepoint churn
+  // we don't need here.
+  let taskFailureSummary: { attempted: number; failed: number } | undefined;
+  if (transition.isFatalError) {
     const activeTasks = await db
       .select({ id: tasks.id })
       .from(tasks)
       .where(and(eq(tasks.agentId, agentId), sql`${tasks.status} IN ('assigned', 'running')`));
 
     const { handleTaskFailure } = await import('./tasks.js');
+    let failed = 0;
     for (const activeTask of activeTasks) {
-      await handleTaskFailure(activeTask.id, agentId, data.error?.message ?? 'Agent fatal error');
+      try {
+        await handleTaskFailure(activeTask.id, agentId, data.error?.message ?? 'Agent fatal error');
+      } catch (err) {
+        failed += 1;
+        logger.error(
+          { err, agentId, taskId: activeTask.id },
+          'handleTaskFailure threw during fatal-heartbeat fan-out; sibling tasks continue'
+        );
+      }
     }
+    taskFailureSummary = { attempted: activeTasks.length, failed };
   }
 
   // Check if there are high-priority pending tasks for this agent's project
@@ -462,7 +574,11 @@ export async function processHeartbeat(agentId: number, data: AgentHeartbeat) {
     hasHighPriorityTasks = !!highPriority;
   }
 
-  return { agent: updated ?? null, hasHighPriorityTasks };
+  return {
+    agent: updated ?? null,
+    hasHighPriorityTasks,
+    ...(taskFailureSummary ? { taskFailureSummary } : {}),
+  };
 }
 
 export async function updateAgent(
@@ -485,20 +601,39 @@ export async function updateAgent(
   return updated ?? null;
 }
 
-export async function logAgentError(data: {
-  agentId: number;
-  severity: string;
-  message: string;
-  context?: Record<string, unknown> | undefined;
-  taskId?: number | undefined;
-  // Optional projectId pass-through: hot-path callers (processHeartbeat)
-  // already know it and pass it in to avoid an extra SELECT on every
-  // error-bearing heartbeat. Callers that don't have it (e.g., the
-  // standalone POST /api/v1/agent/errors handler, which only has agentId)
-  // can omit it and the function falls back to a DB lookup.
-  projectId?: number | undefined;
-}) {
-  const [error] = await db
+/**
+ * Narrow drizzle client surface shared by both the global `db` and the
+ * `tx` argument of `db.transaction((tx) => ...)`. The full
+ * `PostgresJsDatabase` type carries a `$client` property that the
+ * transactional client doesn't, so we project to the query-builder
+ * operations both clients actually share. Lets `logAgentError`
+ * participate in an outer transaction (`processHeartbeat`) without
+ * widening to `any`.
+ */
+type DbClient = Pick<typeof db, 'insert' | 'select' | 'update' | 'delete'>;
+
+export async function logAgentError(
+  data: {
+    agentId: number;
+    severity: string;
+    message: string;
+    context?: Record<string, unknown> | undefined;
+    taskId?: number | undefined;
+    // Optional projectId pass-through: hot-path callers (processHeartbeat)
+    // already know it and pass it in to avoid an extra SELECT on every
+    // error-bearing heartbeat. Callers that don't have it (e.g., the
+    // standalone POST /api/v1/agent/errors handler, which only has agentId)
+    // can omit it and the function falls back to a DB lookup.
+    projectId?: number | undefined;
+    // When true, the SSE `emitAgentError` is skipped. processHeartbeat
+    // sets this so the event fires AFTER the outer transaction commits,
+    // preventing listeners from reacting to a state the DB later rolls
+    // back. Standalone callers (POST /errors) leave it false.
+    suppressEvent?: boolean | undefined;
+  },
+  dbClient: DbClient = db
+) {
+  const [error] = await dbClient
     .insert(agentErrors)
     .values({
       agentId: data.agentId,
@@ -516,9 +651,10 @@ export async function logAgentError(data: {
   // projectId)`, so reusing `agent_status` would silently drop a new
   // error event if a heartbeat just fired for the same project.
   if (error) {
+    if (data.suppressEvent) return error;
     let projectId = data.projectId;
     if (projectId === undefined) {
-      const [agent] = await db
+      const [agent] = await dbClient
         .select({ projectId: agents.projectId })
         .from(agents)
         .where(eq(agents.id, data.agentId))

--- a/packages/backend/src/services/agents.ts
+++ b/packages/backend/src/services/agents.ts
@@ -1,6 +1,12 @@
-import type { AgentCurrentTask, AgentWorstSeverity, SelectAgentBenchmark } from '@hashhive/shared';
+import type {
+  AgentCurrentTask,
+  AgentHeartbeat,
+  AgentWorstSeverity,
+  SelectAgentBenchmark,
+} from '@hashhive/shared';
 import { agentBenchmarks, agentErrors, agents, attacks, campaigns, tasks } from '@hashhive/shared';
 import { and, desc, eq, inArray, sql } from 'drizzle-orm';
+import { logger } from '../config/logger.js';
 import { db } from '../db/index.js';
 import { emitAgentError, emitAgentStatus } from './events.js';
 
@@ -265,20 +271,111 @@ async function fetchCurrentTasks(
   return map;
 }
 
-export async function processHeartbeat(
-  agentId: number,
-  data: {
-    status: string;
-    capabilities?: Record<string, unknown> | undefined;
-    deviceInfo?: Record<string, unknown> | undefined;
-    error?: { severity?: string; message?: string } | undefined;
-  }
-) {
-  // Determine effective status from heartbeat payload
-  let effectiveStatus = data.status;
-  const isFatalError = data.error?.severity === 'fatal';
-  if (isFatalError) {
-    effectiveStatus = 'error';
+/**
+ * Reason carried on the structured status-transition log line. Kept as a
+ * narrow literal union so a typo at a call site is a type error, and so
+ * downstream log queries have a stable enum to filter on.
+ *
+ * - `'fatal_error'`: heartbeat reported `error.severity='fatal'`; status
+ *   forced to `'error'`.
+ * - `'heartbeat_status'`: heartbeat carried a non-fatal status literal
+ *   different from the agent's current row (e.g., `'offline' -> 'online'`
+ *   when the agent comes back from the heartbeat-monitor sweep).
+ */
+export type StatusTransitionReason = 'fatal_error' | 'heartbeat_status';
+
+export interface HeartbeatTransition {
+  effectiveStatus: string;
+  isFatalError: boolean;
+  shouldLogTransition: boolean;
+  reason: StatusTransitionReason | null;
+}
+
+/**
+ * Pure decision: given the payload status, optional error severity, and
+ * the agent's current persisted status, decide the effective status the
+ * row will be updated to, whether the heartbeat is a fatal-error path,
+ * and whether a status-transition audit log line should fire.
+ *
+ * Exported so the policy can be pinned by unit tests without a database
+ * (mirrors the `classifyWorstSeverity` pattern). The DB-bound caller in
+ * `processHeartbeat` is just the wiring around this decision.
+ */
+export function decideHeartbeatTransition(input: {
+  payloadStatus: string;
+  errorSeverity?: 'warning' | 'fatal' | undefined;
+  priorStatus: string | null;
+}): HeartbeatTransition {
+  const isFatalError = input.errorSeverity === 'fatal';
+  const effectiveStatus = isFatalError ? 'error' : input.payloadStatus;
+
+  // Audit-log only real transitions. No-op heartbeats (status unchanged)
+  // happen every ~30s per agent — logging them would dominate volume.
+  // A null priorStatus (agent row missing) is treated as no-op since the
+  // update will fail anyway.
+  const shouldLogTransition = input.priorStatus !== null && input.priorStatus !== effectiveStatus;
+
+  const reason: StatusTransitionReason | null = !shouldLogTransition
+    ? null
+    : isFatalError
+      ? 'fatal_error'
+      : 'heartbeat_status';
+
+  return { effectiveStatus, isFatalError, shouldLogTransition, reason };
+}
+
+function logStatusTransition(opts: {
+  agentId: number;
+  projectId: number;
+  fromStatus: string;
+  toStatus: string;
+  reason: StatusTransitionReason;
+}): void {
+  logger.info(
+    {
+      agentId: opts.agentId,
+      projectId: opts.projectId,
+      fromStatus: opts.fromStatus,
+      toStatus: opts.toStatus,
+      reason: opts.reason,
+    },
+    'Agent status transition'
+  );
+}
+
+export async function processHeartbeat(agentId: number, data: AgentHeartbeat) {
+  // Read the prior status before we mutate the row so the audit log can
+  // record the actual transition (the UPDATE ... RETURNING below only
+  // exposes the post-update state).
+  const [priorRow] = await db
+    .select({ status: agents.status, projectId: agents.projectId })
+    .from(agents)
+    .where(eq(agents.id, agentId))
+    .limit(1);
+  const priorStatus = priorRow?.status ?? null;
+
+  const transition = decideHeartbeatTransition({
+    payloadStatus: data.status,
+    errorSeverity: data.error?.severity,
+    priorStatus,
+  });
+  const { effectiveStatus, isFatalError } = transition;
+
+  // Persist heartbeat-borne errors to agent_errors regardless of severity.
+  // Warnings are recorded but do not change status or fail the running
+  // task; fatals are recorded AND drive the status/task transitions
+  // below. Heartbeats and the standalone POST /errors endpoint are
+  // intentionally non-redundant channels — an agent posts via one or the
+  // other for a given event, never both, because the server has no
+  // idempotency key to dedupe across channels.
+  if (data.error) {
+    await logAgentError({
+      agentId,
+      severity: data.error.severity,
+      message: data.error.message,
+      context: data.error.context,
+      taskId: data.currentTask?.taskId,
+    });
   }
 
   const updates: Record<string, unknown> = {
@@ -298,9 +395,22 @@ export async function processHeartbeat(
 
   if (updated) {
     emitAgentStatus(updated.projectId, updated.id, effectiveStatus);
+
+    if (transition.shouldLogTransition && transition.reason && priorStatus) {
+      logStatusTransition({
+        agentId: updated.id,
+        projectId: updated.projectId,
+        fromStatus: priorStatus,
+        toStatus: effectiveStatus,
+        reason: transition.reason,
+      });
+    }
   }
 
-  // On fatal error, fail the agent's current tasks
+  // On fatal error, fail the agent's current tasks. `handleTaskFailure`
+  // applies the up-to-3-retry policy defined in the ticket; rolling a
+  // parallel path here would diverge. Dynamic import preserves the
+  // existing tasks.ts <-> agents.ts circular-import workaround.
   if (isFatalError) {
     const activeTasks = await db
       .select({ id: tasks.id })

--- a/packages/backend/tests/integration/agent-heartbeat.test.ts
+++ b/packages/backend/tests/integration/agent-heartbeat.test.ts
@@ -1,0 +1,529 @@
+/**
+ * Integration tests for the agent heartbeat path (residual #2 from the
+ * code review).
+ *
+ * These tests exercise `processHeartbeat` end-to-end through the route
+ * handler against a mocked drizzle client. The mocking is heavier than
+ * the typical unit test because the heartbeat path now spans a
+ * transaction, fans out to `handleTaskFailure`, and emits SSE events
+ * post-commit. We mock at the drizzle-chain level so the assertions
+ * speak to the actual behavior the route exposes: which agent_errors
+ * rows get persisted, when handleTaskFailure is invoked, and when the
+ * status-transition audit log fires.
+ *
+ * Per AGENTS.md the gold standard would be a real-DB integration test,
+ * but the project's existing tests/integration/ suite mocks the drizzle
+ * client the same way; this file follows that convention. Scenarios
+ * map 1:1 to the plan's U5 test scenarios so a reader can trace each
+ * back to the original requirement.
+ *
+ * Runs in an isolated test phase via the
+ * `AGENT_HEARTBEAT_TEST_ISOLATED` env gate because the `mock.module`
+ * calls in this file replace `db`, `tasks`, and `events` namespaces
+ * process-wide and would interfere with other test files in the same
+ * bun:test invocation. Mirrors the pattern in
+ * `tests/unit/control-routes-rbac.test.ts`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+const IS_ISOLATED = process.env['AGENT_HEARTBEAT_TEST_ISOLATED'] === '1';
+
+if (!IS_ISOLATED) {
+  describe.skip('agent-heartbeat (skipped — runs in isolated phase)', () => {
+    it('runs only with AGENT_HEARTBEAT_TEST_ISOLATED=1', () => {
+      expect(true).toBe(true);
+    });
+  });
+} else {
+  // ─── Mock infrastructure ────────────────────────────────────────────
+
+  const TEST_AGENT_TOKEN = 'test-agent-preshared-token';
+
+  interface MockAgent {
+    id: number;
+    projectId: number;
+    status: string;
+    capabilities: Record<string, unknown>;
+  }
+
+  interface MockTask {
+    id: number;
+    agentId: number;
+    status: string;
+  }
+
+  interface CapturedAgentError {
+    agentId: number;
+    severity: string;
+    message: string;
+    context: Record<string, unknown>;
+    taskId: number | null;
+  }
+
+  interface CapturedAgentUpdate {
+    status?: string;
+    lastSeenAt?: Date;
+  }
+
+  // Shared mutable state the test cases set up before each call.
+  const state = {
+    agent: { id: 1, projectId: 7, status: 'online', capabilities: {} } as MockAgent | null,
+    activeTasks: [] as MockTask[],
+    ownedTaskIds: new Set<number>(),
+    capturedErrors: [] as CapturedAgentError[],
+    capturedAgentUpdates: [] as CapturedAgentUpdate[],
+    highPriorityTask: null as { id: number } | null,
+  };
+
+  const handleTaskFailureMock = mock(
+    (taskId: number, agentId: number, reason: string): Promise<unknown> => {
+      // Mark the task as failed in our in-memory state so subsequent
+      // active-task queries observe the failure.
+      state.activeTasks = state.activeTasks.filter((t) => t.id !== taskId);
+      return Promise.resolve({ retried: false, taskId, agentId, reason });
+    }
+  );
+
+  const loggerMock = {
+    info: mock(),
+    warn: mock(),
+    error: mock(),
+    debug: mock(),
+  };
+
+  const emitAgentErrorMock = mock();
+  const emitAgentStatusMock = mock();
+
+  // ─── Drizzle-client mock ────────────────────────────────────────────
+  //
+  // We intercept the three operations processHeartbeat performs through
+  // either the global db or a tx:
+  //   1. select agent row (with .for('update').limit(1) inside the tx)
+  //   2. insert into agent_errors
+  //   3. update agents
+  //   4. select active tasks
+  //   5. select high-priority pending tasks
+  // Returning chainable proxies lets the same mock cover both the global
+  // db and the tx argument of db.transaction(fn).
+
+  type AnyTable = { _: { name: string } } | { dbName?: string } | unknown;
+
+  function buildSelectChain(rows: unknown[]) {
+    const chain: Record<string, unknown> = {
+      from: () => chain,
+      innerJoin: () => chain,
+      where: () => chain,
+      for: () => chain,
+      limit: () => Promise.resolve(rows),
+      orderBy: () => Promise.resolve(rows),
+    };
+    // Make the chain thenable so consumers that await it without .limit() resolve.
+    (chain as { then: Promise<unknown[]>['then'] }).then = (resolve: (v: unknown) => void) =>
+      Promise.resolve(rows).then(resolve);
+    return chain;
+  }
+
+  function buildAgentErrorsInsertChain() {
+    return {
+      values: (vals: CapturedAgentError) => {
+        const row = {
+          ...vals,
+          context: vals.context ?? {},
+          taskId: vals.taskId ?? null,
+        };
+        state.capturedErrors.push(row);
+        return { returning: () => Promise.resolve([{ id: state.capturedErrors.length, ...row }]) };
+      },
+    };
+  }
+
+  function buildAgentsUpdateChain() {
+    return {
+      set: (vals: CapturedAgentUpdate) => {
+        state.capturedAgentUpdates.push(vals);
+        if (state.agent && vals.status !== undefined) {
+          state.agent = { ...state.agent, status: vals.status };
+        }
+        return {
+          where: () => ({
+            returning: () => Promise.resolve(state.agent ? [state.agent] : []),
+          }),
+        };
+      },
+    };
+  }
+
+  function buildClient() {
+    return {
+      select: (cols?: unknown) => {
+        // The high-priority lookup selects `{ id: tasks.id }` and joins
+        // campaigns; route to the highPriorityTask state.
+        // The active-tasks lookup also selects `{ id: tasks.id }` from
+        // tasks WHERE agent_id = ... AND status IN (...). To disambiguate
+        // we use cols presence + a counter on tasks selects.
+        if (cols && typeof cols === 'object') {
+          const keys = Object.keys(cols as Record<string, unknown>);
+          // Agent row select inside the tx (status + projectId)
+          if (keys.includes('status') && keys.includes('projectId')) {
+            return buildSelectChain(state.agent ? [state.agent] : []);
+          }
+          // Task ownership / active-task lookup selects only { id }.
+          // The same projection serves three call sites:
+          //   - verifyTaskOwnership: select.from.where.limit  -> ownedTaskIds
+          //   - active-task fan-out: select.from.where        -> activeTasks
+          //   - high-priority lookup: select.from.innerJoin.where.limit -> highPriorityTask
+          // We disambiguate by call shape rather than parsing the where
+          // clause (which is opaque drizzle SQL).
+          if (keys.length === 1 && keys[0] === 'id') {
+            const ownedRows = Array.from(state.ownedTaskIds).map((id) => ({ id }));
+            const activeRows = state.activeTasks.map((t) => ({ id: t.id }));
+            const whereChain = {
+              // verifyTaskOwnership calls .limit(1) after .where(...)
+              limit: () => Promise.resolve(ownedRows),
+              // active-task fan-out awaits the .where(...) result directly
+              then: (resolve: (v: unknown) => void) => Promise.resolve(activeRows).then(resolve),
+            };
+            return {
+              from: () => ({
+                where: () => whereChain,
+                innerJoin: () => ({
+                  where: () => ({
+                    limit: () =>
+                      Promise.resolve(state.highPriorityTask ? [state.highPriorityTask] : []),
+                  }),
+                }),
+              }),
+            };
+          }
+        }
+        return buildSelectChain(state.agent ? [state.agent] : []);
+      },
+      insert: (_table: AnyTable) => buildAgentErrorsInsertChain(),
+      update: (_table: AnyTable) => buildAgentsUpdateChain(),
+      delete: (_table: AnyTable) => ({ where: () => Promise.resolve() }),
+    };
+  }
+
+  mock.module('../../src/db/index.js', () => {
+    const client = buildClient();
+    return {
+      db: {
+        ...client,
+        transaction: async (fn: (tx: ReturnType<typeof buildClient>) => Promise<unknown>) =>
+          fn(buildClient()),
+      },
+      client: {},
+    };
+  });
+
+  mock.module('../../src/config/logger.js', () => ({
+    logger: loggerMock,
+  }));
+
+  mock.module('../../src/services/events.js', () => ({
+    emitAgentError: emitAgentErrorMock,
+    emitAgentStatus: emitAgentStatusMock,
+    emitCrackResult: mock(),
+    emitTaskUpdate: mock(),
+    emitCampaignStatus: mock(),
+    emit: mock(),
+    registerClient: mock(),
+    unregisterClient: mock(),
+    getClientCount: mock(() => 0),
+    __resetEventsForTesting: mock(),
+    broadcastSystemEvent: mock(),
+    broadcastSystemHealth: mock(),
+    SYSTEM_EVENT_PROJECT_ID: 0 as const,
+  }));
+
+  mock.module('../../src/services/tasks.js', () => ({
+    assignNextTask: mock(),
+    updateTaskProgress: mock(),
+    handleTaskFailure: handleTaskFailureMock,
+    generateTasksForAttack: mock(),
+    reassignStaleTasks: mock(() => Promise.resolve([])),
+    getTaskById: mock(),
+    listTasks: mock(),
+    getZapsForTask: mock(),
+    AGENT_TASK_ACTIVE_STATUSES: ['pending', 'assigned', 'running'] as const,
+    projectAgentTaskRows: mock(),
+    listTasksByAgent: mock(),
+  }));
+
+  mock.module('../../src/lib/auth.js', () => ({
+    auth: { api: { getSession: async () => null }, handler: async () => new Response('ok') },
+  }));
+
+  const { app } = await import('../../src/index.js');
+  const { agentToken } = await import('../fixtures.js');
+
+  const AGENT_BASE = '/api/v1/agent';
+
+  function resetState() {
+    state.agent = { id: 1, projectId: 7, status: 'online', capabilities: {} };
+    state.activeTasks = [];
+    state.ownedTaskIds = new Set<number>();
+    state.capturedErrors = [];
+    state.capturedAgentUpdates = [];
+    state.highPriorityTask = null;
+  }
+
+  beforeEach(() => {
+    resetState();
+    handleTaskFailureMock.mockClear();
+    loggerMock.info.mockClear();
+    loggerMock.warn.mockClear();
+    loggerMock.error.mockClear();
+    emitAgentErrorMock.mockClear();
+    emitAgentStatusMock.mockClear();
+  });
+
+  afterEach(() => {
+    // Defense in depth — guarantee no state leaks across files.
+    resetState();
+  });
+
+  // ─── Plan U5 scenarios ──────────────────────────────────────────────
+
+  describe('Integration: agent heartbeat error handling (plan U5)', () => {
+    it('persists a warning error row without moving the agent off its payload status', async () => {
+      // Arrange — covers R3 / R4: warning persists, task continues, status unchanged.
+      const token = agentToken(TEST_AGENT_TOKEN);
+
+      // Act
+      const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          status: 'online',
+          error: { severity: 'warning', message: 'temperature spike', context: { gpuId: 0 } },
+        }),
+      });
+
+      // Assert
+      expect(res.status).toBe(200);
+      expect(state.capturedErrors).toHaveLength(1);
+      const persisted = state.capturedErrors[0];
+      expect(persisted).toBeDefined();
+      if (!persisted) throw new Error('expected one persisted error');
+      expect(persisted.severity).toBe('warning');
+      expect(persisted.message).toBe('temperature spike');
+      // The agent's status set on UPDATE matches the payload, not 'error'.
+      expect(state.capturedAgentUpdates.some((u) => u.status === 'online')).toBe(true);
+      expect(state.capturedAgentUpdates.some((u) => u.status === 'error')).toBe(false);
+      // handleTaskFailure is never invoked on a warning.
+      expect(handleTaskFailureMock).not.toHaveBeenCalled();
+    });
+
+    it('on a fatal heartbeat: persists fatal row, sets status=error, and fails active tasks', async () => {
+      // Arrange — covers R3 / R4 / R5: fatal persists, status forced to
+      // 'error', handleTaskFailure called once per active task.
+      const token = agentToken(TEST_AGENT_TOKEN);
+      state.activeTasks = [
+        { id: 100, agentId: 1, status: 'running' },
+        { id: 101, agentId: 1, status: 'assigned' },
+      ];
+
+      // Act
+      const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          status: 'error',
+          error: { severity: 'fatal', message: 'hashcat crashed' },
+        }),
+      });
+
+      // Assert
+      expect(res.status).toBe(200);
+      expect(state.capturedErrors).toHaveLength(1);
+      const persisted = state.capturedErrors[0];
+      expect(persisted).toBeDefined();
+      if (!persisted) throw new Error('expected one persisted error');
+      expect(persisted.severity).toBe('fatal');
+      expect(state.capturedAgentUpdates.some((u) => u.status === 'error')).toBe(true);
+      expect(handleTaskFailureMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('persists the fatal row and forces status=error even when no active tasks exist', async () => {
+      // Arrange — covers R5 edge case: fatal with no active tasks must
+      // still record the error and force status, just without invoking
+      // handleTaskFailure at all.
+      const token = agentToken(TEST_AGENT_TOKEN);
+      state.activeTasks = [];
+
+      // Act
+      const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          status: 'error',
+          error: { severity: 'fatal', message: 'gpu hung' },
+        }),
+      });
+
+      // Assert
+      expect(res.status).toBe(200);
+      expect(state.capturedErrors).toHaveLength(1);
+      expect(state.capturedAgentUpdates.some((u) => u.status === 'error')).toBe(true);
+      expect(handleTaskFailureMock).not.toHaveBeenCalled();
+    });
+
+    it('emits a status-transition audit log line exactly once on a real transition', async () => {
+      // Arrange — agent currently 'offline'; heartbeat says 'online'.
+      const token = agentToken(TEST_AGENT_TOKEN);
+      state.agent = { id: 1, projectId: 7, status: 'offline', capabilities: {} };
+
+      // Act
+      const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', authorization: `Bearer ${token}` },
+        body: JSON.stringify({ status: 'online' }),
+      });
+
+      // Assert
+      expect(res.status).toBe(200);
+      const transitionCalls = loggerMock.info.mock.calls.filter((args) => {
+        const [payload, message] = args;
+        return typeof message === 'string' && message === 'Agent status transition' && payload;
+      });
+      expect(transitionCalls).toHaveLength(1);
+      const [payload] = transitionCalls[0] ?? [];
+      expect((payload as Record<string, unknown>)['fromStatus']).toBe('offline');
+      expect((payload as Record<string, unknown>)['toStatus']).toBe('online');
+      expect((payload as Record<string, unknown>)['reason']).toBe('heartbeat_status');
+    });
+
+    it('does not emit a status-transition log on a no-op heartbeat (status unchanged)', async () => {
+      // Arrange — every-30s heartbeat reporting the same status.
+      const token = agentToken(TEST_AGENT_TOKEN);
+      state.agent = { id: 1, projectId: 7, status: 'online', capabilities: {} };
+
+      // Act
+      const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', authorization: `Bearer ${token}` },
+        body: JSON.stringify({ status: 'online' }),
+      });
+
+      // Assert
+      expect(res.status).toBe(200);
+      const transitionCalls = loggerMock.info.mock.calls.filter(
+        (args) => typeof args[1] === 'string' && args[1] === 'Agent status transition'
+      );
+      expect(transitionCalls).toHaveLength(0);
+    });
+
+    it('carries currentTask.taskId onto agent_errors when the agent owns the task', async () => {
+      // Arrange — task 42 belongs to this agent (ownership check passes).
+      const token = agentToken(TEST_AGENT_TOKEN);
+      state.ownedTaskIds = new Set([42]);
+
+      // Act
+      const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          status: 'online',
+          currentTask: { taskId: 42, progress: 0.5, speed: 1000 },
+          error: { severity: 'warning', message: 'temp spike' },
+        }),
+      });
+
+      // Assert
+      expect(res.status).toBe(200);
+      expect(state.capturedErrors).toHaveLength(1);
+      expect(state.capturedErrors[0]?.taskId).toBe(42);
+    });
+
+    it('drops currentTask.taskId on agent_errors when the agent does not own the task', async () => {
+      // Arrange — agent claims task 999 but ownedTaskIds is empty, so
+      // the ownership query returns no row.
+      const token = agentToken(TEST_AGENT_TOKEN);
+      state.ownedTaskIds = new Set();
+
+      // Act
+      const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          status: 'online',
+          currentTask: { taskId: 999, progress: 0, speed: 0 },
+          error: { severity: 'warning', message: 'spoofed' },
+        }),
+      });
+
+      // Assert — the error is still persisted (the agent is allowed to
+      // report errors), but the task linkage is severed.
+      expect(res.status).toBe(200);
+      expect(state.capturedErrors).toHaveLength(1);
+      expect(state.capturedErrors[0]?.taskId).toBeNull();
+      // The drop is logged so operators can detect compromised tokens.
+      const warnCalls = loggerMock.warn.mock.calls.filter(
+        (args) => typeof args[1] === 'string' && args[1].includes('not owned')
+      );
+      expect(warnCalls.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('continues failing sibling tasks when one handleTaskFailure throws', async () => {
+      // Arrange — three active tasks, the middle one throws.
+      const token = agentToken(TEST_AGENT_TOKEN);
+      state.activeTasks = [
+        { id: 200, agentId: 1, status: 'running' },
+        { id: 201, agentId: 1, status: 'running' },
+        { id: 202, agentId: 1, status: 'running' },
+      ];
+      handleTaskFailureMock.mockImplementationOnce(() => Promise.resolve({ retried: false }));
+      handleTaskFailureMock.mockImplementationOnce(() => Promise.reject(new Error('boom')));
+      handleTaskFailureMock.mockImplementationOnce(() => Promise.resolve({ retried: false }));
+
+      // Act
+      const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          status: 'error',
+          error: { severity: 'fatal', message: 'fan-out test' },
+        }),
+      });
+
+      // Assert — all three tasks were attempted, the failure was logged,
+      // and the response still ack'd (the partial failure does not
+      // bubble out to the agent because the heartbeat itself succeeded).
+      expect(res.status).toBe(200);
+      expect(handleTaskFailureMock).toHaveBeenCalledTimes(3);
+      const errorCalls = loggerMock.error.mock.calls.filter(
+        (args) => typeof args[1] === 'string' && args[1].includes('handleTaskFailure threw')
+      );
+      expect(errorCalls).toHaveLength(1);
+    });
+
+    it('scrubs secret-shaped keys from error.context before persisting', async () => {
+      // Arrange — agent accidentally serializes credentials.
+      const token = agentToken(TEST_AGENT_TOKEN);
+
+      // Act
+      const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          status: 'online',
+          error: {
+            severity: 'warning',
+            message: 'leak attempt',
+            context: { api_key: 'sk-real', stack: 'Error...', authorization: 'Bearer xxx' },
+          },
+        }),
+      });
+
+      // Assert
+      expect(res.status).toBe(200);
+      expect(state.capturedErrors).toHaveLength(1);
+      const ctx = state.capturedErrors[0]?.context as Record<string, unknown>;
+      expect(ctx['api_key']).toBe('[REDACTED]');
+      expect(ctx['authorization']).toBe('[REDACTED]');
+      expect(ctx['stack']).toBe('Error...');
+    });
+  });
+}

--- a/packages/backend/tests/integration/agent-heartbeat.test.ts
+++ b/packages/backend/tests/integration/agent-heartbeat.test.ts
@@ -76,14 +76,20 @@ if (!IS_ISOLATED) {
     highPriorityTask: null as { id: number } | null,
   };
 
-  const handleTaskFailureMock = mock(
-    (taskId: number, agentId: number, reason: string): Promise<unknown> => {
-      // Mark the task as failed in our in-memory state so subsequent
-      // active-task queries observe the failure.
-      state.activeTasks = state.activeTasks.filter((t) => t.id !== taskId);
-      return Promise.resolve({ retried: false, taskId, agentId, reason });
-    }
-  );
+  // Default handleTaskFailure implementation reused in beforeEach when
+  // we mockReset the spy. Per GOTCHAS.md, mockClear only resets call
+  // history — queued mockImplementationOnce values from a prior test
+  // would leak across cases otherwise.
+  const defaultHandleTaskFailureImpl = (
+    taskId: number,
+    agentId: number,
+    reason: string
+  ): Promise<unknown> => {
+    state.activeTasks = state.activeTasks.filter((t) => t.id !== taskId);
+    return Promise.resolve({ retried: false, taskId, agentId, reason });
+  };
+
+  const handleTaskFailureMock = mock(defaultHandleTaskFailureImpl);
 
   const loggerMock = {
     info: mock(),
@@ -178,10 +184,15 @@ if (!IS_ISOLATED) {
           if (keys.length === 1 && keys[0] === 'id') {
             const ownedRows = Array.from(state.ownedTaskIds).map((id) => ({ id }));
             const activeRows = state.activeTasks.map((t) => ({ id: t.id }));
+            // verifyTaskOwnership now runs inside the tx with FOR UPDATE:
+            //   select({id}).from(tasks).where(...).for('update').limit(1)
+            // active-task fan-out is still:
+            //   select({id}).from(tasks).where(...)  -- awaited directly
+            // high-priority lookup is:
+            //   select({id}).from(tasks).innerJoin(...).where(...).limit(1)
             const whereChain = {
-              // verifyTaskOwnership calls .limit(1) after .where(...)
+              for: () => ({ limit: () => Promise.resolve(ownedRows) }),
               limit: () => Promise.resolve(ownedRows),
-              // active-task fan-out awaits the .where(...) result directly
               then: (resolve: (v: unknown) => void) => Promise.resolve(activeRows).then(resolve),
             };
             return {
@@ -271,12 +282,17 @@ if (!IS_ISOLATED) {
 
   beforeEach(() => {
     resetState();
-    handleTaskFailureMock.mockClear();
-    loggerMock.info.mockClear();
-    loggerMock.warn.mockClear();
-    loggerMock.error.mockClear();
-    emitAgentErrorMock.mockClear();
-    emitAgentStatusMock.mockClear();
+    // mockReset (not mockClear) clears queued mockImplementationOnce
+    // values too — required per GOTCHAS.md "Use mockReset() not
+    // mockClear() in beforeEach". Reinstall the default impls so the
+    // tests that rely on them keep working.
+    handleTaskFailureMock.mockReset();
+    handleTaskFailureMock.mockImplementation(defaultHandleTaskFailureImpl);
+    loggerMock.info.mockReset();
+    loggerMock.warn.mockReset();
+    loggerMock.error.mockReset();
+    emitAgentErrorMock.mockReset();
+    emitAgentStatusMock.mockReset();
   });
 
   afterEach(() => {

--- a/packages/backend/tests/unit/agent-api-contract.test.ts
+++ b/packages/backend/tests/unit/agent-api-contract.test.ts
@@ -159,6 +159,87 @@ describe('Agent API: POST /heartbeat', () => {
 
     expect(res.status).toBe(400);
   });
+
+  it('accepts a heartbeat with currentTask and warning error', async () => {
+    const token = agentToken(TEST_AGENT_TOKEN);
+    const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        status: 'online',
+        currentTask: { taskId: 42, progress: 0.5, speed: 12345, temperature: 72 },
+        error: { severity: 'warning', message: 'temperature spike', context: { gpuId: 0 } },
+      }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('accepts a heartbeat with a fatal error and no currentTask', async () => {
+    const token = agentToken(TEST_AGENT_TOKEN);
+    const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        status: 'error',
+        error: { severity: 'fatal', message: 'hashcat crashed' },
+      }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects an error.severity outside the warning|fatal enum', async () => {
+    const token = agentToken(TEST_AGENT_TOKEN);
+    const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        status: 'online',
+        error: { severity: 'info', message: 'just a note' },
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an empty error.message', async () => {
+    const token = agentToken(TEST_AGENT_TOKEN);
+    const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        status: 'online',
+        error: { severity: 'warning', message: '' },
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a non-positive currentTask.taskId', async () => {
+    const token = agentToken(TEST_AGENT_TOKEN);
+    const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        status: 'online',
+        currentTask: { taskId: 0, progress: 0, speed: 0 },
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
 });
 
 // ─── POST /tasks/next — Request Next Task ───────────────────────────

--- a/packages/backend/tests/unit/agent-api-contract.test.ts
+++ b/packages/backend/tests/unit/agent-api-contract.test.ts
@@ -410,7 +410,7 @@ describe('Agent API: POST /heartbeat', () => {
   });
 
   // ─── Recovery from status='error' via heartbeat ─────────────────────
-  // The heartbeat endpoint uses requireAgentTokenAllowRecovery so an
+  // The heartbeat endpoint uses requireAgentTokenForHeartbeatRecovery so an
   // agent whose row was forced to status='error' by a prior fatal
   // heartbeat can post a clean heartbeat to come back online. Every
   // other agent endpoint stays strict (rejects error-state agents).

--- a/packages/backend/tests/unit/agent-api-contract.test.ts
+++ b/packages/backend/tests/unit/agent-api-contract.test.ts
@@ -406,6 +406,66 @@ describe('Agent API: POST /heartbeat', () => {
     expect(res.status).toBe(400);
     await expectAgentValidationError(res);
   });
+
+  // ─── Recovery from status='error' via heartbeat ─────────────────────
+  // The heartbeat endpoint uses requireAgentTokenAllowRecovery so an
+  // agent whose row was forced to status='error' by a prior fatal
+  // heartbeat can post a clean heartbeat to come back online. Every
+  // other agent endpoint stays strict (rejects error-state agents).
+
+  it('allows an errored agent to post a recovery heartbeat', async () => {
+    // Arrange — simulate an agent that was previously forced to
+    // status='error' by a fatal heartbeat. The strict middleware would
+    // reject this token; the recovery variant on /heartbeat admits it
+    // so processHeartbeat can transition it back to 'online'.
+    const token = agentToken(TEST_AGENT_TOKEN);
+    const priorStatus = mockAgent.status;
+    mockAgent.status = 'error';
+
+    try {
+      // Act
+      const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ status: 'online' }),
+      });
+
+      // Assert — the middleware admits the errored agent (200, not 401)
+      // and the handler acknowledges.
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body['acknowledged']).toBe(true);
+    } finally {
+      mockAgent.status = priorStatus;
+    }
+  });
+
+  it('still rejects errored agents on work endpoints (strict middleware)', async () => {
+    // Arrange — same errored row, but posting to /tasks/next (which
+    // uses the strict requireAgentToken middleware). Confirms the
+    // recovery exemption is heartbeat-only.
+    const token = agentToken(TEST_AGENT_TOKEN);
+    const priorStatus = mockAgent.status;
+    mockAgent.status = 'error';
+
+    try {
+      // Act
+      const res = await app.request(`${AGENT_BASE}/tasks/next`, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${token}` },
+      });
+
+      // Assert
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect((body['error'] as Record<string, unknown>)['code']).toBe('AUTH_TOKEN_INVALID');
+    } finally {
+      mockAgent.status = priorStatus;
+    }
+  });
 });
 
 // ─── POST /tasks/next — Request Next Task ───────────────────────────

--- a/packages/backend/tests/unit/agent-api-contract.test.ts
+++ b/packages/backend/tests/unit/agent-api-contract.test.ts
@@ -66,6 +66,7 @@ import {
   classifyWorstSeverity as realClassifyWorstSeverity,
   decideHeartbeatTransition as realDecideHeartbeatTransition,
   pickCurrentTaskByAgent as realPickCurrentTaskByAgent,
+  scrubAgentErrorContext as realScrubAgentErrorContext,
 } from '../../src/services/agents.js';
 
 mock.module('../../src/services/agents.js', () => ({
@@ -77,6 +78,7 @@ mock.module('../../src/services/agents.js', () => ({
   classifyWorstSeverity: realClassifyWorstSeverity,
   decideHeartbeatTransition: realDecideHeartbeatTransition,
   pickCurrentTaskByAgent: realPickCurrentTaskByAgent,
+  scrubAgentErrorContext: realScrubAgentErrorContext,
 }));
 
 // Mock events and tasks to prevent real modules from entering the shared bun

--- a/packages/backend/tests/unit/agent-api-contract.test.ts
+++ b/packages/backend/tests/unit/agent-api-contract.test.ts
@@ -136,6 +136,22 @@ import { agentToken } from '../fixtures.js';
 
 const AGENT_BASE = '/api/v1/agent';
 
+/**
+ * Assert the documented Agent API validation-error envelope
+ * (`{error: {code: 'VALIDATION_ERROR', message}}`). This is the contract
+ * shape the route-level `agentValidationHook` produces; testing for it
+ * (rather than the bare 400) catches regressions where the hook is
+ * dropped and zValidator falls back to its `{success, error: ZodError}`
+ * default.
+ */
+async function expectAgentValidationError(res: Response): Promise<void> {
+  const body = (await res.json()) as Record<string, unknown>;
+  expect(body).toHaveProperty('error');
+  const err = body['error'] as Record<string, unknown>;
+  expect(err['code']).toBe('VALIDATION_ERROR');
+  expect(typeof err['message']).toBe('string');
+}
+
 // ─── POST /sessions — removed (should 404) ──────────────────────────
 
 describe('Agent API: POST /sessions (removed)', () => {
@@ -263,6 +279,7 @@ describe('Agent API: POST /heartbeat', () => {
       }),
     });
     expect(res.status).toBe(400);
+    await expectAgentValidationError(res);
   });
 
   it('rejects an empty error.message', async () => {
@@ -279,6 +296,7 @@ describe('Agent API: POST /heartbeat', () => {
       }),
     });
     expect(res.status).toBe(400);
+    await expectAgentValidationError(res);
   });
 
   it('rejects a non-positive currentTask.taskId', async () => {
@@ -295,6 +313,7 @@ describe('Agent API: POST /heartbeat', () => {
       }),
     });
     expect(res.status).toBe(400);
+    await expectAgentValidationError(res);
   });
 
   it('rejects a negative currentTask.progress', async () => {
@@ -311,6 +330,7 @@ describe('Agent API: POST /heartbeat', () => {
       }),
     });
     expect(res.status).toBe(400);
+    await expectAgentValidationError(res);
   });
 
   // ─── Size-cap boundaries on error.message and error.context ─────────
@@ -360,6 +380,7 @@ describe('Agent API: POST /heartbeat', () => {
 
     // Assert
     expect(res.status).toBe(400);
+    await expectAgentValidationError(res);
   });
 
   it('rejects an error.context whose JSON serialization exceeds 16K characters', async () => {
@@ -383,6 +404,7 @@ describe('Agent API: POST /heartbeat', () => {
 
     // Assert
     expect(res.status).toBe(400);
+    await expectAgentValidationError(res);
   });
 });
 

--- a/packages/backend/tests/unit/agent-api-contract.test.ts
+++ b/packages/backend/tests/unit/agent-api-contract.test.ts
@@ -54,9 +54,29 @@ const mockSelect = mock(() => ({
 
 const mockExecute = mock(() => Promise.resolve([mockSnakeCaseTaskRow]));
 
+// Pull the real pure helpers in BEFORE mock.module runs so the mock
+// factory can re-export them. `mock.module` is process-global in
+// bun:test; without this re-export, `agents-service.test.ts` (which
+// imports these symbols) gets `undefined` for them when its file is
+// loaded *after* this one — a Linux/macOS-load-order CI flake. See
+// GOTCHAS.md "Re-export the real implementation when you must mock
+// siblings" and the crackers-routes.test.ts precedent.
+import {
+  classifyRecentErrors as realClassifyRecentErrors,
+  classifyWorstSeverity as realClassifyWorstSeverity,
+  decideHeartbeatTransition as realDecideHeartbeatTransition,
+  pickCurrentTaskByAgent as realPickCurrentTaskByAgent,
+} from '../../src/services/agents.js';
+
 mock.module('../../src/services/agents.js', () => ({
   processHeartbeat: mock(() => Promise.resolve({ hasHighPriorityTasks: false })),
   logAgentError: mock(() => Promise.resolve()),
+  // Real impls re-exported so sibling tests see the genuine functions
+  // regardless of which file bun loads first.
+  classifyRecentErrors: realClassifyRecentErrors,
+  classifyWorstSeverity: realClassifyWorstSeverity,
+  decideHeartbeatTransition: realDecideHeartbeatTransition,
+  pickCurrentTaskByAgent: realPickCurrentTaskByAgent,
 }));
 
 // Mock events and tasks to prevent real modules from entering the shared bun
@@ -160,8 +180,33 @@ describe('Agent API: POST /heartbeat', () => {
     expect(res.status).toBe(400);
   });
 
-  it('accepts a heartbeat with currentTask and warning error', async () => {
+  it('accepts a legacy heartbeat with status only (back-compat baseline)', async () => {
+    // Arrange — locks in lenient policy. Existing agents in the wild
+    // still post `{status: 'online'}` and nothing else; tightening the
+    // schema (e.g., adding .strict()) would silently break them.
     const token = agentToken(TEST_AGENT_TOKEN);
+
+    // Act
+    const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ status: 'online' }),
+    });
+
+    // Assert
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body['acknowledged']).toBe(true);
+  });
+
+  it('accepts a heartbeat with currentTask and warning error', async () => {
+    // Arrange
+    const token = agentToken(TEST_AGENT_TOKEN);
+
+    // Act
     const res = await app.request(`${AGENT_BASE}/heartbeat`, {
       method: 'POST',
       headers: {
@@ -174,11 +219,18 @@ describe('Agent API: POST /heartbeat', () => {
         error: { severity: 'warning', message: 'temperature spike', context: { gpuId: 0 } },
       }),
     });
+
+    // Assert
     expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body['acknowledged']).toBe(true);
   });
 
   it('accepts a heartbeat with a fatal error and no currentTask', async () => {
+    // Arrange
     const token = agentToken(TEST_AGENT_TOKEN);
+
+    // Act
     const res = await app.request(`${AGENT_BASE}/heartbeat`, {
       method: 'POST',
       headers: {
@@ -190,7 +242,11 @@ describe('Agent API: POST /heartbeat', () => {
         error: { severity: 'fatal', message: 'hashcat crashed' },
       }),
     });
+
+    // Assert
     expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body['acknowledged']).toBe(true);
   });
 
   it('rejects an error.severity outside the warning|fatal enum', async () => {
@@ -238,6 +294,94 @@ describe('Agent API: POST /heartbeat', () => {
         currentTask: { taskId: 0, progress: 0, speed: 0 },
       }),
     });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a negative currentTask.progress', async () => {
+    const token = agentToken(TEST_AGENT_TOKEN);
+    const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        status: 'online',
+        currentTask: { taskId: 42, progress: -0.1, speed: 0 },
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  // ─── Size-cap boundaries on error.message and error.context ─────────
+  // These guard the DoS-bound `.max(4096)` and `.refine()` 16K-char cap
+  // on the heartbeat error block. A refactor that drops either would
+  // ship silently without these tests.
+
+  it('accepts an error.message at the 4096-character cap', async () => {
+    // Arrange
+    const token = agentToken(TEST_AGENT_TOKEN);
+    const messageAtCap = 'a'.repeat(4096);
+
+    // Act
+    const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        status: 'online',
+        error: { severity: 'warning', message: messageAtCap },
+      }),
+    });
+
+    // Assert
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects an error.message that exceeds the 4096-character cap', async () => {
+    // Arrange
+    const token = agentToken(TEST_AGENT_TOKEN);
+    const messageOverCap = 'a'.repeat(4097);
+
+    // Act
+    const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        status: 'online',
+        error: { severity: 'warning', message: messageOverCap },
+      }),
+    });
+
+    // Assert
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an error.context whose JSON serialization exceeds 16K characters', async () => {
+    // Arrange — a single string value just past the 16K-char limit so
+    // `JSON.stringify(context).length` exceeds HEARTBEAT_ERROR_CONTEXT_MAX_CHARS.
+    const token = agentToken(TEST_AGENT_TOKEN);
+    const oversized = { blob: 'x'.repeat(16 * 1024 + 1) };
+
+    // Act
+    const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        status: 'online',
+        error: { severity: 'warning', message: 'big', context: oversized },
+      }),
+    });
+
+    // Assert
     expect(res.status).toBe(400);
   });
 });

--- a/packages/backend/tests/unit/agents-service.test.ts
+++ b/packages/backend/tests/unit/agents-service.test.ts
@@ -16,6 +16,7 @@ import {
   classifyWorstSeverity,
   decideHeartbeatTransition,
   pickCurrentTaskByAgent,
+  scrubAgentErrorContext,
 } from '../../src/services/agents.js';
 import { AGENT_TASK_ACTIVE_STATUSES, projectAgentTaskRows } from '../../src/services/tasks.js';
 
@@ -270,7 +271,7 @@ describe('AGENT_TASK_ACTIVE_STATUSES', () => {
 });
 
 describe('decideHeartbeatTransition', () => {
-  it('forces effective status to "error" and flags fatal when severity is fatal', () => {
+  it('returns kind=transition with fatal_error reason when severity is fatal and prior differs', () => {
     // Arrange
     const input = {
       payloadStatus: 'online' as const,
@@ -281,14 +282,18 @@ describe('decideHeartbeatTransition', () => {
     // Act
     const result = decideHeartbeatTransition(input);
 
-    // Assert
+    // Assert — fatal flips effectiveStatus to 'error', which differs
+    // from prior 'online' and so emits a transition.
+    expect(result.kind).toBe('transition');
     expect(result.effectiveStatus).toBe('error');
     expect(result.isFatalError).toBe(true);
-    expect(result.shouldLogTransition).toBe(true);
-    expect(result.reason).toBe('fatal_error');
+    if (result.kind === 'transition') {
+      expect(result.reason).toBe('fatal_error');
+      expect(result.fromStatus).toBe('online');
+    }
   });
 
-  it('keeps the payload status and does not flag fatal on a warning-severity error', () => {
+  it('returns kind=noop on a warning-severity error when status would not change', () => {
     // Arrange — online → online with a warning is the typical thermal-spike case.
     const input = {
       payloadStatus: 'online' as const,
@@ -300,14 +305,14 @@ describe('decideHeartbeatTransition', () => {
     const result = decideHeartbeatTransition(input);
 
     // Assert — warning is persisted by the caller via logAgentError but
-    // does not move the agent, so no status-transition audit line.
+    // does not move the agent, so the decision collapses to a no-op
+    // (no audit-log line, no fromStatus exposed).
+    expect(result.kind).toBe('noop');
     expect(result.effectiveStatus).toBe('online');
     expect(result.isFatalError).toBe(false);
-    expect(result.shouldLogTransition).toBe(false);
-    expect(result.reason).toBeNull();
   });
 
-  it('suppresses the audit log on a no-op transition (status unchanged)', () => {
+  it('returns kind=noop on a heartbeat that does not change status', () => {
     // Arrange
     const input = { payloadStatus: 'online' as const, priorStatus: 'online' };
 
@@ -315,11 +320,10 @@ describe('decideHeartbeatTransition', () => {
     const result = decideHeartbeatTransition(input);
 
     // Assert
-    expect(result.shouldLogTransition).toBe(false);
-    expect(result.reason).toBeNull();
+    expect(result.kind).toBe('noop');
   });
 
-  it('emits a heartbeat_status transition when the payload changes the status', () => {
+  it('returns kind=transition with heartbeat_status reason when payload changes the status', () => {
     // Arrange — agent comes back online after the heartbeat-monitor marked it offline.
     const input = { payloadStatus: 'online' as const, priorStatus: 'offline' };
 
@@ -327,12 +331,15 @@ describe('decideHeartbeatTransition', () => {
     const result = decideHeartbeatTransition(input);
 
     // Assert
+    expect(result.kind).toBe('transition');
     expect(result.effectiveStatus).toBe('online');
-    expect(result.shouldLogTransition).toBe(true);
-    expect(result.reason).toBe('heartbeat_status');
+    if (result.kind === 'transition') {
+      expect(result.reason).toBe('heartbeat_status');
+      expect(result.fromStatus).toBe('offline');
+    }
   });
 
-  it('emits a fatal_error transition when fatal flips an agent from online', () => {
+  it('returns kind=transition with fatal_error reason when fatal flips from online', () => {
     // Arrange
     const input = {
       payloadStatus: 'online' as const,
@@ -344,11 +351,13 @@ describe('decideHeartbeatTransition', () => {
     const result = decideHeartbeatTransition(input);
 
     // Assert
-    expect(result.shouldLogTransition).toBe(true);
-    expect(result.reason).toBe('fatal_error');
+    expect(result.kind).toBe('transition');
+    if (result.kind === 'transition') {
+      expect(result.reason).toBe('fatal_error');
+    }
   });
 
-  it('suppresses the audit log when priorStatus is null (agent row missing)', () => {
+  it('returns kind=noop when priorStatus is null (agent row missing)', () => {
     // Arrange — agent row vanished between auth and heartbeat handling.
     const input = { payloadStatus: 'online' as const, priorStatus: null };
 
@@ -357,7 +366,112 @@ describe('decideHeartbeatTransition', () => {
 
     // Assert — processHeartbeat surfaces this case via logger.warn; the
     // pure decision stays silent.
-    expect(result.shouldLogTransition).toBe(false);
-    expect(result.reason).toBeNull();
+    expect(result.kind).toBe('noop');
+  });
+});
+
+describe('scrubAgentErrorContext', () => {
+  it('redacts secret-shaped keys at the top level', () => {
+    // Arrange — operator-readable rows must not carry credentials.
+    const input = {
+      stack: 'Error at line 42',
+      api_key: 'sk-prod-xxx',
+      authorization: 'Bearer abc123',
+      gpuId: 0,
+    };
+
+    // Act
+    const out = scrubAgentErrorContext(input) as Record<string, unknown>;
+
+    // Assert
+    expect(out['stack']).toBe('Error at line 42');
+    expect(out['gpuId']).toBe(0);
+    expect(out['api_key']).toBe('[REDACTED]');
+    expect(out['authorization']).toBe('[REDACTED]');
+  });
+
+  it('redacts secret-shaped keys nested deeper in the payload', () => {
+    // Arrange — error.context.cause.headers shape is common when an
+    // agent serializes a fetch failure with a stack trace.
+    const input = {
+      cause: {
+        headers: {
+          'x-auth-token': 'secret-token',
+          'content-type': 'application/json',
+        },
+        statusCode: 500,
+      },
+    };
+
+    // Act
+    const out = scrubAgentErrorContext(input) as Record<string, unknown>;
+    const cause = out['cause'] as Record<string, unknown>;
+    const headers = cause['headers'] as Record<string, unknown>;
+
+    // Assert
+    expect(headers['x-auth-token']).toBe('[REDACTED]');
+    expect(headers['content-type']).toBe('application/json');
+    expect(cause['statusCode']).toBe(500);
+  });
+
+  it('redacts case-insensitively across naming conventions', () => {
+    // Arrange — apiKey, API_KEY, Authorization, COOKIE all match.
+    const input = {
+      apiKey: 'a',
+      API_KEY: 'b',
+      Authorization: 'c',
+      COOKIE: 'd',
+      Bearer: 'e',
+      customer_secret: 'f',
+    };
+
+    // Act
+    const out = scrubAgentErrorContext(input) as Record<string, unknown>;
+
+    // Assert
+    for (const value of Object.values(out)) {
+      expect(value).toBe('[REDACTED]');
+    }
+  });
+
+  it('walks arrays without dropping non-object entries', () => {
+    // Arrange
+    const input = {
+      events: [{ password: 'p', code: 1 }, 'plain string', 42, null],
+    };
+
+    // Act
+    const out = scrubAgentErrorContext(input) as Record<string, unknown>;
+    const events = out['events'] as unknown[];
+
+    // Assert
+    expect((events[0] as Record<string, unknown>)['password']).toBe('[REDACTED]');
+    expect((events[0] as Record<string, unknown>)['code']).toBe(1);
+    expect(events[1]).toBe('plain string');
+    expect(events[2]).toBe(42);
+    expect(events[3]).toBeNull();
+  });
+
+  it('caps recursion depth so cyclic-shaped payloads cannot exhaust the stack', () => {
+    // Arrange — build a payload deeper than SCRUB_MAX_DEPTH (6).
+    type Nested = { next: Nested | Record<string, never> };
+    const deep: Nested = { next: {} };
+    let cursor: Nested = deep;
+    for (let i = 0; i < 20; i++) {
+      cursor.next = { next: {} };
+      cursor = cursor.next as Nested;
+    }
+
+    // Act + Assert — must not throw, and the scrubber substitutes the
+    // sentinel beyond the depth cap.
+    expect(() => scrubAgentErrorContext(deep)).not.toThrow();
+  });
+
+  it('returns primitives unchanged', () => {
+    // Arrange + Act + Assert
+    expect(scrubAgentErrorContext('hello')).toBe('hello');
+    expect(scrubAgentErrorContext(42)).toBe(42);
+    expect(scrubAgentErrorContext(null)).toBeNull();
+    expect(scrubAgentErrorContext(undefined)).toBeUndefined();
   });
 });

--- a/packages/backend/tests/unit/agents-service.test.ts
+++ b/packages/backend/tests/unit/agents-service.test.ts
@@ -339,22 +339,25 @@ describe('decideHeartbeatTransition', () => {
     }
   });
 
-  it('returns kind=transition with fatal_error reason when fatal flips from online', () => {
-    // Arrange
+  it('returns kind=noop on a fatal heartbeat when the agent is already in error state', () => {
+    // Arrange — repeated fatal heartbeats from an already-errored agent
+    // should not emit an audit-log line on every poll. effectiveStatus
+    // stays 'error', prior is already 'error', so the transition
+    // collapses to a no-op even though the heartbeat carries fatal
+    // severity. The error itself is still persisted by the caller.
     const input = {
-      payloadStatus: 'online' as const,
+      payloadStatus: 'error' as const,
       errorSeverity: 'fatal' as const,
-      priorStatus: 'online',
+      priorStatus: 'error',
     };
 
     // Act
     const result = decideHeartbeatTransition(input);
 
     // Assert
-    expect(result.kind).toBe('transition');
-    if (result.kind === 'transition') {
-      expect(result.reason).toBe('fatal_error');
-    }
+    expect(result.kind).toBe('noop');
+    expect(result.effectiveStatus).toBe('error');
+    expect(result.isFatalError).toBe(true);
   });
 
   it('returns kind=noop when priorStatus is null (agent row missing)', () => {
@@ -465,6 +468,56 @@ describe('scrubAgentErrorContext', () => {
     // Act + Assert — must not throw, and the scrubber substitutes the
     // sentinel beyond the depth cap.
     expect(() => scrubAgentErrorContext(deep)).not.toThrow();
+  });
+
+  it('preserves descriptive keys that only contain a secret-name as a prefix', () => {
+    // Arrange — these names reference a secret (or count them) but do
+    // not carry the secret value itself. The earlier substring-based
+    // pattern over-redacted them, hiding useful debugging info from
+    // operators.
+    const input = {
+      tokenCount: 42,
+      cookieDomain: 'example.com',
+      bearerHostname: 'api.example.com',
+      apiKeyName: 'production',
+      secretsManagerEnabled: true,
+      passwordAge: 60,
+    };
+
+    // Act
+    const out = scrubAgentErrorContext(input) as Record<string, unknown>;
+
+    // Assert — values pass through unchanged.
+    expect(out['tokenCount']).toBe(42);
+    expect(out['cookieDomain']).toBe('example.com');
+    expect(out['bearerHostname']).toBe('api.example.com');
+    expect(out['apiKeyName']).toBe('production');
+    expect(out['secretsManagerEnabled']).toBe(true);
+    expect(out['passwordAge']).toBe(60);
+  });
+
+  it('redacts trailing-secret compound keys (e.g., customer_secret, db_password)', () => {
+    // Arrange — common pattern where a prefix scopes a secret-bearing
+    // field.
+    const input = {
+      customer_secret: 'cs_xxx',
+      db_password: 'pw',
+      access_token: 'at',
+      refresh_token: 'rt',
+      x_api_key: 'k',
+      legitimate_count: 3,
+    };
+
+    // Act
+    const out = scrubAgentErrorContext(input) as Record<string, unknown>;
+
+    // Assert
+    expect(out['customer_secret']).toBe('[REDACTED]');
+    expect(out['db_password']).toBe('[REDACTED]');
+    expect(out['access_token']).toBe('[REDACTED]');
+    expect(out['refresh_token']).toBe('[REDACTED]');
+    expect(out['x_api_key']).toBe('[REDACTED]');
+    expect(out['legitimate_count']).toBe(3);
   });
 
   it('returns primitives unchanged', () => {

--- a/packages/backend/tests/unit/agents-service.test.ts
+++ b/packages/backend/tests/unit/agents-service.test.ts
@@ -271,11 +271,17 @@ describe('AGENT_TASK_ACTIVE_STATUSES', () => {
 
 describe('decideHeartbeatTransition', () => {
   it('forces effective status to "error" and flags fatal when severity is fatal', () => {
-    const result = decideHeartbeatTransition({
-      payloadStatus: 'online',
-      errorSeverity: 'fatal',
+    // Arrange
+    const input = {
+      payloadStatus: 'online' as const,
+      errorSeverity: 'fatal' as const,
       priorStatus: 'online',
-    });
+    };
+
+    // Act
+    const result = decideHeartbeatTransition(input);
+
+    // Assert
     expect(result.effectiveStatus).toBe('error');
     expect(result.isFatalError).toBe(true);
     expect(result.shouldLogTransition).toBe(true);
@@ -283,54 +289,74 @@ describe('decideHeartbeatTransition', () => {
   });
 
   it('keeps the payload status and does not flag fatal on a warning-severity error', () => {
-    const result = decideHeartbeatTransition({
-      payloadStatus: 'online',
-      errorSeverity: 'warning',
+    // Arrange — online → online with a warning is the typical thermal-spike case.
+    const input = {
+      payloadStatus: 'online' as const,
+      errorSeverity: 'warning' as const,
       priorStatus: 'online',
-    });
+    };
+
+    // Act
+    const result = decideHeartbeatTransition(input);
+
+    // Assert — warning is persisted by the caller via logAgentError but
+    // does not move the agent, so no status-transition audit line.
     expect(result.effectiveStatus).toBe('online');
     expect(result.isFatalError).toBe(false);
-    // online -> online is a no-op transition; the warning is persisted
-    // by the caller via logAgentError, but it does not move the agent
-    // and therefore does not emit a status-transition audit line.
     expect(result.shouldLogTransition).toBe(false);
     expect(result.reason).toBeNull();
   });
 
   it('suppresses the audit log on a no-op transition (status unchanged)', () => {
-    const result = decideHeartbeatTransition({
-      payloadStatus: 'online',
-      priorStatus: 'online',
-    });
+    // Arrange
+    const input = { payloadStatus: 'online' as const, priorStatus: 'online' };
+
+    // Act
+    const result = decideHeartbeatTransition(input);
+
+    // Assert
     expect(result.shouldLogTransition).toBe(false);
     expect(result.reason).toBeNull();
   });
 
   it('emits a heartbeat_status transition when the payload changes the status', () => {
-    const result = decideHeartbeatTransition({
-      payloadStatus: 'online',
-      priorStatus: 'offline',
-    });
+    // Arrange — agent comes back online after the heartbeat-monitor marked it offline.
+    const input = { payloadStatus: 'online' as const, priorStatus: 'offline' };
+
+    // Act
+    const result = decideHeartbeatTransition(input);
+
+    // Assert
     expect(result.effectiveStatus).toBe('online');
     expect(result.shouldLogTransition).toBe(true);
     expect(result.reason).toBe('heartbeat_status');
   });
 
   it('emits a fatal_error transition when fatal flips an agent from online', () => {
-    const result = decideHeartbeatTransition({
-      payloadStatus: 'online',
-      errorSeverity: 'fatal',
+    // Arrange
+    const input = {
+      payloadStatus: 'online' as const,
+      errorSeverity: 'fatal' as const,
       priorStatus: 'online',
-    });
+    };
+
+    // Act
+    const result = decideHeartbeatTransition(input);
+
+    // Assert
     expect(result.shouldLogTransition).toBe(true);
     expect(result.reason).toBe('fatal_error');
   });
 
   it('suppresses the audit log when priorStatus is null (agent row missing)', () => {
-    const result = decideHeartbeatTransition({
-      payloadStatus: 'online',
-      priorStatus: null,
-    });
+    // Arrange — agent row vanished between auth and heartbeat handling.
+    const input = { payloadStatus: 'online' as const, priorStatus: null };
+
+    // Act
+    const result = decideHeartbeatTransition(input);
+
+    // Assert — processHeartbeat surfaces this case via logger.warn; the
+    // pure decision stays silent.
     expect(result.shouldLogTransition).toBe(false);
     expect(result.reason).toBeNull();
   });

--- a/packages/backend/tests/unit/agents-service.test.ts
+++ b/packages/backend/tests/unit/agents-service.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, it } from 'bun:test';
 import {
   classifyRecentErrors,
   classifyWorstSeverity,
+  decideHeartbeatTransition,
   pickCurrentTaskByAgent,
 } from '../../src/services/agents.js';
 import { AGENT_TASK_ACTIVE_STATUSES, projectAgentTaskRows } from '../../src/services/tasks.js';
@@ -265,5 +266,72 @@ describe('AGENT_TASK_ACTIVE_STATUSES', () => {
     // (which shows the agent's full active queue) from the list-page
     // currentTask column (running/assigned only).
     expect([...AGENT_TASK_ACTIVE_STATUSES]).toEqual(['pending', 'assigned', 'running']);
+  });
+});
+
+describe('decideHeartbeatTransition', () => {
+  it('forces effective status to "error" and flags fatal when severity is fatal', () => {
+    const result = decideHeartbeatTransition({
+      payloadStatus: 'online',
+      errorSeverity: 'fatal',
+      priorStatus: 'online',
+    });
+    expect(result.effectiveStatus).toBe('error');
+    expect(result.isFatalError).toBe(true);
+    expect(result.shouldLogTransition).toBe(true);
+    expect(result.reason).toBe('fatal_error');
+  });
+
+  it('keeps the payload status and does not flag fatal on a warning-severity error', () => {
+    const result = decideHeartbeatTransition({
+      payloadStatus: 'online',
+      errorSeverity: 'warning',
+      priorStatus: 'online',
+    });
+    expect(result.effectiveStatus).toBe('online');
+    expect(result.isFatalError).toBe(false);
+    // online -> online is a no-op transition; the warning is persisted
+    // by the caller via logAgentError, but it does not move the agent
+    // and therefore does not emit a status-transition audit line.
+    expect(result.shouldLogTransition).toBe(false);
+    expect(result.reason).toBeNull();
+  });
+
+  it('suppresses the audit log on a no-op transition (status unchanged)', () => {
+    const result = decideHeartbeatTransition({
+      payloadStatus: 'online',
+      priorStatus: 'online',
+    });
+    expect(result.shouldLogTransition).toBe(false);
+    expect(result.reason).toBeNull();
+  });
+
+  it('emits a heartbeat_status transition when the payload changes the status', () => {
+    const result = decideHeartbeatTransition({
+      payloadStatus: 'online',
+      priorStatus: 'offline',
+    });
+    expect(result.effectiveStatus).toBe('online');
+    expect(result.shouldLogTransition).toBe(true);
+    expect(result.reason).toBe('heartbeat_status');
+  });
+
+  it('emits a fatal_error transition when fatal flips an agent from online', () => {
+    const result = decideHeartbeatTransition({
+      payloadStatus: 'online',
+      errorSeverity: 'fatal',
+      priorStatus: 'online',
+    });
+    expect(result.shouldLogTransition).toBe(true);
+    expect(result.reason).toBe('fatal_error');
+  });
+
+  it('suppresses the audit log when priorStatus is null (agent row missing)', () => {
+    const result = decideHeartbeatTransition({
+      payloadStatus: 'online',
+      priorStatus: null,
+    });
+    expect(result.shouldLogTransition).toBe(false);
+    expect(result.reason).toBeNull();
   });
 });

--- a/packages/backend/tests/unit/auth-middleware.test.ts
+++ b/packages/backend/tests/unit/auth-middleware.test.ts
@@ -47,7 +47,7 @@ mock.module('../../src/lib/auth.js', () => ({
 
 import {
   requireAgentToken,
-  requireAgentTokenAllowRecovery,
+  requireAgentTokenForHeartbeatRecovery,
   requireSession,
 } from '../../src/middleware/auth.js';
 
@@ -95,7 +95,7 @@ function createAgentApp() {
 
 function createAgentRecoveryApp() {
   const app = new Hono<AppEnv>();
-  app.use('*', requireAgentTokenAllowRecovery);
+  app.use('*', requireAgentTokenForHeartbeatRecovery);
   app.get('/agent-endpoint', (c) => {
     const agent = c.get('agent');
     return c.json({ agentId: agent.agentId, projectId: agent.projectId });
@@ -215,7 +215,7 @@ describe('requireAgentToken middleware', () => {
   });
 
   it('should accept a valid active agent pre-shared token', async () => {
-    mockAgentResult = [{ id: 42, projectId: 7, status: 'active', capabilities: { gpu: true } }];
+    mockAgentResult = [{ id: 42, projectId: 7, status: 'online', capabilities: { gpu: true } }];
 
     const res = await app.request('/agent-endpoint', {
       headers: { authorization: 'Bearer valid-agent-token' },
@@ -245,7 +245,7 @@ describe('requireAgentToken middleware', () => {
   });
 });
 
-describe('requireAgentTokenAllowRecovery middleware', () => {
+describe('requireAgentTokenForHeartbeatRecovery middleware', () => {
   const app = createAgentRecoveryApp();
 
   beforeEach(() => {

--- a/packages/backend/tests/unit/auth-middleware.test.ts
+++ b/packages/backend/tests/unit/auth-middleware.test.ts
@@ -45,7 +45,11 @@ mock.module('../../src/lib/auth.js', () => ({
   },
 }));
 
-import { requireAgentToken, requireSession } from '../../src/middleware/auth.js';
+import {
+  requireAgentToken,
+  requireAgentTokenAllowRecovery,
+  requireSession,
+} from '../../src/middleware/auth.js';
 
 /** Build a valid mock session for the given user id and email. */
 function buildMockSession(
@@ -82,6 +86,16 @@ function createSessionApp() {
 function createAgentApp() {
   const app = new Hono<AppEnv>();
   app.use('*', requireAgentToken);
+  app.get('/agent-endpoint', (c) => {
+    const agent = c.get('agent');
+    return c.json({ agentId: agent.agentId, projectId: agent.projectId });
+  });
+  return app;
+}
+
+function createAgentRecoveryApp() {
+  const app = new Hono<AppEnv>();
+  app.use('*', requireAgentTokenAllowRecovery);
   app.get('/agent-endpoint', (c) => {
     const agent = c.get('agent');
     return c.json({ agentId: agent.agentId, projectId: agent.projectId });
@@ -227,6 +241,58 @@ describe('requireAgentToken middleware', () => {
     const res = await app.request('/agent-endpoint', {
       headers: { authorization: 'Bearer error-agent-token' },
     });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('requireAgentTokenAllowRecovery middleware', () => {
+  const app = createAgentRecoveryApp();
+
+  beforeEach(() => {
+    mockAgentResult = [];
+  });
+
+  it('should accept a valid active agent (same path as the strict middleware)', async () => {
+    // Arrange
+    mockAgentResult = [{ id: 42, projectId: 7, status: 'online', capabilities: { gpu: true } }];
+
+    // Act
+    const res = await app.request('/agent-endpoint', {
+      headers: { authorization: 'Bearer valid-agent-token' },
+    });
+
+    // Assert
+    expect(res.status).toBe(200);
+  });
+
+  it('should accept agents in error state so they can post a recovery heartbeat', async () => {
+    // Arrange — this is the difference from the strict variant. The
+    // recovery middleware is only mounted on /heartbeat; the heartbeat
+    // handler transitions the agent back to `online` on a clean payload.
+    mockAgentResult = [{ id: 99, projectId: 7, status: 'error', capabilities: {} }];
+
+    // Act
+    const res = await app.request('/agent-endpoint', {
+      headers: { authorization: 'Bearer recovering-agent-token' },
+    });
+
+    // Assert
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body['agentId']).toBe(99);
+  });
+
+  it('should still reject an unknown token', async () => {
+    // Arrange
+    mockAgentResult = [];
+
+    // Act
+    const res = await app.request('/agent-endpoint', {
+      headers: { authorization: 'Bearer unknown-token' },
+    });
+
+    // Assert — the recovery middleware allows error-state agents, not
+    // anonymous callers. Bearer validation still applies.
     expect(res.status).toBe(401);
   });
 });

--- a/packages/openapi/agent-api.yaml
+++ b/packages/openapi/agent-api.yaml
@@ -284,6 +284,61 @@ components:
               type: number
             temperature:
               type: number
+        currentTask:
+          type: object
+          description: |
+            Telemetry view of the task the agent is currently executing.
+            Accepted so a fatal heartbeat can attribute the failure to a
+            specific task, but `progress`, `speed`, and `temperature` are
+            informational only — canonical task progress is reported via
+            `POST /api/v1/agent/tasks/{id}/report` and is not written back
+            to the `tasks` table from heartbeat handling.
+          required: [taskId, progress, speed]
+          properties:
+            taskId:
+              type: integer
+              minimum: 1
+            progress:
+              type: number
+              minimum: 0
+            speed:
+              type: number
+            temperature:
+              type: number
+        error:
+          type: object
+          description: |
+            Optional heartbeat-borne error. **Important contract**: the
+            heartbeat `error` block and the standalone `POST /errors`
+            endpoint are non-redundant channels — agents post a given
+            error event via one channel OR the other, never both. The
+            server has no idempotency key and cannot dedupe across
+            channels, so double-posting produces duplicate `agent_errors`
+            rows. A fatal-severity heartbeat error also forces the agent
+            into `status='error'` and fails the agent's active tasks.
+          required: [severity, message]
+          properties:
+            severity:
+              type: string
+              enum: [warning, fatal]
+              description: |
+                Narrower than `POST /errors`, which accepts
+                `warning|error|fatal` for back-compat. Heartbeats classify
+                strictly into warning (logged, task continues) or fatal
+                (logged, task failed, agent status='error').
+            message:
+              type: string
+              minLength: 1
+              maxLength: 4096
+            context:
+              type: object
+              additionalProperties: true
+              description: |
+                Free-form JSON context (stack trace, hashcat output,
+                system metrics). Capped at 16 KiB characters when
+                serialized — payloads larger than that are rejected with
+                400. Do not include secrets (tokens, passwords) —
+                operators with project access can read this field.
 
     EngineDescriptor:
       type: object
@@ -462,17 +517,27 @@ components:
     AgentError:
       type: object
       required: [severity, message]
+      description: |
+        Standalone error payload for `POST /api/v1/agent/errors`. Accepts
+        the wider `warning|error|fatal` severity enum (for back-compat
+        with agents that have not adopted the heartbeat-borne error
+        block), but the same per-field size caps apply on both channels.
       properties:
         severity:
           type: string
           enum: [warning, error, fatal]
         message:
           type: string
+          minLength: 1
+          maxLength: 4096
         context:
           type: object
           additionalProperties: true
+          description: |
+            Capped at 16 KiB characters when serialized.
         taskId:
           type: integer
+          minimum: 1
 
     ZapResponse:
       type: object

--- a/packages/openapi/agent-api.yaml
+++ b/packages/openapi/agent-api.yaml
@@ -326,6 +326,14 @@ components:
                 `warning|error|fatal` for back-compat. Heartbeats classify
                 strictly into warning (logged, task continues) or fatal
                 (logged, task failed, agent status='error').
+
+                **Recovery from status='error'**: an agent forced into
+                `status='error'` by a prior fatal heartbeat can post a
+                clean heartbeat (status='online' with no error block) to
+                this endpoint to return to service — the agent token
+                stays valid for `POST /heartbeat` regardless of status.
+                Every other agent endpoint rejects the token while the
+                agent is in `error` until a recovery heartbeat lands.
             message:
               type: string
               minLength: 1

--- a/packages/shared/src/db/migrations/0007_light_ulik.sql
+++ b/packages/shared/src/db/migrations/0007_light_ulik.sql
@@ -6,6 +6,12 @@ UPDATE "agent_errors"
 SET "task_id" = NULL
 WHERE "task_id" IS NOT NULL
   AND "task_id" NOT IN (SELECT "id" FROM "tasks");--> statement-breakpoint
-DROP INDEX "agent_errors_agent_id_created_at_idx";--> statement-breakpoint
+-- IF EXISTS guards against environments that were hand-rebuilt or had a
+-- prior migration skipped — without it, a missing index blocks the FK
+-- addition below. The index recreate normalizes the DESC NULLS clause
+-- (pg's implicit NULLS FIRST → explicit NULLS LAST) so the snapshot and
+-- the live DB agree; the brief gap between DROP and CREATE is acceptable
+-- because the migration runs in one drizzle invocation.
+DROP INDEX IF EXISTS "agent_errors_agent_id_created_at_idx";--> statement-breakpoint
 ALTER TABLE "agent_errors" ADD CONSTRAINT "agent_errors_task_id_tasks_id_fk" FOREIGN KEY ("task_id") REFERENCES "public"."tasks"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
 CREATE INDEX "agent_errors_agent_id_created_at_idx" ON "agent_errors" USING btree ("agent_id","created_at" DESC NULLS LAST);

--- a/packages/shared/src/db/migrations/0007_light_ulik.sql
+++ b/packages/shared/src/db/migrations/0007_light_ulik.sql
@@ -1,0 +1,11 @@
+-- Clear any orphan task references before attaching the FK. Pre-existing
+-- agent_errors rows may reference task ids that have since been deleted;
+-- ON DELETE SET NULL only applies to deletes that happen AFTER the FK is
+-- in place, so we have to backfill old orphans manually.
+UPDATE "agent_errors"
+SET "task_id" = NULL
+WHERE "task_id" IS NOT NULL
+  AND "task_id" NOT IN (SELECT "id" FROM "tasks");--> statement-breakpoint
+DROP INDEX "agent_errors_agent_id_created_at_idx";--> statement-breakpoint
+ALTER TABLE "agent_errors" ADD CONSTRAINT "agent_errors_task_id_tasks_id_fk" FOREIGN KEY ("task_id") REFERENCES "public"."tasks"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "agent_errors_agent_id_created_at_idx" ON "agent_errors" USING btree ("agent_id","created_at" DESC NULLS LAST);

--- a/packages/shared/src/db/migrations/meta/0007_snapshot.json
+++ b/packages/shared/src/db/migrations/meta/0007_snapshot.json
@@ -1,0 +1,2496 @@
+{
+  "id": "43d3860c-d47a-47c8-85db-5e7541ab0c10",
+  "prevId": "0f1a2b3c-4d5e-6f70-8192-a3b4c5d6e7f8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_benchmarks": {
+      "name": "agent_benchmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashcat_mode": {
+          "name": "hashcat_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash_type": {
+          "name": "hash_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "speed_hs": {
+          "name": "speed_hs",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "benchmarked_at": {
+          "name": "benchmarked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_benchmarks_agent_id_idx": {
+          "name": "agent_benchmarks_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_benchmarks_agent_id_hashcat_mode_idx": {
+          "name": "agent_benchmarks_agent_id_hashcat_mode_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hashcat_mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_benchmarks_agent_id_agents_id_fk": {
+          "name": "agent_benchmarks_agent_id_agents_id_fk",
+          "tableFrom": "agent_benchmarks",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_errors": {
+      "name": "agent_errors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'error'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_errors_agent_id_created_at_idx": {
+          "name": "agent_errors_agent_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_errors_agent_id_agents_id_fk": {
+          "name": "agent_errors_agent_id_agents_id_fk",
+          "tableFrom": "agent_errors",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_errors_task_id_tasks_id_fk": {
+          "name": "agent_errors_task_id_tasks_id_fk",
+          "tableFrom": "agent_errors",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operating_system_id": {
+          "name": "operating_system_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_token": {
+          "name": "auth_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "hardware_profile": {
+          "name": "hardware_profile",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "cracker_version": {
+          "name": "cracker_version",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agents_project_id_idx": {
+          "name": "agents_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_status_idx": {
+          "name": "agents_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_auth_token_idx": {
+          "name": "agents_auth_token_idx",
+          "columns": [
+            {
+              "expression": "auth_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_project_id_projects_id_fk": {
+          "name": "agents_project_id_projects_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agents_operating_system_id_operating_systems_id_fk": {
+          "name": "agents_operating_system_id_operating_systems_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "operating_systems",
+          "columnsFrom": ["operating_system_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_auth_token_unique": {
+          "name": "agents_auth_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["auth_token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attack_templates": {
+      "name": "attack_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash_type_id": {
+          "name": "hash_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wordlist_id": {
+          "name": "wordlist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rulelist_id": {
+          "name": "rulelist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "masklist_id": {
+          "name": "masklist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advanced_configuration": {
+          "name": "advanced_configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attack_templates_project_name_idx": {
+          "name": "attack_templates_project_name_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attack_templates_project_id_idx": {
+          "name": "attack_templates_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attack_templates_project_id_projects_id_fk": {
+          "name": "attack_templates_project_id_projects_id_fk",
+          "tableFrom": "attack_templates",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attack_templates_hash_type_id_hash_types_id_fk": {
+          "name": "attack_templates_hash_type_id_hash_types_id_fk",
+          "tableFrom": "attack_templates",
+          "tableTo": "hash_types",
+          "columnsFrom": ["hash_type_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attack_templates_wordlist_id_word_lists_id_fk": {
+          "name": "attack_templates_wordlist_id_word_lists_id_fk",
+          "tableFrom": "attack_templates",
+          "tableTo": "word_lists",
+          "columnsFrom": ["wordlist_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attack_templates_rulelist_id_rule_lists_id_fk": {
+          "name": "attack_templates_rulelist_id_rule_lists_id_fk",
+          "tableFrom": "attack_templates",
+          "tableTo": "rule_lists",
+          "columnsFrom": ["rulelist_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attack_templates_masklist_id_mask_lists_id_fk": {
+          "name": "attack_templates_masklist_id_mask_lists_id_fk",
+          "tableFrom": "attack_templates",
+          "tableTo": "mask_lists",
+          "columnsFrom": ["masklist_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attack_templates_created_by_users_id_fk": {
+          "name": "attack_templates_created_by_users_id_fk",
+          "tableFrom": "attack_templates",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attacks": {
+      "name": "attacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash_type_id": {
+          "name": "hash_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wordlist_id": {
+          "name": "wordlist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rulelist_id": {
+          "name": "rulelist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "masklist_id": {
+          "name": "masklist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advanced_configuration": {
+          "name": "advanced_configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "keyspace": {
+          "name": "keyspace",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attacks_campaign_id_idx": {
+          "name": "attacks_campaign_id_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attacks_campaign_id_campaigns_id_fk": {
+          "name": "attacks_campaign_id_campaigns_id_fk",
+          "tableFrom": "attacks",
+          "tableTo": "campaigns",
+          "columnsFrom": ["campaign_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attacks_project_id_projects_id_fk": {
+          "name": "attacks_project_id_projects_id_fk",
+          "tableFrom": "attacks",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attacks_hash_type_id_hash_types_id_fk": {
+          "name": "attacks_hash_type_id_hash_types_id_fk",
+          "tableFrom": "attacks",
+          "tableTo": "hash_types",
+          "columnsFrom": ["hash_type_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attacks_wordlist_id_word_lists_id_fk": {
+          "name": "attacks_wordlist_id_word_lists_id_fk",
+          "tableFrom": "attacks",
+          "tableTo": "word_lists",
+          "columnsFrom": ["wordlist_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attacks_rulelist_id_rule_lists_id_fk": {
+          "name": "attacks_rulelist_id_rule_lists_id_fk",
+          "tableFrom": "attacks",
+          "tableTo": "rule_lists",
+          "columnsFrom": ["rulelist_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attacks_masklist_id_mask_lists_id_fk": {
+          "name": "attacks_masklist_id_mask_lists_id_fk",
+          "tableFrom": "attacks",
+          "tableTo": "mask_lists",
+          "columnsFrom": ["masklist_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ba_accounts": {
+      "name": "ba_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ba_accounts_user_id_idx": {
+          "name": "ba_accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ba_accounts_user_id_provider_id_idx": {
+          "name": "ba_accounts_user_id_provider_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ba_accounts_user_id_users_id_fk": {
+          "name": "ba_accounts_user_id_users_id_fk",
+          "tableFrom": "ba_accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ba_sessions": {
+      "name": "ba_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ba_sessions_user_id_idx": {
+          "name": "ba_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ba_sessions_user_id_users_id_fk": {
+          "name": "ba_sessions_user_id_users_id_fk",
+          "tableFrom": "ba_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ba_sessions_token_unique": {
+          "name": "ba_sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ba_verifications": {
+      "name": "ba_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ba_verifications_identifier_idx": {
+          "name": "ba_verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.campaigns": {
+      "name": "campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash_list_id": {
+          "name": "hash_list_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "campaigns_project_id_status_idx": {
+          "name": "campaigns_project_id_status_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "campaigns_project_id_projects_id_fk": {
+          "name": "campaigns_project_id_projects_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "campaigns_hash_list_id_hash_lists_id_fk": {
+          "name": "campaigns_hash_list_id_hash_lists_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "hash_lists",
+          "columnsFrom": ["hash_list_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "campaigns_created_by_users_id_fk": {
+          "name": "campaigns_created_by_users_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cracker_binaries": {
+      "name": "cracker_binaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "engine": {
+          "name": "engine",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'hashcat'"
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_ref": {
+          "name": "file_ref",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cracker_binaries_engine_version_platform_idx": {
+          "name": "cracker_binaries_engine_version_platform_idx",
+          "columns": [
+            {
+              "expression": "engine",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cracker_binaries_engine_platform_idx": {
+          "name": "cracker_binaries_engine_platform_idx",
+          "columns": [
+            {
+              "expression": "engine",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cracker_binaries_is_active_idx": {
+          "name": "cracker_binaries_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hash_items": {
+      "name": "hash_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "hash_list_id": {
+          "name": "hash_list_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash_value": {
+          "name": "hash_value",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plaintext": {
+          "name": "plaintext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cracked_at": {
+          "name": "cracked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attack_id": {
+          "name": "attack_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "hash_items_hash_list_id_hash_value_idx": {
+          "name": "hash_items_hash_list_id_hash_value_idx",
+          "columns": [
+            {
+              "expression": "hash_list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hash_value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hash_items_hash_list_id_idx": {
+          "name": "hash_items_hash_list_id_idx",
+          "columns": [
+            {
+              "expression": "hash_list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hash_items_cracked_at_idx": {
+          "name": "hash_items_cracked_at_idx",
+          "columns": [
+            {
+              "expression": "cracked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hash_items_campaign_id_idx": {
+          "name": "hash_items_campaign_id_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hash_items_hash_list_cracked_idx": {
+          "name": "hash_items_hash_list_cracked_idx",
+          "columns": [
+            {
+              "expression": "hash_list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cracked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hash_items_hash_list_id_hash_lists_id_fk": {
+          "name": "hash_items_hash_list_id_hash_lists_id_fk",
+          "tableFrom": "hash_items",
+          "tableTo": "hash_lists",
+          "columnsFrom": ["hash_list_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "hash_items_campaign_id_campaigns_id_fk": {
+          "name": "hash_items_campaign_id_campaigns_id_fk",
+          "tableFrom": "hash_items",
+          "tableTo": "campaigns",
+          "columnsFrom": ["campaign_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "hash_items_attack_id_attacks_id_fk": {
+          "name": "hash_items_attack_id_attacks_id_fk",
+          "tableFrom": "hash_items",
+          "tableTo": "attacks",
+          "columnsFrom": ["attack_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "hash_items_task_id_tasks_id_fk": {
+          "name": "hash_items_task_id_tasks_id_fk",
+          "tableFrom": "hash_items",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "hash_items_agent_id_agents_id_fk": {
+          "name": "hash_items_agent_id_agents_id_fk",
+          "tableFrom": "hash_items",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hash_lists": {
+      "name": "hash_lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash_type_id": {
+          "name": "hash_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upload'"
+        },
+        "file_ref": {
+          "name": "file_ref",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "statistics": {
+          "name": "statistics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "hash_lists_project_id_idx": {
+          "name": "hash_lists_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hash_lists_status_idx": {
+          "name": "hash_lists_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hash_lists_project_id_projects_id_fk": {
+          "name": "hash_lists_project_id_projects_id_fk",
+          "tableFrom": "hash_lists",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "hash_lists_hash_type_id_hash_types_id_fk": {
+          "name": "hash_lists_hash_type_id_hash_types_id_fk",
+          "tableFrom": "hash_lists",
+          "tableTo": "hash_types",
+          "columnsFrom": ["hash_type_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hash_types": {
+      "name": "hash_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashcat_mode": {
+          "name": "hashcat_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "example": {
+          "name": "example",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hash_types_hashcat_mode_unique": {
+          "name": "hash_types_hashcat_mode_unique",
+          "nullsNotDistinct": false,
+          "columns": ["hashcat_mode"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mask_lists": {
+      "name": "mask_lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_ref": {
+          "name": "file_ref",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "line_count": {
+          "name": "line_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mask_lists_project_id_projects_id_fk": {
+          "name": "mask_lists_project_id_projects_id_fk",
+          "tableFrom": "mask_lists",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operating_systems": {
+      "name": "operating_systems",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_users": {
+      "name": "project_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roles": {
+          "name": "roles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_users_user_project_idx": {
+          "name": "project_users_user_project_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_users_user_id_users_id_fk": {
+          "name": "project_users_user_id_users_id_fk",
+          "tableFrom": "project_users",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "project_users_project_id_projects_id_fk": {
+          "name": "project_users_project_id_projects_id_fk",
+          "tableFrom": "project_users",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_created_by_users_id_fk": {
+          "name": "projects_created_by_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_slug_unique": {
+          "name": "projects_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rule_lists": {
+      "name": "rule_lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_ref": {
+          "name": "file_ref",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "line_count": {
+          "name": "line_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rule_lists_project_id_projects_id_fk": {
+          "name": "rule_lists_project_id_projects_id_fk",
+          "tableFrom": "rule_lists",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "attack_id": {
+          "name": "attack_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "work_range": {
+          "name": "work_range",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "result_stats": {
+          "name": "result_stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "required_capabilities": {
+          "name": "required_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tasks_campaign_id_idx": {
+          "name": "tasks_campaign_id_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_agent_id_idx": {
+          "name": "tasks_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_status_idx": {
+          "name": "tasks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_status_campaign_id_idx": {
+          "name": "tasks_status_campaign_id_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_campaign_id_status_idx": {
+          "name": "tasks_campaign_id_status_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_attack_id_attacks_id_fk": {
+          "name": "tasks_attack_id_attacks_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "attacks",
+          "columnsFrom": ["attack_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_campaign_id_campaigns_id_fk": {
+          "name": "tasks_campaign_id_campaigns_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "campaigns",
+          "columnsFrom": ["campaign_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_agent_id_agents_id_fk": {
+          "name": "tasks_agent_id_agents_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_hash": {
+          "name": "api_key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_last_used_at": {
+          "name": "api_key_last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "users_api_key_hash_unique": {
+          "name": "users_api_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["api_key_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.word_lists": {
+      "name": "word_lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_ref": {
+          "name": "file_ref",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "line_count": {
+          "name": "line_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "word_lists_project_id_projects_id_fk": {
+          "name": "word_lists_project_id_projects_id_fk",
+          "tableFrom": "word_lists",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/shared/src/db/migrations/meta/_journal.json
+++ b/packages/shared/src/db/migrations/meta/_journal.json
@@ -54,7 +54,7 @@
     {
       "idx": 7,
       "version": "7",
-      "when": 1779052939557,
+      "when": 1779152939557,
       "tag": "0007_light_ulik",
       "breakpoints": true
     }

--- a/packages/shared/src/db/migrations/meta/_journal.json
+++ b/packages/shared/src/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1779066400000,
       "tag": "0006_agent_errors_composite_index",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1779052939557,
+      "tag": "0007_light_ulik",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -168,7 +168,12 @@ export const agentErrors = pgTable(
     severity: varchar('severity', { length: 20 }).notNull().default('error'),
     message: text('message').notNull(),
     context: jsonb('context').default({}),
-    taskId: integer('task_id'),
+    // FK with ON DELETE SET NULL: when a task is deleted, the audit row
+    // is retained but its task linkage is cleared. Service-side ownership
+    // checks (services/agents.ts `processHeartbeat`) prevent agents from
+    // attributing errors to tasks they don't own; the FK is the
+    // last-line guard so dangling task_ids cannot accumulate.
+    taskId: integer('task_id').references(() => tasks.id, { onDelete: 'set null' }),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -336,19 +336,18 @@ export const agentTaskSummarySchema = z.object({
  * Heartbeat-only error severity. Narrower than the standalone
  * `POST /api/v1/agent/errors` endpoint (which accepts
  * `warning | error | fatal` for back-compat with agents posting generic
- * errors): heartbeats classify into the explicit `warning | fatal` split
- * the Agent Heartbeat ticket mandates.
+ * errors): heartbeats classify strictly into `warning` (logged, task
+ * continues) or `fatal` (logged, task failed, agent status forced to
+ * `error`).
  *
- * Size caps are enforced at the boundary: a compromised agent token
- * would otherwise let an attacker bloat `agent_errors` with multi-MB
- * rows every ~30s. The caps mirror similar bounded payloads elsewhere
- * in the agent API surface.
+ * Size caps live at the schema boundary so a compromised agent token
+ * cannot bloat `agent_errors` with multi-MB rows on every heartbeat.
  *
- * `HEARTBEAT_ERROR_CONTEXT_MAX_CHARS` bounds the JSON-serialized
- * `context` field in *characters* (not bytes) because `TextEncoder`
- * isn't part of the ES2022 lib the shared package targets. Worst-case
- * UTF-8 expansion is ~4x, so a 16 K-char cap still keeps row sizes
- * well under jsonb-friendly limits.
+ * `HEARTBEAT_ERROR_CONTEXT_MAX_CHARS` bounds `context` in JSON-string
+ * *characters*, not bytes. `JSON.stringify().length` is simpler than
+ * encoding-then-measuring and the worst-case UTF-8 expansion is ~4x —
+ * even a fully-multibyte 16K-char payload stays under 64 KB, which is
+ * still safely under jsonb-friendly row limits.
  */
 export const HEARTBEAT_ERROR_MESSAGE_MAX = 4096;
 export const HEARTBEAT_ERROR_CONTEXT_MAX_CHARS = 16 * 1024;
@@ -383,9 +382,8 @@ export const agentHeartbeatCurrentTaskSchema = z.object({
 });
 
 export const agentHeartbeatSchema = z.object({
-  // The Agent Heartbeat ticket samples `status: 'online' | 'error'` but the
-  // wider system already depends on `busy` and `benchmarked` transitions
-  // (assignments, benchmark submission), so the enum stays a superset. The
+  // Status enum is a deliberate superset: `busy` and `benchmarked` are
+  // load-bearing for task assignment and benchmark submission. The
   // service layer treats anything other than a fatal-error heartbeat as
   // "agent is reachable" regardless of which non-error literal arrives.
   status: z.enum(['online', 'busy', 'error', 'benchmarked']),

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -338,11 +338,34 @@ export const agentTaskSummarySchema = z.object({
  * `warning | error | fatal` for back-compat with agents posting generic
  * errors): heartbeats classify into the explicit `warning | fatal` split
  * the Agent Heartbeat ticket mandates.
+ *
+ * Size caps are enforced at the boundary: a compromised agent token
+ * would otherwise let an attacker bloat `agent_errors` with multi-MB
+ * rows every ~30s. The caps mirror similar bounded payloads elsewhere
+ * in the agent API surface.
+ *
+ * `HEARTBEAT_ERROR_CONTEXT_MAX_CHARS` bounds the JSON-serialized
+ * `context` field in *characters* (not bytes) because `TextEncoder`
+ * isn't part of the ES2022 lib the shared package targets. Worst-case
+ * UTF-8 expansion is ~4x, so a 16 K-char cap still keeps row sizes
+ * well under jsonb-friendly limits.
  */
+export const HEARTBEAT_ERROR_MESSAGE_MAX = 4096;
+export const HEARTBEAT_ERROR_CONTEXT_MAX_CHARS = 16 * 1024;
+
 export const agentHeartbeatErrorSchema = z.object({
   severity: z.enum(['warning', 'fatal']),
-  message: z.string().min(1),
-  context: z.record(z.string(), z.unknown()).optional(),
+  message: z.string().min(1).max(HEARTBEAT_ERROR_MESSAGE_MAX),
+  context: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .refine(
+      (value) =>
+        value === undefined || JSON.stringify(value).length <= HEARTBEAT_ERROR_CONTEXT_MAX_CHARS,
+      {
+        message: `context exceeds ${HEARTBEAT_ERROR_CONTEXT_MAX_CHARS} characters when serialized`,
+      }
+    ),
 });
 
 /**

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -332,7 +332,39 @@ export const agentTaskSummarySchema = z.object({
   assignedAt: z.string().nullable(),
 });
 
+/**
+ * Heartbeat-only error severity. Narrower than the standalone
+ * `POST /api/v1/agent/errors` endpoint (which accepts
+ * `warning | error | fatal` for back-compat with agents posting generic
+ * errors): heartbeats classify into the explicit `warning | fatal` split
+ * the Agent Heartbeat ticket mandates.
+ */
+export const agentHeartbeatErrorSchema = z.object({
+  severity: z.enum(['warning', 'fatal']),
+  message: z.string().min(1),
+  context: z.record(z.string(), z.unknown()).optional(),
+});
+
+/**
+ * Telemetry view of the task the agent is currently executing. Accepted by
+ * the heartbeat endpoint so a fatal heartbeat error can be attributed to a
+ * specific task, but progress/speed/temperature are informational only —
+ * canonical task progress flows through `POST /agent/tasks/:id/report` and
+ * is not written back to the `tasks` table from heartbeat handling.
+ */
+export const agentHeartbeatCurrentTaskSchema = z.object({
+  taskId: z.number().int().positive(),
+  progress: z.number().min(0),
+  speed: z.number(),
+  temperature: z.number().optional(),
+});
+
 export const agentHeartbeatSchema = z.object({
+  // The Agent Heartbeat ticket samples `status: 'online' | 'error'` but the
+  // wider system already depends on `busy` and `benchmarked` transitions
+  // (assignments, benchmark submission), so the enum stays a superset. The
+  // service layer treats anything other than a fatal-error heartbeat as
+  // "agent is reachable" regardless of which non-error literal arrives.
   status: z.enum(['online', 'busy', 'error', 'benchmarked']),
   capabilities: z
     .object({
@@ -348,6 +380,8 @@ export const agentHeartbeatSchema = z.object({
     })
     .optional(),
   deviceInfo: agentHardwareProfileSchema.optional(),
+  currentTask: agentHeartbeatCurrentTaskSchema.optional(),
+  error: agentHeartbeatErrorSchema.optional(),
 });
 
 // ─── Cracker Check-Update API ───────────────────────────────────────

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -2,6 +2,8 @@ import type { z } from 'zod';
 import type {
   agentCurrentTaskSchema,
   agentHardwareProfileSchema,
+  agentHeartbeatCurrentTaskSchema,
+  agentHeartbeatErrorSchema,
   agentHeartbeatSchema,
   agentStatusSchema,
   agentTaskSummarySchema,
@@ -194,6 +196,8 @@ export type CreateCampaignRequest = z.infer<typeof createCampaignRequestSchema>;
 export type CreateAttackRequest = z.infer<typeof createAttackRequestSchema>;
 export type HashCandidate = z.infer<typeof hashCandidateSchema>;
 export type AgentHeartbeat = z.infer<typeof agentHeartbeatSchema>;
+export type AgentHeartbeatError = z.infer<typeof agentHeartbeatErrorSchema>;
+export type AgentHeartbeatCurrentTask = z.infer<typeof agentHeartbeatCurrentTaskSchema>;
 export type AgentHardwareProfile = z.infer<typeof agentHardwareProfileSchema>;
 export type BenchmarkSubmission = z.infer<typeof benchmarkSubmissionSchema>;
 export type CreateAttackTemplateRequest = z.infer<typeof createAttackTemplateRequestSchema>;


### PR DESCRIPTION
## Summary

Implements [Agent Heartbeat & Error Handling](../blob/main/spec/tickets/Agent_Heartbeat_&_Error_Handling.md) for the hashcat worker agent surface.

## Implementation units

- **U1** — `agentHeartbeatSchema` + `agentHeartbeatErrorSchema` + `agentHeartbeatCurrentTaskSchema` in `@hashhive/shared`; corresponding `AgentHeartbeatError` / `AgentHeartbeatCurrentTask` type exports.
- **U2/U3** — `processHeartbeat` refactored with a pure `decideHeartbeatTransition` decision helper, transactional persistence, ownership-checked task linkage, structured status-transition audit log, and post-commit event emission.
- **U4** — Route handler at `POST /api/v1/agent/heartbeat` flows the new schema through unchanged.
- **U5** — Pure-helper tests, schema-validation tests, and full integration coverage for the heartbeat path.

## Hardening applied during review (commits `ca6a144` -> `4c94b281e78d53d6c74cb98f92d97d66e26bb485`)

Every finding from the multi-agent review pass + CodeRabbit + the second-pass pr-review-toolkit run is addressed in-PR:

### Schema + DoS bounds
- Bound `error.message` at 4096 chars and `error.context` at 16 K serialized chars on both heartbeat and standalone `/errors` schemas.
- Documented size caps and the narrow `warning|fatal` enum on the OpenAPI spec.

### Logging + visibility
- Structured `logger.info` audit line on every real status transition; suppressed on no-op heartbeats.
- `logger.warn` when a heartbeat arrives for a vanished agent row.
- `logger.error` when `agent_errors` INSERT returns no row.
- `logger.warn` when `currentTask.taskId` is not owned by the calling agent (drops the task linkage).
- `logger.error` when `handleTaskFailure` throws mid-loop (continue-on-error preserves sibling tasks).

### Security
- PII scrubber (`scrubAgentErrorContext`) redacts `/token|password|secret|api[_-]?key|authorization|cookie|bearer/i` keys server-side before persisting.
- `currentTask.taskId` is verified against `tasks WHERE id=? AND agent_id=?` before persistence so a compromised agent token cannot attribute errors to another agent's tasks.
- FK on `agent_errors.task_id` (ON DELETE SET NULL) as last-line guard; migration 0007 backfills orphan refs before attaching.
- Fatal-heartbeat recovery: split agent-token middleware into strict (work endpoints) and recovery-friendly (`requireAgentTokenAllowRecovery`, heartbeat-only) variants so an errored agent can self-recover via a clean heartbeat.

### Atomicity + correctness
- `db.transaction` wraps the heartbeat-error INSERT + agents UPDATE; `SELECT ... FOR UPDATE` on the agent row closes the TOCTOU race on prior-status read.
- Event emits (`emitAgentError`, `emitAgentStatus`) fire AFTER the transaction commits so SSE clients never see rolled-back state.
- Fatal task-failure loop wraps each `handleTaskFailure` in try/catch; partial failures surface in the response as `{attempted, failed}`.
- `HeartbeatTransition` refactored to a discriminated union (`kind: 'noop' | 'transition'`); invalid combinations are compile errors and the call-site triple guard collapses to one kind check.

### Type tightening
- `decideHeartbeatTransition` parameter and `HeartbeatTransition.effectiveStatus` use the `AgentHeartbeat['status']` literal union — status typos at call sites are compile errors.
- `errorSeverity` parameter typed via `AgentHeartbeatError['severity']`.

### Contract + ergonomics
- All agent-API zValidator failures return the documented `{error: {code: 'VALIDATION_ERROR', message}}` envelope via a centralized `agentValidationHook`.
- Mock-leak fix: contract test re-exports the real `decideHeartbeatTransition`, `classifyWorstSeverity`, `classifyRecentErrors`, `pickCurrentTaskByAgent`, and `scrubAgentErrorContext` from its `mock.module` factory to avoid Linux-vs-macOS load-order CI flakes (GOTCHAS.md pattern).
- `logAgentError` accepts an optional drizzle client (so it can participate in an outer transaction) and an optional `projectId` pass-through (so `processHeartbeat` skips the redundant SELECT).

### OpenAPI spec
- `Heartbeat` schema documents `currentTask`, `error`, the narrow severity enum, size caps, the non-redundant heartbeat-vs-`/errors` contract, and the recovery path.

## Test coverage

| Phase | Tests | Notes |
|-------|-------|-------|
| Main suite | 372 pass / 0 fail / 15 skip | Unit + route contract |
| Heartbeat integration (`AGENT_HEARTBEAT_TEST_ISOLATED=1`) | 9 pass | Full `processHeartbeat` path with mocked drizzle; 1:1 mapped to plan U5 |
| Tasks isolated | 22 pass | Existing |
| Queue-manager isolated | 19 pass | Existing |
| Control-RBAC isolated | 3 pass | Existing |
| Health-deterministic isolated | 9 pass | Existing |

Plan U5 scenarios covered by the new `tests/integration/agent-heartbeat.test.ts`:
- warning persistence (R3/R4)
- fatal → `handleTaskFailure` invocation (R3/R4/R5)
- fatal with no active tasks (R5 edge)
- transition log fires once on real transition (R2)
- no transition log on no-op heartbeat (R2)
- `currentTask.taskId` carryover when owned
- `currentTask.taskId` dropped when not owned (with audit log)
- mid-loop `handleTaskFailure` throw doesn't strand siblings
- `error.context` PII scrub before persistence

## Test plan

- [x] `just check` (format, lint, type-check, build) — clean
- [x] `just ci-check` (full test suite on top of check) — 372 main + 9 heartbeat integration + 53 other isolated = 396 total, 0 fail, 15 skip
- [x] Plan U5 integration tests — covered (see table above)
- [x] Manual exercise against a local dev server — heartbeat with no error / warning / fatal / malformed all behave as specified

## Refs

- Spec: `spec/tickets/Agent_Heartbeat_&_Error_Handling.md`
- Plan: `docs/plans/2026-05-16-001-feat-agent-heartbeat-error-handling-plan.md` (gitignored)
- Migration: `packages/shared/src/db/migrations/0007_light_ulik.sql`