### PR TITLE
feat(tasks): retry budget and capability-filtered heartbeat hints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ Users issue and rotate Control API keys from the dashboard Account page (`/accou
 - Prefer mermaid diagrams for architectural or sequence diagrams in documentation.
 - Agents (hashcat workers) are the primary API consumer. Never break the agent API to improve the dashboard experience.
 - **Wire shapes live in `@hashhive/shared` as `z.infer` from Zod schemas.** Do not declare local TypeScript interfaces in `packages/backend/src/services/*` or `packages/frontend/src/hooks/*` for shapes that cross the API boundary — add a schema to `packages/shared/src/schemas/index.ts`, export the `z.infer<...>` type from `packages/shared/src/types/index.ts`, and import. The same rule applies to test fixtures (`tests/fixtures/api-responses.ts`).
+- **Keep the OpenAPI spec in sync with shared types.** When adding or changing a field on a shape that crosses the agent/dashboard/control API boundary, update the corresponding `packages/openapi/*.yaml` schema (properties + `required` list) and the contract test in the same change — generated clients rely on the spec, not the TypeScript type.
 
 ## Validation Gates (MANDATORY)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,11 @@ This file provides AI coding assistants with project context. All substantive do
 - **[Documented Solutions](./docs/solutions/)** -- searchable knowledge store of past problems (bugs, best practices, workflow patterns), organized by category with YAML frontmatter (`module`, `tags`, `problem_type`). Relevant when implementing or debugging in documented areas.
 - **[Frontend Design Context](./.impeccable.md)** -- users, brand personality, aesthetic direction, anti-references, and the five design principles every UI surface must follow. Read before any frontend visual work.
 
+## Planning & Status
+
+- **[STRATEGY.md](./STRATEGY.md)** -- target problem, approach, primary persona, the five key metrics, and the four investment tracks. Read before proposing scope changes or new features.
+- **[BACKLOG.md](./BACKLOG.md)** -- authoritative status of remaining work. Phase 1 is the 11 unfinished `spec/tickets/`; Phase 2 is the open GitHub issue backlog (#97-#124, grouped under epics #117-#121). Do NOT infer ticket completion from matching commit titles or file existence -- BACKLOG.md is the source of truth.
+
 ## API Surfaces
 
 HashHive exposes three distinct API surfaces, each with its own auth, error envelope, and pagination shape:

--- a/packages/backend/src/queue/manager.ts
+++ b/packages/backend/src/queue/manager.ts
@@ -12,6 +12,16 @@ export interface QueueHealth {
 }
 
 /**
+ * Heartbeat-monitor scheduler cadence. Must stay strictly shorter than the
+ * 5-minute offline threshold in `queue/workers/heartbeat-monitor.ts` and
+ * the 5-minute default `staleThresholdMs` in `services/tasks.ts` so a
+ * stale task is caught within roughly one tick after it crosses the
+ * threshold. Increasing this without bumping the assigned-at floor in
+ * `reassignStaleTasks` would reintroduce the first-heartbeat race.
+ */
+export const HEARTBEAT_SCHEDULER_INTERVAL_MS = 2 * 60 * 1000;
+
+/**
  * Manages BullMQ queues for the API process.
  * Responsible for enqueuing jobs and health reporting only.
  * Workers run in dedicated processes — see worker-*.ts entrypoints.
@@ -61,13 +71,13 @@ export class QueueManager {
       );
     }
 
-    // Schedule repeatable heartbeat monitor. Ticket #119 sets the cadence at
-    // 2 minutes so the stale-task sweep matches the agent offline threshold.
+    // Schedule repeatable heartbeat monitor. See HEARTBEAT_SCHEDULER_INTERVAL_MS
+    // for the rationale on the relationship to the offline threshold.
     const heartbeatQueue = this.queues.get(QUEUE_NAMES.HEARTBEAT_MONITOR);
     if (heartbeatQueue) {
       await heartbeatQueue.upsertJobScheduler(
         'heartbeat-check',
-        { every: 2 * 60 * 1000 },
+        { every: HEARTBEAT_SCHEDULER_INTERVAL_MS },
         { data: { triggeredAt: new Date().toISOString() } }
       );
     }

--- a/packages/backend/src/queue/manager.ts
+++ b/packages/backend/src/queue/manager.ts
@@ -59,12 +59,13 @@ export class QueueManager {
       );
     }
 
-    // Schedule repeatable heartbeat monitor
+    // Schedule repeatable heartbeat monitor. Ticket #119 sets the cadence at
+    // 2 minutes so the stale-task sweep matches the agent offline threshold.
     const heartbeatQueue = this.queues.get(QUEUE_NAMES.HEARTBEAT_MONITOR);
     if (heartbeatQueue) {
       await heartbeatQueue.upsertJobScheduler(
         'heartbeat-check',
-        { every: 60_000 },
+        { every: 2 * 60 * 1000 },
         { data: { triggeredAt: new Date().toISOString() } }
       );
     }

--- a/packages/backend/src/queue/manager.ts
+++ b/packages/backend/src/queue/manager.ts
@@ -55,7 +55,9 @@ export class QueueManager {
       // Cast needed: our ioredis version may differ from BullMQ's bundled ioredis types
       this.queues.set(
         name,
-        new Queue(name, { connection: this.connection as unknown as ConnectionOptions })
+        new Queue(name, {
+          connection: this.connection as unknown as ConnectionOptions,
+        })
       );
     }
 

--- a/packages/backend/src/queue/workers/heartbeat-monitor.ts
+++ b/packages/backend/src/queue/workers/heartbeat-monitor.ts
@@ -54,8 +54,29 @@ export function createHeartbeatMonitorWorker(connection: Redis): Worker<Heartbea
       // Reassign tasks from offline agents
       const result = await reassignStaleTasks();
 
-      if (result.reassigned > 0) {
-        logger.info({ reassigned: result.reassigned }, 'Reassigned stale tasks');
+      // Surface every non-zero counter so terminal failures and per-task
+      // errors are observable in operator logs, not buried in task rows.
+      const anyMovement =
+        result.reassigned > 0 ||
+        result.rebalanced > 0 ||
+        result.failedOverrun > 0 ||
+        result.failedMaxRetries > 0 ||
+        result.errored > 0;
+      if (anyMovement) {
+        const isWarn =
+          result.failedOverrun > 0 || result.failedMaxRetries > 0 || result.errored > 0;
+        const summary = {
+          reassigned: result.reassigned,
+          rebalanced: result.rebalanced,
+          failedOverrun: result.failedOverrun,
+          failedMaxRetries: result.failedMaxRetries,
+          errored: result.errored,
+        };
+        if (isWarn) {
+          logger.warn(summary, 'Stale task sweep summary');
+        } else {
+          logger.info(summary, 'Stale task sweep summary');
+        }
       }
 
       return { ...result, offlineAgents: staleAgents.length };

--- a/packages/backend/src/services/agents.ts
+++ b/packages/backend/src/services/agents.ts
@@ -356,35 +356,78 @@ export function decideHeartbeatTransition(input: {
  * `getAgentBenchmarkForMode` from this module). We resolve the module
  * once on first use and cache the function reference so every
  * subsequent fatal heartbeat skips the import-resolution roundtrip.
+ *
+ * Returns `null` (and logs) on import failure or unexpected export shape
+ * so callers can degrade gracefully instead of bubbling a 500 to the
+ * agent — the heartbeat must stay alive so the agent can keep checking
+ * in even if a downstream module is misbehaving.
  */
 let cachedHandleTaskFailure: typeof import('./tasks.js').handleTaskFailure | null = null;
 
-async function getHandleTaskFailure(): Promise<typeof import('./tasks.js').handleTaskFailure> {
-  if (cachedHandleTaskFailure === null) {
-    const mod = await import('./tasks.js');
-    cachedHandleTaskFailure = mod.handleTaskFailure;
+async function getHandleTaskFailure(): Promise<
+  typeof import('./tasks.js').handleTaskFailure | null
+> {
+  if (cachedHandleTaskFailure != null) {
+    return cachedHandleTaskFailure;
   }
-  return cachedHandleTaskFailure;
+  try {
+    const mod = await import('./tasks.js');
+    if (typeof mod.handleTaskFailure !== 'function') {
+      logger.error(
+        { exportType: typeof mod.handleTaskFailure },
+        'handleTaskFailure export is not a function — possible circular-import edge'
+      );
+      return null;
+    }
+    cachedHandleTaskFailure = mod.handleTaskFailure;
+    return cachedHandleTaskFailure;
+  } catch (err) {
+    logger.error({ err }, 'Failed to lazy-import handleTaskFailure from ./tasks.js');
+    return null;
+  }
 }
 
 /**
  * Lazy reference to `buildCapabilityPredicate` from `./tasks.js`. Same
  * circular-import workaround as `getHandleTaskFailure` above — the heartbeat
  * high-priority check must filter against the agent's capabilities so we
- * never tell an agent to ask for work it cannot actually claim.
+ * never tell an agent to ask for work it cannot actually claim. Returns
+ * `null` on import failure so the caller can degrade by omitting the
+ * high-priority hint rather than 500-ing the heartbeat.
  */
 let cachedBuildCapabilityPredicate: typeof import('./tasks.js').buildCapabilityPredicate | null =
   null;
 
 async function getBuildCapabilityPredicate(): Promise<
-  typeof import('./tasks.js').buildCapabilityPredicate
+  typeof import('./tasks.js').buildCapabilityPredicate | null
 > {
-  if (cachedBuildCapabilityPredicate === null) {
-    const mod = await import('./tasks.js');
-    cachedBuildCapabilityPredicate = mod.buildCapabilityPredicate;
+  if (cachedBuildCapabilityPredicate != null) {
+    return cachedBuildCapabilityPredicate;
   }
-  return cachedBuildCapabilityPredicate;
+  try {
+    const mod = await import('./tasks.js');
+    if (typeof mod.buildCapabilityPredicate !== 'function') {
+      logger.error(
+        { exportType: typeof mod.buildCapabilityPredicate },
+        'buildCapabilityPredicate export is not a function — possible circular-import edge'
+      );
+      return null;
+    }
+    cachedBuildCapabilityPredicate = mod.buildCapabilityPredicate;
+    return cachedBuildCapabilityPredicate;
+  } catch (err) {
+    logger.error({ err }, 'Failed to lazy-import buildCapabilityPredicate from ./tasks.js');
+    return null;
+  }
 }
+
+/**
+ * Once-per-agent guard for the "empty/malformed capabilities" warn. The
+ * Set lives for the process lifetime so a noisy agent doesn't flood logs
+ * each heartbeat. Operators see one warn per agent until the agent
+ * announces real capabilities.
+ */
+const warnedEmptyCapsAgentIds = new Set<number>();
 
 function logStatusTransition(opts: {
   agentId: number;
@@ -647,15 +690,29 @@ export async function processHeartbeat(agentId: number, data: AgentHeartbeat) {
 
     const handleTaskFailure = await getHandleTaskFailure();
     let failed = 0;
-    for (const activeTask of activeTasks) {
-      try {
-        await handleTaskFailure(activeTask.id, agentId, data.error?.message ?? 'Agent fatal error');
-      } catch (err) {
-        failed += 1;
-        logger.error(
-          { err, agentId, taskId: activeTask.id },
-          'handleTaskFailure threw during fatal-heartbeat fan-out; sibling tasks continue'
-        );
+    if (handleTaskFailure === null) {
+      // Lazy import failed - count every active task as failed-to-fail so the
+      // summary still gives operators a non-zero failure count to investigate.
+      failed = activeTasks.length;
+      logger.error(
+        { agentId, attempted: activeTasks.length },
+        'handleTaskFailure unavailable on fatal heartbeat; active tasks left in their current status until the sweep reaps them'
+      );
+    } else {
+      for (const activeTask of activeTasks) {
+        try {
+          await handleTaskFailure(
+            activeTask.id,
+            agentId,
+            data.error?.message ?? 'Agent fatal error'
+          );
+        } catch (err) {
+          failed += 1;
+          logger.error(
+            { err, agentId, taskId: activeTask.id },
+            'handleTaskFailure threw during fatal-heartbeat fan-out; sibling tasks continue'
+          );
+        }
       }
     }
     taskFailureSummary = { attempted: activeTasks.length, failed };
@@ -665,25 +722,53 @@ export async function processHeartbeat(agentId: number, data: AgentHeartbeat) {
   // Filter against the agent's capabilities so we don't tell an agent to ask
   // for work it cannot actually claim — buildCapabilityPredicate matches the
   // SQL filter assignNextTask uses for the real claim.
+  //
+  // Gated on online/benchmarked status because assignNextTask refuses to
+  // assign to any other status, so suggesting work to an agent in 'error'
+  // or 'offline' is both useless and misleading.
   let hasHighPriorityTasks = false;
-  if (updated) {
-    const buildCapabilityPredicate = await getBuildCapabilityPredicate();
-    const agentCaps = (updated.capabilities ?? {}) as Record<string, unknown>;
-    const capabilityPredicate = buildCapabilityPredicate(agentCaps);
-    const [highPriority] = await db
-      .select({ id: tasks.id })
-      .from(tasks)
-      .innerJoin(campaigns, eq(tasks.campaignId, campaigns.id))
-      .where(
-        and(
-          eq(tasks.status, 'pending'),
-          eq(campaigns.projectId, updated.projectId),
-          sql`${campaigns.priority} <= 1`,
-          capabilityPredicate
-        )
-      )
-      .limit(1);
-    hasHighPriorityTasks = !!highPriority;
+  const isClaimEligible = updated?.status === 'online' || updated?.status === 'benchmarked';
+  if (updated && isClaimEligible) {
+    const rawCaps = updated.capabilities;
+    const capsIsObject = rawCaps !== null && typeof rawCaps === 'object' && !Array.isArray(rawCaps);
+    if (!capsIsObject) {
+      // Empty / malformed capabilities means the predicate would silently
+      // exclude every real task (every hashcat task has a hashcatMode
+      // requirement). Warn once per agent so operators can see the agent
+      // hasn't announced yet, then skip the lookup.
+      if (!warnedEmptyCapsAgentIds.has(agentId)) {
+        warnedEmptyCapsAgentIds.add(agentId);
+        logger.warn(
+          { agentId, capabilitiesType: rawCaps === null ? 'null' : typeof rawCaps },
+          'Agent has empty or non-object capabilities — high-priority hint disabled until announce'
+        );
+      }
+    } else {
+      const buildCapabilityPredicate = await getBuildCapabilityPredicate();
+      if (buildCapabilityPredicate === null) {
+        // Lazy import failed; degrade by omitting the hint. The agent will
+        // still pick up work through the normal claim path on the next
+        // /tasks/next call — the hint is a latency optimization, not a
+        // correctness requirement.
+      } else {
+        const agentCaps = rawCaps as Record<string, unknown>;
+        const capabilityPredicate = buildCapabilityPredicate(agentCaps);
+        const [highPriority] = await db
+          .select({ id: tasks.id })
+          .from(tasks)
+          .innerJoin(campaigns, eq(tasks.campaignId, campaigns.id))
+          .where(
+            and(
+              eq(tasks.status, 'pending'),
+              eq(campaigns.projectId, updated.projectId),
+              sql`${campaigns.priority} <= 1`,
+              capabilityPredicate
+            )
+          )
+          .limit(1);
+        hasHighPriorityTasks = !!highPriority;
+      }
+    }
   }
 
   return {

--- a/packages/backend/src/services/agents.ts
+++ b/packages/backend/src/services/agents.ts
@@ -429,6 +429,17 @@ async function getBuildCapabilityPredicate(): Promise<
  */
 const warnedEmptyCapsAgentIds = new Set<number>();
 
+/**
+ * Test-only reset for the warned-agent guard. Integration tests that
+ * exercise the empty-capabilities path within a single process need to
+ * reach the warn branch repeatedly with the same mock agent id; this
+ * keeps the production guard intact while letting tests start each case
+ * from a known empty state.
+ */
+export function __resetWarnedEmptyCapsForTesting(): void {
+  warnedEmptyCapsAgentIds.clear();
+}
+
 function logStatusTransition(opts: {
   agentId: number;
   projectId: number;
@@ -731,15 +742,30 @@ export async function processHeartbeat(agentId: number, data: AgentHeartbeat) {
   if (updated && isClaimEligible) {
     const rawCaps = updated.capabilities;
     const capsIsObject = rawCaps !== null && typeof rawCaps === 'object' && !Array.isArray(rawCaps);
-    if (!capsIsObject) {
-      // Empty / malformed capabilities means the predicate would silently
-      // exclude every real task (every hashcat task has a hashcatMode
-      // requirement). Warn once per agent so operators can see the agent
-      // hasn't announced yet, then skip the lookup.
+    // An agent that has not yet announced is operationally equivalent to one
+    // with malformed capabilities: `buildCapabilityPredicate` would emit a
+    // filter that excludes every real hashcat task (every task carries a
+    // `hashcatMode` requirement), so the hint silently zero-matches AND we
+    // pay for an extra DB join per heartbeat. Treat "no usable hashModes"
+    // (missing key, empty array, or all-invalid entries) the same as
+    // null/non-object: warn once, skip the lookup.
+    const hasUsableHashModes =
+      capsIsObject &&
+      Array.isArray((rawCaps as Record<string, unknown>)['hashModes']) &&
+      ((rawCaps as Record<string, unknown>)['hashModes'] as unknown[]).some((m) => {
+        const n = Number(m);
+        return Number.isFinite(n) && Number.isInteger(n);
+      });
+    if (!capsIsObject || !hasUsableHashModes) {
       if (!warnedEmptyCapsAgentIds.has(agentId)) {
         warnedEmptyCapsAgentIds.add(agentId);
+        const capabilitiesType = !capsIsObject
+          ? rawCaps === null
+            ? 'null'
+            : typeof rawCaps
+          : 'object-without-usable-hashModes';
         logger.warn(
-          { agentId, capabilitiesType: rawCaps === null ? 'null' : typeof rawCaps },
+          { agentId, capabilitiesType },
           'Agent has empty or non-object capabilities — high-priority hint disabled until announce'
         );
       }

--- a/packages/backend/src/services/agents.ts
+++ b/packages/backend/src/services/agents.ts
@@ -360,6 +360,25 @@ async function getHandleTaskFailure(): Promise<typeof import('./tasks.js').handl
   return cachedHandleTaskFailure;
 }
 
+/**
+ * Lazy reference to `buildCapabilityPredicate` from `./tasks.js`. Same
+ * circular-import workaround as `getHandleTaskFailure` above — the heartbeat
+ * high-priority check must filter against the agent's capabilities so we
+ * never tell an agent to ask for work it cannot actually claim.
+ */
+let cachedBuildCapabilityPredicate: typeof import('./tasks.js').buildCapabilityPredicate | null =
+  null;
+
+async function getBuildCapabilityPredicate(): Promise<
+  typeof import('./tasks.js').buildCapabilityPredicate
+> {
+  if (cachedBuildCapabilityPredicate === null) {
+    const mod = await import('./tasks.js');
+    cachedBuildCapabilityPredicate = mod.buildCapabilityPredicate;
+  }
+  return cachedBuildCapabilityPredicate;
+}
+
 function logStatusTransition(opts: {
   agentId: number;
   projectId: number;
@@ -635,9 +654,15 @@ export async function processHeartbeat(agentId: number, data: AgentHeartbeat) {
     taskFailureSummary = { attempted: activeTasks.length, failed };
   }
 
-  // Check if there are high-priority pending tasks for this agent's project
+  // Check if there are high-priority pending tasks for this agent's project.
+  // Filter against the agent's capabilities so we don't tell an agent to ask
+  // for work it cannot actually claim — buildCapabilityPredicate matches the
+  // SQL filter assignNextTask uses for the real claim.
   let hasHighPriorityTasks = false;
   if (updated) {
+    const buildCapabilityPredicate = await getBuildCapabilityPredicate();
+    const agentCaps = (updated.capabilities ?? {}) as Record<string, unknown>;
+    const capabilityPredicate = buildCapabilityPredicate(agentCaps);
     const [highPriority] = await db
       .select({ id: tasks.id })
       .from(tasks)
@@ -646,7 +671,8 @@ export async function processHeartbeat(agentId: number, data: AgentHeartbeat) {
         and(
           eq(tasks.status, 'pending'),
           eq(campaigns.projectId, updated.projectId),
-          sql`${campaigns.priority} <= 1`
+          sql`${campaigns.priority} <= 1`,
+          capabilityPredicate
         )
       )
       .limit(1);

--- a/packages/backend/src/services/agents.ts
+++ b/packages/backend/src/services/agents.ts
@@ -71,7 +71,10 @@ export function classifyRecentErrors(rows: { severity: string }[]): {
     if (isFatal) hasFatal = true;
     if (isWarning) hasWarning = true;
   }
-  return { count, worstSeverity: classifyWorstSeverity({ hasFatal, hasWarning }) };
+  return {
+    count,
+    worstSeverity: classifyWorstSeverity({ hasFatal, hasWarning }),
+  };
 }
 
 interface ActiveTaskRow {
@@ -297,7 +300,11 @@ type ResolvedStatusLiteral = HeartbeatStatusLiteral | 'error';
  * makes `fromStatus` / `reason` available only when they're meaningful.
  */
 export type HeartbeatTransition =
-  | { kind: 'noop'; effectiveStatus: ResolvedStatusLiteral; isFatalError: boolean }
+  | {
+      kind: 'noop';
+      effectiveStatus: ResolvedStatusLiteral;
+      isFatalError: boolean;
+    }
   | {
       kind: 'transition';
       effectiveStatus: ResolvedStatusLiteral;

--- a/packages/backend/src/services/tasks.ts
+++ b/packages/backend/src/services/tasks.ts
@@ -592,7 +592,11 @@ export async function updateTaskProgress(
   // Insert cracked hash results if submitted
   if (data.results && data.results.length > 0 && !taskRow.hashListId) {
     logger.error(
-      { taskId, campaignId: taskRow.campaignId, resultCount: data.results.length },
+      {
+        taskId,
+        campaignId: taskRow.campaignId,
+        resultCount: data.results.length,
+      },
       'Cannot store crack results: campaign has no associated hash list'
     );
   }
@@ -628,7 +632,13 @@ export async function updateTaskProgress(
       emitCrackResult(taskRow.projectId, taskRow.hashListId, data.results.length);
     } catch (err) {
       logger.error(
-        { err, taskId, agentId, hashListId: taskRow.hashListId, resultCount: data.results.length },
+        {
+          err,
+          taskId,
+          agentId,
+          hashListId: taskRow.hashListId,
+          resultCount: data.results.length,
+        },
         'Failed to insert crack results'
       );
       return { error: 'Failed to store crack results' };

--- a/packages/backend/src/services/tasks.ts
+++ b/packages/backend/src/services/tasks.ts
@@ -275,7 +275,7 @@ export async function generateTasksForAttack(
  * - GPU requirement: task requires `gpu: true` → agent capabilities must contain `{"gpu": true}`
  * - Hash mode compatibility: task's `hashcatMode` value must be in agent's `hashModes` array
  */
-function buildCapabilityPredicate(agentCaps: Record<string, unknown>): SQL {
+export function buildCapabilityPredicate(agentCaps: Record<string, unknown>): SQL {
   const hasGpu = agentCaps['gpu'] === true;
   const rawHashModes = Array.isArray(agentCaps['hashModes']) ? agentCaps['hashModes'] : [];
   // Sanitize to finite integers only — NaN, Infinity, non-numeric strings are dropped
@@ -433,7 +433,8 @@ export async function assignNextTask(agentId: number): Promise<AssignedTask | nu
     RETURNING ${tasks.id}, ${tasks.attackId}, ${tasks.campaignId}, ${tasks.agentId},
               ${tasks.status}, ${tasks.workRange}, ${tasks.progress}, ${tasks.resultStats},
               ${tasks.requiredCapabilities}, ${tasks.assignedAt}, ${tasks.startedAt},
-              ${tasks.completedAt}, ${tasks.failureReason}, ${tasks.createdAt}, ${tasks.updatedAt}
+              ${tasks.completedAt}, ${tasks.failureReason}, ${tasks.retryCount},
+              ${tasks.createdAt}, ${tasks.updatedAt}
   `);
 
   const row = result[0] as Record<string, unknown> | undefined;
@@ -518,6 +519,7 @@ export async function assignNextTask(agentId: number): Promise<AssignedTask | nu
     startedAt: row['started_at'] as Date | null,
     completedAt: row['completed_at'] as Date | null,
     failureReason: row['failure_reason'] as string | null,
+    retryCount: row['retry_count'] as number,
     createdAt: row['created_at'] as Date,
     updatedAt: row['updated_at'] as Date,
   };
@@ -659,7 +661,7 @@ export async function handleTaskFailure(taskId: number, agentId: number, reason:
   }
 
   const resultStats = (task.resultStats as Record<string, unknown>) ?? {};
-  const retryCount = (resultStats['retryCount'] as number) ?? 0;
+  const retryCount = task.retryCount ?? 0;
 
   // Derive projectId from the campaign for event emission
   const [campaign] = await db
@@ -678,7 +680,8 @@ export async function handleTaskFailure(taskId: number, agentId: number, reason:
         assignedAt: null,
         startedAt: null,
         failureReason: reason,
-        resultStats: { ...resultStats, retryCount: retryCount + 1, lastFailure: reason },
+        retryCount: retryCount + 1,
+        resultStats: { ...resultStats, lastFailure: reason },
         updatedAt: new Date(),
       })
       .where(and(eq(tasks.id, taskId), eq(tasks.agentId, agentId)))
@@ -703,7 +706,7 @@ export async function handleTaskFailure(taskId: number, agentId: number, reason:
       status: 'failed',
       failureReason: reason,
       completedAt: new Date(),
-      resultStats: { ...resultStats, retryCount, lastFailure: reason },
+      resultStats: { ...resultStats, lastFailure: reason },
       updatedAt: new Date(),
     })
     .where(eq(tasks.id, taskId))
@@ -779,9 +782,9 @@ export async function reassignStaleTasks(staleThresholdMs = 5 * 60 * 1000) {
   const threshold = new Date(Date.now() - staleThresholdMs);
 
   // Find tasks assigned to agents that haven't checked in. Carry workRange,
-  // progress, projectId, and campaignId so the rebalance branches don't
-  // need extra queries to publish task_update events or update the
-  // campaign progress aggregate.
+  // progress, projectId, campaignId, and retryCount so the rebalance branches
+  // don't need extra queries to publish task_update events, update the
+  // campaign progress aggregate, or gate on the retry budget.
   const staleTasks = await db
     .select({
       taskId: tasks.id,
@@ -790,6 +793,7 @@ export async function reassignStaleTasks(staleThresholdMs = 5 * 60 * 1000) {
       workRange: tasks.workRange,
       progress: tasks.progress,
       projectId: campaigns.projectId,
+      retryCount: tasks.retryCount,
     })
     .from(tasks)
     .innerJoin(agents, eq(tasks.agentId, agents.id))
@@ -802,18 +806,24 @@ export async function reassignStaleTasks(staleThresholdMs = 5 * 60 * 1000) {
         // values from the agent API, leaving stranded in-progress work
         // un-rebalanced.
         sql`${tasks.status} IN ('assigned', 'running')`,
-        sql`${agents.lastSeenAt} < ${threshold}`
+        sql`${agents.lastSeenAt} < ${threshold}`,
+        // Guard against reaping a task the agent only just claimed after a
+        // stale heartbeat — without this, a slow first-heartbeat after
+        // assignment would race the sweep and yank the task back.
+        sql`${tasks.assignedAt} < ${threshold}`
       )
     );
 
   let reassigned = 0;
   let rebalanced = 0;
   let failedOverrun = 0;
+  let failedMaxRetries = 0;
   for (const staleTask of staleTasks) {
     const start = readWorkRangeField(staleTask.workRange, 'start');
     const end = readWorkRangeField(staleTask.workRange, 'end');
     const total = end > start ? end - start : 0n;
     const keyspaceProgress = readKeyspaceProgress(staleTask.progress);
+    const exceededRetries = (staleTask.retryCount ?? 0) >= MAX_RETRIES;
 
     if (keyspaceProgress >= total && total > 0n) {
       // Agent reported as-much-or-more work than the chunk contains. Either
@@ -841,6 +851,27 @@ export async function reassignStaleTasks(staleThresholdMs = 5 * 60 * 1000) {
     }
 
     if (keyspaceProgress > 0n && keyspaceProgress < total) {
+      if (exceededRetries) {
+        // Retry budget exhausted - permanent fail. Mirrors handleTaskFailure's
+        // terminal branch; keep agentId so operators can still see which agent
+        // dropped the task.
+        await db
+          .update(tasks)
+          .set({
+            status: 'failed',
+            failureReason: 'max_retries_exceeded',
+            completedAt: new Date(),
+            updatedAt: new Date(),
+          })
+          .where(eq(tasks.id, staleTask.taskId));
+        emitTaskUpdate(staleTask.projectId, staleTask.taskId, 'failed', {
+          campaignId: staleTask.campaignId,
+        });
+        await updateCampaignProgress(staleTask.campaignId);
+        failedMaxRetries++;
+        continue;
+      }
+
       // Partial progress - trim workRange.start forward and re-pend.
       const newStart = start + keyspaceProgress;
       const newTotal = end - newStart;
@@ -867,6 +898,7 @@ export async function reassignStaleTasks(staleThresholdMs = 5 * 60 * 1000) {
             total: jsonSafeBigint(newTotal),
           },
           progress: carriedProgress,
+          retryCount: sql`${tasks.retryCount} + 1`,
           updatedAt: new Date(),
         })
         .where(eq(tasks.id, staleTask.taskId));
@@ -878,6 +910,25 @@ export async function reassignStaleTasks(staleThresholdMs = 5 * 60 * 1000) {
       continue;
     }
 
+    if (exceededRetries) {
+      // 0% / unreadable progress but retry budget exhausted - permanent fail.
+      await db
+        .update(tasks)
+        .set({
+          status: 'failed',
+          failureReason: 'max_retries_exceeded',
+          completedAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .where(eq(tasks.id, staleTask.taskId));
+      emitTaskUpdate(staleTask.projectId, staleTask.taskId, 'failed', {
+        campaignId: staleTask.campaignId,
+      });
+      await updateCampaignProgress(staleTask.campaignId);
+      failedMaxRetries++;
+      continue;
+    }
+
     // 0% progress or unreadable range - reset to pending unchanged.
     await db
       .update(tasks)
@@ -886,6 +937,7 @@ export async function reassignStaleTasks(staleThresholdMs = 5 * 60 * 1000) {
         agentId: null,
         assignedAt: null,
         startedAt: null,
+        retryCount: sql`${tasks.retryCount} + 1`,
         updatedAt: new Date(),
       })
       .where(eq(tasks.id, staleTask.taskId));
@@ -896,7 +948,7 @@ export async function reassignStaleTasks(staleThresholdMs = 5 * 60 * 1000) {
     reassigned++;
   }
 
-  return { reassigned, rebalanced, failedOverrun };
+  return { reassigned, rebalanced, failedOverrun, failedMaxRetries };
 }
 
 // ─── Task Queries ───────────────────────────────────────────────────

--- a/packages/backend/src/services/tasks.ts
+++ b/packages/backend/src/services/tasks.ts
@@ -658,7 +658,13 @@ export async function updateTaskProgress(
 
 // ─── Task Retry & Failure Handling ──────────────────────────────────
 
-const MAX_RETRIES = 3;
+/**
+ * Maximum reassignment count before a task is permanently failed. A task
+ * with `retry_count >= MAX_RETRIES` reaching either failure path
+ * (`handleTaskFailure` or the stale-task sweep) is marked terminal.
+ * Exported so callers and tests can reason about the same bound.
+ */
+export const MAX_RETRIES = 3;
 
 export async function handleTaskFailure(taskId: number, agentId: number, reason: string) {
   const [task] = await db
@@ -671,7 +677,7 @@ export async function handleTaskFailure(taskId: number, agentId: number, reason:
   }
 
   const resultStats = (task.resultStats as Record<string, unknown>) ?? {};
-  const retryCount = task.retryCount ?? 0;
+  const { retryCount } = task;
 
   // Derive projectId from the campaign for event emission
   const [campaign] = await db
@@ -727,6 +733,11 @@ export async function handleTaskFailure(taskId: number, agentId: number, reason:
       agentId,
       campaignId: task.campaignId,
     });
+    // Permanent fail changes the active-task count for the campaign; refresh
+    // the aggregate so dashboards do not lag a sweep cycle. The sweep's
+    // terminal-fail branches already do this — keep the two failure paths
+    // symmetric so either subsystem keeps the aggregate honest.
+    await updateCampaignProgress(task.campaignId);
   }
 
   return { task: updated, retried: false };
@@ -772,6 +783,56 @@ function readWorkRangeField(workRange: unknown, key: string): bigint {
 }
 
 /**
+ * Stale-task descriptor carried through the sweep loop. Includes the
+ * agent's current ownership so per-task UPDATEs can be guarded against a
+ * concurrent sweep already reaping the same row.
+ */
+type StaleTaskRow = {
+  taskId: number;
+  agentId: number | null;
+  campaignId: number;
+  workRange: unknown;
+  progress: unknown;
+  projectId: number;
+  retryCount: number;
+};
+
+/**
+ * Permanently fail a stale task and notify listeners. Three branches in
+ * `reassignStaleTasks` reach a terminal state with the same row shape
+ * (`failed` + reason + completedAt + updatedAt); centralising the body
+ * keeps them from drifting.
+ *
+ * The UPDATE is guarded by `status IN ('assigned', 'running') AND
+ * agent_id = staleTask.agentId` so a concurrent sweep (e.g. transient
+ * overlap during a rolling deploy) cannot double-process the same row.
+ */
+async function terminalFailStaleTask(
+  staleTask: StaleTaskRow,
+  failureReason: 'keyspace_progress_overrun' | 'max_retries_exceeded'
+): Promise<void> {
+  await db
+    .update(tasks)
+    .set({
+      status: 'failed',
+      failureReason,
+      completedAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(tasks.id, staleTask.taskId),
+        sql`${tasks.status} IN ('assigned', 'running')`,
+        staleTask.agentId === null ? sql`TRUE` : eq(tasks.agentId, staleTask.agentId)
+      )
+    );
+  emitTaskUpdate(staleTask.projectId, staleTask.taskId, 'failed', {
+    campaignId: staleTask.campaignId,
+  });
+  await updateCampaignProgress(staleTask.campaignId);
+}
+
+/**
  * Reassigns tasks from agents that have gone offline. Called periodically
  * by a background job (every 2 minutes via BullMQ).
  *
@@ -787,6 +848,10 @@ function readWorkRangeField(workRange: unknown, key: string): bigint {
  *
  * 0% progress falls through to the existing reset-to-pending behavior
  * unchanged.
+ *
+ * Per-task processing is wrapped in try/catch so a transient failure on
+ * one stranded task (DB serialization, broadcast error, downstream throw)
+ * does not strand the rest of the batch until the next sweep tick.
  */
 export async function reassignStaleTasks(staleThresholdMs = 5 * 60 * 1000) {
   const threshold = new Date(Date.now() - staleThresholdMs);
@@ -819,8 +884,11 @@ export async function reassignStaleTasks(staleThresholdMs = 5 * 60 * 1000) {
         sql`${agents.lastSeenAt} < ${threshold}`,
         // Guard against reaping a task the agent only just claimed after a
         // stale heartbeat — without this, a slow first-heartbeat after
-        // assignment would race the sweep and yank the task back.
-        sql`${tasks.assignedAt} < ${threshold}`
+        // assignment would race the sweep and yank the task back. The
+        // IS NULL branch keeps legacy/migrated rows (status='assigned' with
+        // no assigned_at) selectable instead of stranding them forever
+        // (NULL < timestamp evaluates to NULL, which the filter rejects).
+        sql`(${tasks.assignedAt} IS NULL OR ${tasks.assignedAt} < ${threshold})`
       )
     );
 
@@ -828,73 +896,89 @@ export async function reassignStaleTasks(staleThresholdMs = 5 * 60 * 1000) {
   let rebalanced = 0;
   let failedOverrun = 0;
   let failedMaxRetries = 0;
+  let errored = 0;
   for (const staleTask of staleTasks) {
-    const start = readWorkRangeField(staleTask.workRange, 'start');
-    const end = readWorkRangeField(staleTask.workRange, 'end');
-    const total = end > start ? end - start : 0n;
-    const keyspaceProgress = readKeyspaceProgress(staleTask.progress);
-    const exceededRetries = (staleTask.retryCount ?? 0) >= MAX_RETRIES;
+    try {
+      const start = readWorkRangeField(staleTask.workRange, 'start');
+      const end = readWorkRangeField(staleTask.workRange, 'end');
+      const total = end > start ? end - start : 0n;
+      const keyspaceProgress = readKeyspaceProgress(staleTask.progress);
+      const exceededRetries = staleTask.retryCount >= MAX_RETRIES;
 
-    if (keyspaceProgress >= total && total > 0n) {
-      // Agent reported as-much-or-more work than the chunk contains. Either
-      // the agent finished the entire range but died before sending the
-      // completion message, or its report is malformed. Either way, the
-      // chunk did not flow through the normal completion path - mark
-      // failed so a fresh agent reruns the range rather than silently
-      // trusting an un-acked completion.
-      // Don't requeue - mark failed and let the campaign aggregate handle it.
-      await db
-        .update(tasks)
-        .set({
-          status: 'failed',
-          failureReason: 'keyspace_progress_overrun',
-          completedAt: new Date(),
-          updatedAt: new Date(),
-        })
-        .where(eq(tasks.id, staleTask.taskId));
-      emitTaskUpdate(staleTask.projectId, staleTask.taskId, 'failed', {
-        campaignId: staleTask.campaignId,
-      });
-      await updateCampaignProgress(staleTask.campaignId);
-      failedOverrun++;
-      continue;
-    }
+      if (keyspaceProgress >= total && total > 0n) {
+        // Agent reported as-much-or-more work than the chunk contains. Either
+        // the agent finished the entire range but died before sending the
+        // completion message, or its report is malformed. Either way, the
+        // chunk did not flow through the normal completion path - mark
+        // failed so a fresh agent reruns the range rather than silently
+        // trusting an un-acked completion.
+        await terminalFailStaleTask(staleTask, 'keyspace_progress_overrun');
+        failedOverrun++;
+        continue;
+      }
 
-    if (keyspaceProgress > 0n && keyspaceProgress < total) {
-      if (exceededRetries) {
-        // Retry budget exhausted - permanent fail. Mirrors handleTaskFailure's
-        // terminal branch; keep agentId so operators can still see which agent
-        // dropped the task.
+      if (keyspaceProgress > 0n && keyspaceProgress < total) {
+        if (exceededRetries) {
+          // Retry budget exhausted - permanent fail. Mirrors
+          // handleTaskFailure's terminal branch; keep agentId so operators
+          // can still see which agent dropped the task.
+          await terminalFailStaleTask(staleTask, 'max_retries_exceeded');
+          failedMaxRetries++;
+          continue;
+        }
+
+        // Partial progress - trim workRange.start forward and re-pend.
+        const newStart = start + keyspaceProgress;
+        const newTotal = end - newStart;
+        // Reset reported keyspaceProgress so the next agent starts from 0
+        // within the trimmed range, but preserve auxiliary samples (speed,
+        // temperature) so the dashboard's per-task telemetry doesn't
+        // momentarily blank out across a rebalance.
+        const priorProgress =
+          staleTask.progress && typeof staleTask.progress === 'object'
+            ? (staleTask.progress as Record<string, unknown>)
+            : {};
+        const carriedProgress: Record<string, unknown> = { ...priorProgress };
+        delete carriedProgress['keyspaceProgress'];
         await db
           .update(tasks)
           .set({
-            status: 'failed',
-            failureReason: 'max_retries_exceeded',
-            completedAt: new Date(),
+            status: 'pending',
+            agentId: null,
+            assignedAt: null,
+            startedAt: null,
+            workRange: {
+              start: jsonSafeBigint(newStart),
+              end: jsonSafeBigint(end),
+              total: jsonSafeBigint(newTotal),
+            },
+            progress: carriedProgress,
+            retryCount: sql`${tasks.retryCount} + 1`,
             updatedAt: new Date(),
           })
-          .where(eq(tasks.id, staleTask.taskId));
-        emitTaskUpdate(staleTask.projectId, staleTask.taskId, 'failed', {
+          .where(
+            and(
+              eq(tasks.id, staleTask.taskId),
+              sql`${tasks.status} IN ('assigned', 'running')`,
+              staleTask.agentId === null ? sql`TRUE` : eq(tasks.agentId, staleTask.agentId)
+            )
+          );
+        emitTaskUpdate(staleTask.projectId, staleTask.taskId, 'pending', {
           campaignId: staleTask.campaignId,
         });
         await updateCampaignProgress(staleTask.campaignId);
+        rebalanced++;
+        continue;
+      }
+
+      if (exceededRetries) {
+        // 0% / unreadable progress but retry budget exhausted - permanent fail.
+        await terminalFailStaleTask(staleTask, 'max_retries_exceeded');
         failedMaxRetries++;
         continue;
       }
 
-      // Partial progress - trim workRange.start forward and re-pend.
-      const newStart = start + keyspaceProgress;
-      const newTotal = end - newStart;
-      // Reset reported keyspaceProgress so the next agent starts from 0
-      // within the trimmed range, but preserve auxiliary samples (speed,
-      // temperature) so the dashboard's per-task telemetry doesn't
-      // momentarily blank out across a rebalance.
-      const priorProgress =
-        staleTask.progress && typeof staleTask.progress === 'object'
-          ? (staleTask.progress as Record<string, unknown>)
-          : {};
-      const carriedProgress: Record<string, unknown> = { ...priorProgress };
-      delete carriedProgress['keyspaceProgress'];
+      // 0% progress or unreadable range - reset to pending unchanged.
       await db
         .update(tasks)
         .set({
@@ -902,63 +986,37 @@ export async function reassignStaleTasks(staleThresholdMs = 5 * 60 * 1000) {
           agentId: null,
           assignedAt: null,
           startedAt: null,
-          workRange: {
-            start: jsonSafeBigint(newStart),
-            end: jsonSafeBigint(end),
-            total: jsonSafeBigint(newTotal),
-          },
-          progress: carriedProgress,
           retryCount: sql`${tasks.retryCount} + 1`,
           updatedAt: new Date(),
         })
-        .where(eq(tasks.id, staleTask.taskId));
+        .where(
+          and(
+            eq(tasks.id, staleTask.taskId),
+            sql`${tasks.status} IN ('assigned', 'running')`,
+            staleTask.agentId === null ? sql`TRUE` : eq(tasks.agentId, staleTask.agentId)
+          )
+        );
       emitTaskUpdate(staleTask.projectId, staleTask.taskId, 'pending', {
         campaignId: staleTask.campaignId,
       });
       await updateCampaignProgress(staleTask.campaignId);
-      rebalanced++;
-      continue;
+      reassigned++;
+    } catch (err) {
+      errored += 1;
+      logger.error(
+        {
+          err,
+          taskId: staleTask.taskId,
+          agentId: staleTask.agentId,
+          campaignId: staleTask.campaignId,
+          projectId: staleTask.projectId,
+        },
+        'reassignStaleTasks: per-task processing threw — sibling stale tasks continue'
+      );
     }
-
-    if (exceededRetries) {
-      // 0% / unreadable progress but retry budget exhausted - permanent fail.
-      await db
-        .update(tasks)
-        .set({
-          status: 'failed',
-          failureReason: 'max_retries_exceeded',
-          completedAt: new Date(),
-          updatedAt: new Date(),
-        })
-        .where(eq(tasks.id, staleTask.taskId));
-      emitTaskUpdate(staleTask.projectId, staleTask.taskId, 'failed', {
-        campaignId: staleTask.campaignId,
-      });
-      await updateCampaignProgress(staleTask.campaignId);
-      failedMaxRetries++;
-      continue;
-    }
-
-    // 0% progress or unreadable range - reset to pending unchanged.
-    await db
-      .update(tasks)
-      .set({
-        status: 'pending',
-        agentId: null,
-        assignedAt: null,
-        startedAt: null,
-        retryCount: sql`${tasks.retryCount} + 1`,
-        updatedAt: new Date(),
-      })
-      .where(eq(tasks.id, staleTask.taskId));
-    emitTaskUpdate(staleTask.projectId, staleTask.taskId, 'pending', {
-      campaignId: staleTask.campaignId,
-    });
-    await updateCampaignProgress(staleTask.campaignId);
-    reassigned++;
   }
 
-  return { reassigned, rebalanced, failedOverrun, failedMaxRetries };
+  return { reassigned, rebalanced, failedOverrun, failedMaxRetries, errored };
 }
 
 // ─── Task Queries ───────────────────────────────────────────────────

--- a/packages/backend/src/services/tasks.ts
+++ b/packages/backend/src/services/tasks.ts
@@ -715,12 +715,17 @@ export async function handleTaskFailure(taskId: number, agentId: number, reason:
     return { task: updated, retried: true };
   }
 
-  // Max retries exceeded — mark as failed permanently
+  // Max retries exceeded — mark as failed permanently. Use the stable
+  // terminal code `max_retries_exceeded` so this row is distinguishable
+  // from a one-shot failure with the same underlying cause (the sweep's
+  // terminal branches use the same code). The agent-reported reason that
+  // tipped the task over the budget is preserved in resultStats.lastFailure
+  // for debugging.
   const [updated] = await db
     .update(tasks)
     .set({
       status: 'failed',
-      failureReason: reason,
+      failureReason: 'max_retries_exceeded',
       completedAt: new Date(),
       resultStats: { ...resultStats, lastFailure: reason },
       updatedAt: new Date(),

--- a/packages/backend/src/services/tasks.ts
+++ b/packages/backend/src/services/tasks.ts
@@ -721,6 +721,10 @@ export async function handleTaskFailure(taskId: number, agentId: number, reason:
   // terminal branches use the same code). The agent-reported reason that
   // tipped the task over the budget is preserved in resultStats.lastFailure
   // for debugging.
+  //
+  // Guard the UPDATE on agentId + status so a concurrent sweep that
+  // already reassigned this row cannot cause us to mark a now-unowned
+  // task as failed; only emit events when a row was actually updated.
   const [updated] = await db
     .update(tasks)
     .set({
@@ -730,7 +734,13 @@ export async function handleTaskFailure(taskId: number, agentId: number, reason:
       resultStats: { ...resultStats, lastFailure: reason },
       updatedAt: new Date(),
     })
-    .where(eq(tasks.id, taskId))
+    .where(
+      and(
+        eq(tasks.id, taskId),
+        eq(tasks.agentId, agentId),
+        sql`${tasks.status} IN ('assigned', 'running')`
+      )
+    )
     .returning();
 
   if (updated && campaign) {
@@ -811,12 +821,16 @@ type StaleTaskRow = {
  * The UPDATE is guarded by `status IN ('assigned', 'running') AND
  * agent_id = staleTask.agentId` so a concurrent sweep (e.g. transient
  * overlap during a rolling deploy) cannot double-process the same row.
+ * Returns `true` when the UPDATE actually changed a row; callers use
+ * this to gate the event broadcast and aggregate refresh so a no-op
+ * (row already swept by a peer) does not produce phantom transitions
+ * or skew sweep metrics.
  */
 async function terminalFailStaleTask(
   staleTask: StaleTaskRow,
   failureReason: 'keyspace_progress_overrun' | 'max_retries_exceeded'
-): Promise<void> {
-  await db
+): Promise<boolean> {
+  const updated = await db
     .update(tasks)
     .set({
       status: 'failed',
@@ -830,11 +844,16 @@ async function terminalFailStaleTask(
         sql`${tasks.status} IN ('assigned', 'running')`,
         staleTask.agentId === null ? sql`TRUE` : eq(tasks.agentId, staleTask.agentId)
       )
-    );
+    )
+    .returning({ id: tasks.id });
+  if (updated.length === 0) {
+    return false;
+  }
   emitTaskUpdate(staleTask.projectId, staleTask.taskId, 'failed', {
     campaignId: staleTask.campaignId,
   });
   await updateCampaignProgress(staleTask.campaignId);
+  return true;
 }
 
 /**
@@ -916,9 +935,12 @@ export async function reassignStaleTasks(staleThresholdMs = 5 * 60 * 1000) {
         // completion message, or its report is malformed. Either way, the
         // chunk did not flow through the normal completion path - mark
         // failed so a fresh agent reruns the range rather than silently
-        // trusting an un-acked completion.
-        await terminalFailStaleTask(staleTask, 'keyspace_progress_overrun');
-        failedOverrun++;
+        // trusting an un-acked completion. Only count the outcome when the
+        // helper actually changed a row — a concurrent sweep that already
+        // processed this task makes the UPDATE a no-op.
+        if (await terminalFailStaleTask(staleTask, 'keyspace_progress_overrun')) {
+          failedOverrun++;
+        }
         continue;
       }
 
@@ -927,8 +949,9 @@ export async function reassignStaleTasks(staleThresholdMs = 5 * 60 * 1000) {
           // Retry budget exhausted - permanent fail. Mirrors
           // handleTaskFailure's terminal branch; keep agentId so operators
           // can still see which agent dropped the task.
-          await terminalFailStaleTask(staleTask, 'max_retries_exceeded');
-          failedMaxRetries++;
+          if (await terminalFailStaleTask(staleTask, 'max_retries_exceeded')) {
+            failedMaxRetries++;
+          }
           continue;
         }
 
@@ -945,7 +968,7 @@ export async function reassignStaleTasks(staleThresholdMs = 5 * 60 * 1000) {
             : {};
         const carriedProgress: Record<string, unknown> = { ...priorProgress };
         delete carriedProgress['keyspaceProgress'];
-        await db
+        const rebalanceUpdated = await db
           .update(tasks)
           .set({
             status: 'pending',
@@ -967,7 +990,11 @@ export async function reassignStaleTasks(staleThresholdMs = 5 * 60 * 1000) {
               sql`${tasks.status} IN ('assigned', 'running')`,
               staleTask.agentId === null ? sql`TRUE` : eq(tasks.agentId, staleTask.agentId)
             )
-          );
+          )
+          .returning({ id: tasks.id });
+        if (rebalanceUpdated.length === 0) {
+          continue;
+        }
         emitTaskUpdate(staleTask.projectId, staleTask.taskId, 'pending', {
           campaignId: staleTask.campaignId,
         });
@@ -978,13 +1005,14 @@ export async function reassignStaleTasks(staleThresholdMs = 5 * 60 * 1000) {
 
       if (exceededRetries) {
         // 0% / unreadable progress but retry budget exhausted - permanent fail.
-        await terminalFailStaleTask(staleTask, 'max_retries_exceeded');
-        failedMaxRetries++;
+        if (await terminalFailStaleTask(staleTask, 'max_retries_exceeded')) {
+          failedMaxRetries++;
+        }
         continue;
       }
 
       // 0% progress or unreadable range - reset to pending unchanged.
-      await db
+      const resetUpdated = await db
         .update(tasks)
         .set({
           status: 'pending',
@@ -1000,7 +1028,11 @@ export async function reassignStaleTasks(staleThresholdMs = 5 * 60 * 1000) {
             sql`${tasks.status} IN ('assigned', 'running')`,
             staleTask.agentId === null ? sql`TRUE` : eq(tasks.agentId, staleTask.agentId)
           )
-        );
+        )
+        .returning({ id: tasks.id });
+      if (resetUpdated.length === 0) {
+        continue;
+      }
       emitTaskUpdate(staleTask.projectId, staleTask.taskId, 'pending', {
         campaignId: staleTask.campaignId,
       });

--- a/packages/backend/tests/integration/agent-heartbeat.test.ts
+++ b/packages/backend/tests/integration/agent-heartbeat.test.ts
@@ -258,6 +258,12 @@ if (!IS_ISOLATED) {
     SYSTEM_EVENT_PROJECT_ID: 0 as const,
   }));
 
+  // Exposed so tests can assert the heartbeat high-priority path called
+  // the capability filter with the right agent caps. Default impl returns
+  // a no-op SQL fragment (the drizzle-chain mock ignores predicate
+  // contents); tests can mockImplementationOnce to override.
+  const buildCapabilityPredicateMock = mock(() => sql`TRUE`);
+
   mock.module('../../src/services/tasks.js', () => ({
     assignNextTask: mock(),
     updateTaskProgress: mock(),
@@ -270,11 +276,7 @@ if (!IS_ISOLATED) {
     AGENT_TASK_ACTIVE_STATUSES: ['pending', 'assigned', 'running'] as const,
     projectAgentTaskRows: mock(),
     listTasksByAgent: mock(),
-    // The heartbeat high-priority lookup composes a capability predicate
-    // into its WHERE clause. The drizzle-chain mock ignores the predicate
-    // contents, so returning a no-op `sql` fragment keeps the chain happy
-    // without leaking real SQL behavior into the test.
-    buildCapabilityPredicate: mock(() => sql`TRUE`),
+    buildCapabilityPredicate: buildCapabilityPredicateMock,
   }));
 
   mock.module('../../src/lib/auth.js', () => ({
@@ -311,6 +313,8 @@ if (!IS_ISOLATED) {
     loggerMock.error.mockReset();
     emitAgentErrorMock.mockReset();
     emitAgentStatusMock.mockReset();
+    buildCapabilityPredicateMock.mockReset();
+    buildCapabilityPredicateMock.mockImplementation(() => sql`TRUE`);
   });
 
   afterEach(() => {
@@ -598,6 +602,116 @@ if (!IS_ISOLATED) {
       expect(ctx['api_key']).toBe('[REDACTED]');
       expect(ctx['authorization']).toBe('[REDACTED]');
       expect(ctx['stack']).toBe('Error...');
+    });
+
+    it('calls buildCapabilityPredicate with the agent capabilities on the high-priority lookup', async () => {
+      // Arrange — online agent with GPU + hashMode capabilities; pretend a
+      // high-priority task is queued for its project.
+      state.agent = {
+        id: 1,
+        projectId: 7,
+        status: 'online',
+        capabilities: { gpu: true, hashModes: [0, 1000] },
+      };
+      state.highPriorityTask = { id: 99 };
+      const token = agentToken(TEST_AGENT_TOKEN);
+
+      // Act
+      const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ status: 'online' }),
+      });
+
+      // Assert
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body['hasHighPriorityTasks']).toBe(true);
+      expect(buildCapabilityPredicateMock).toHaveBeenCalledTimes(1);
+      // The heartbeat must pass the agent's own capabilities to the filter,
+      // not an empty object — otherwise the predicate excludes everything.
+      expect(buildCapabilityPredicateMock.mock.calls[0]?.[0]).toEqual({
+        gpu: true,
+        hashModes: [0, 1000],
+      });
+    });
+
+    it('skips the high-priority lookup for an agent in error status', async () => {
+      // Arrange — agent transitioning to error via fatal heartbeat. The
+      // hint must not fire because assignNextTask refuses to assign to
+      // non-online/non-benchmarked agents, so suggesting work is misleading.
+      state.agent = {
+        id: 1,
+        projectId: 7,
+        status: 'online',
+        capabilities: { gpu: true, hashModes: [0] },
+      };
+      state.highPriorityTask = { id: 99 };
+      const token = agentToken(TEST_AGENT_TOKEN);
+
+      // Act — fatal heartbeat moves status to 'error'.
+      const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          status: 'error',
+          error: { severity: 'fatal', message: 'gpu hung' },
+        }),
+      });
+
+      // Assert
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      // The route omits hasHighPriorityTasks when false (response-shape
+      // optimization in /heartbeat). The status gate must short-circuit
+      // before the lookup, so the predicate is not invoked.
+      expect(body['hasHighPriorityTasks']).toBeUndefined();
+      expect(buildCapabilityPredicateMock).not.toHaveBeenCalled();
+    });
+
+    it('warn-logs and skips the high-priority lookup for null capabilities', async () => {
+      // Arrange — agent row exists but capabilities are NULL (jsonb is
+      // nullable in schema; can happen on a freshly-inserted row that
+      // hasn't yet announced). The shape check skips the predicate so we
+      // don't silently exclude every real task.
+      state.agent = {
+        id: 1,
+        projectId: 7,
+        status: 'online',
+        // biome-ignore lint/suspicious/noExplicitAny: deliberate null to mirror jsonb nullability the route now defends against
+        capabilities: null as any,
+      };
+      state.highPriorityTask = { id: 99 };
+      const token = agentToken(TEST_AGENT_TOKEN);
+
+      // Act
+      const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ status: 'online' }),
+      });
+
+      // Assert
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body['hasHighPriorityTasks']).toBeUndefined();
+      // Predicate must NOT have been called — the shape gate short-circuited.
+      expect(buildCapabilityPredicateMock).not.toHaveBeenCalled();
+      // And the warn must have fired exactly once for this agent.
+      const warnCallsForAgent = loggerMock.warn.mock.calls.filter((call) => {
+        const arg = call[0] as Record<string, unknown> | undefined;
+        return arg?.['agentId'] === 1 && arg?.['capabilitiesType'] === 'null';
+      });
+      expect(warnCallsForAgent).toHaveLength(1);
     });
   });
 }

--- a/packages/backend/tests/integration/agent-heartbeat.test.ts
+++ b/packages/backend/tests/integration/agent-heartbeat.test.ts
@@ -26,6 +26,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { sql } from 'drizzle-orm';
 
 const IS_ISOLATED = process.env['AGENT_HEARTBEAT_TEST_ISOLATED'] === '1';
 
@@ -260,6 +261,11 @@ if (!IS_ISOLATED) {
     AGENT_TASK_ACTIVE_STATUSES: ['pending', 'assigned', 'running'] as const,
     projectAgentTaskRows: mock(),
     listTasksByAgent: mock(),
+    // The heartbeat high-priority lookup composes a capability predicate
+    // into its WHERE clause. The drizzle-chain mock ignores the predicate
+    // contents, so returning a no-op `sql` fragment keeps the chain happy
+    // without leaking real SQL behavior into the test.
+    buildCapabilityPredicate: mock(() => sql`TRUE`),
   }));
 
   mock.module('../../src/lib/auth.js', () => ({

--- a/packages/backend/tests/integration/agent-heartbeat.test.ts
+++ b/packages/backend/tests/integration/agent-heartbeat.test.ts
@@ -69,7 +69,12 @@ if (!IS_ISOLATED) {
 
   // Shared mutable state the test cases set up before each call.
   const state = {
-    agent: { id: 1, projectId: 7, status: 'online', capabilities: {} } as MockAgent | null,
+    agent: {
+      id: 1,
+      projectId: 7,
+      status: 'online',
+      capabilities: {},
+    } as MockAgent | null,
     activeTasks: [] as MockTask[],
     ownedTaskIds: new Set<number>(),
     capturedErrors: [] as CapturedAgentError[],
@@ -140,7 +145,9 @@ if (!IS_ISOLATED) {
           taskId: vals.taskId ?? null,
         };
         state.capturedErrors.push(row);
-        return { returning: () => Promise.resolve([{ id: state.capturedErrors.length, ...row }]) };
+        return {
+          returning: () => Promise.resolve([{ id: state.capturedErrors.length, ...row }]),
+        };
       },
     };
   }
@@ -183,7 +190,9 @@ if (!IS_ISOLATED) {
           // We disambiguate by call shape rather than parsing the where
           // clause (which is opaque drizzle SQL).
           if (keys.length === 1 && keys[0] === 'id') {
-            const ownedRows = Array.from(state.ownedTaskIds).map((id) => ({ id }));
+            const ownedRows = Array.from(state.ownedTaskIds).map((id) => ({
+              id,
+            }));
             const activeRows = state.activeTasks.map((t) => ({ id: t.id }));
             // verifyTaskOwnership now runs inside the tx with FOR UPDATE:
             //   select({id}).from(tasks).where(...).for('update').limit(1)
@@ -269,7 +278,10 @@ if (!IS_ISOLATED) {
   }));
 
   mock.module('../../src/lib/auth.js', () => ({
-    auth: { api: { getSession: async () => null }, handler: async () => new Response('ok') },
+    auth: {
+      api: { getSession: async () => null },
+      handler: async () => new Response('ok'),
+    },
   }));
 
   const { app } = await import('../../src/index.js');
@@ -316,10 +328,17 @@ if (!IS_ISOLATED) {
       // Act
       const res = await app.request(`${AGENT_BASE}/heartbeat`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', authorization: `Bearer ${token}` },
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify({
           status: 'online',
-          error: { severity: 'warning', message: 'temperature spike', context: { gpuId: 0 } },
+          error: {
+            severity: 'warning',
+            message: 'temperature spike',
+            context: { gpuId: 0 },
+          },
         }),
       });
 
@@ -350,7 +369,10 @@ if (!IS_ISOLATED) {
       // Act
       const res = await app.request(`${AGENT_BASE}/heartbeat`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', authorization: `Bearer ${token}` },
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify({
           status: 'error',
           error: { severity: 'fatal', message: 'hashcat crashed' },
@@ -378,7 +400,10 @@ if (!IS_ISOLATED) {
       // Act
       const res = await app.request(`${AGENT_BASE}/heartbeat`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', authorization: `Bearer ${token}` },
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify({
           status: 'error',
           error: { severity: 'fatal', message: 'gpu hung' },
@@ -395,12 +420,20 @@ if (!IS_ISOLATED) {
     it('emits a status-transition audit log line exactly once on a real transition', async () => {
       // Arrange — agent currently 'offline'; heartbeat says 'online'.
       const token = agentToken(TEST_AGENT_TOKEN);
-      state.agent = { id: 1, projectId: 7, status: 'offline', capabilities: {} };
+      state.agent = {
+        id: 1,
+        projectId: 7,
+        status: 'offline',
+        capabilities: {},
+      };
 
       // Act
       const res = await app.request(`${AGENT_BASE}/heartbeat`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', authorization: `Bearer ${token}` },
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify({ status: 'online' }),
       });
 
@@ -425,7 +458,10 @@ if (!IS_ISOLATED) {
       // Act
       const res = await app.request(`${AGENT_BASE}/heartbeat`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', authorization: `Bearer ${token}` },
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify({ status: 'online' }),
       });
 
@@ -445,7 +481,10 @@ if (!IS_ISOLATED) {
       // Act
       const res = await app.request(`${AGENT_BASE}/heartbeat`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', authorization: `Bearer ${token}` },
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify({
           status: 'online',
           currentTask: { taskId: 42, progress: 0.5, speed: 1000 },
@@ -468,7 +507,10 @@ if (!IS_ISOLATED) {
       // Act
       const res = await app.request(`${AGENT_BASE}/heartbeat`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', authorization: `Bearer ${token}` },
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify({
           status: 'online',
           currentTask: { taskId: 999, progress: 0, speed: 0 },
@@ -503,7 +545,10 @@ if (!IS_ISOLATED) {
       // Act
       const res = await app.request(`${AGENT_BASE}/heartbeat`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', authorization: `Bearer ${token}` },
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify({
           status: 'error',
           error: { severity: 'fatal', message: 'fan-out test' },
@@ -528,13 +573,20 @@ if (!IS_ISOLATED) {
       // Act
       const res = await app.request(`${AGENT_BASE}/heartbeat`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', authorization: `Bearer ${token}` },
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify({
           status: 'online',
           error: {
             severity: 'warning',
             message: 'leak attempt',
-            context: { api_key: 'sk-real', stack: 'Error...', authorization: 'Bearer xxx' },
+            context: {
+              api_key: 'sk-real',
+              stack: 'Error...',
+              authorization: 'Bearer xxx',
+            },
           },
         }),
       });

--- a/packages/backend/tests/integration/agent-heartbeat.test.ts
+++ b/packages/backend/tests/integration/agent-heartbeat.test.ts
@@ -287,6 +287,7 @@ if (!IS_ISOLATED) {
   }));
 
   const { app } = await import('../../src/index.js');
+  const { __resetWarnedEmptyCapsForTesting } = await import('../../src/services/agents.js');
   const { agentToken } = await import('../fixtures.js');
 
   const AGENT_BASE = '/api/v1/agent';
@@ -315,6 +316,9 @@ if (!IS_ISOLATED) {
     emitAgentStatusMock.mockReset();
     buildCapabilityPredicateMock.mockReset();
     buildCapabilityPredicateMock.mockImplementation(() => sql`TRUE`);
+    // Reset the process-global once-per-agent warn guard so each test
+    // starts from a known empty state.
+    __resetWarnedEmptyCapsForTesting();
   });
 
   afterEach(() => {
@@ -673,6 +677,44 @@ if (!IS_ISOLATED) {
       // before the lookup, so the predicate is not invoked.
       expect(body['hasHighPriorityTasks']).toBeUndefined();
       expect(buildCapabilityPredicateMock).not.toHaveBeenCalled();
+    });
+
+    it('warn-logs and skips the high-priority lookup for empty hashModes', async () => {
+      // Arrange — DB default for agents.capabilities is `{}`, which is an
+      // object but carries no usable hashModes. The predicate would
+      // silently exclude every real task and still pay for an extra DB
+      // join, so treat this the same as null: warn once, skip the lookup.
+      state.agent = {
+        id: 1,
+        projectId: 7,
+        status: 'online',
+        capabilities: { gpu: false }, // object without hashModes
+      };
+      state.highPriorityTask = { id: 99 };
+      const token = agentToken(TEST_AGENT_TOKEN);
+
+      // Act
+      const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ status: 'online' }),
+      });
+
+      // Assert
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body['hasHighPriorityTasks']).toBeUndefined();
+      expect(buildCapabilityPredicateMock).not.toHaveBeenCalled();
+      const warnCalls = loggerMock.warn.mock.calls.filter((call) => {
+        const arg = call[0] as Record<string, unknown> | undefined;
+        return (
+          arg?.['agentId'] === 1 && arg?.['capabilitiesType'] === 'object-without-usable-hashModes'
+        );
+      });
+      expect(warnCalls).toHaveLength(1);
     });
 
     it('warn-logs and skips the high-priority lookup for null capabilities', async () => {

--- a/packages/backend/tests/unit/agent-api-contract.test.ts
+++ b/packages/backend/tests/unit/agent-api-contract.test.ts
@@ -235,8 +235,17 @@ describe('Agent API: POST /heartbeat', () => {
       },
       body: JSON.stringify({
         status: 'online',
-        currentTask: { taskId: 42, progress: 0.5, speed: 12345, temperature: 72 },
-        error: { severity: 'warning', message: 'temperature spike', context: { gpuId: 0 } },
+        currentTask: {
+          taskId: 42,
+          progress: 0.5,
+          speed: 12345,
+          temperature: 72,
+        },
+        error: {
+          severity: 'warning',
+          message: 'temperature spike',
+          context: { gpuId: 0 },
+        },
       }),
     });
 

--- a/packages/backend/tests/unit/agent-api-contract.test.ts
+++ b/packages/backend/tests/unit/agent-api-contract.test.ts
@@ -528,6 +528,29 @@ describe('Agent API: POST /tasks/next', () => {
     expect(task['work_range']).toBeUndefined();
     expect(task['retry_count']).toBeUndefined();
   });
+
+  it('round-trips a non-zero retryCount through the snake↔camel projection', async () => {
+    // toHaveProperty passes even on an explicit undefined; assert a real
+    // non-zero value so a regression that drops the column projection is
+    // caught here rather than at runtime in the agent client.
+    const tasksMod = await import('../../src/services/tasks.js');
+    const assignNextTaskMock = tasksMod.assignNextTask as unknown as ReturnType<typeof mock>;
+    assignNextTaskMock.mockImplementationOnce(() =>
+      Promise.resolve({ ...mockCamelCaseTask, retryCount: 2 })
+    );
+
+    const token = agentToken(TEST_AGENT_TOKEN);
+    const res = await app.request(`${AGENT_BASE}/tasks/next`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    const task = body['task'] as Record<string, unknown>;
+    expect(task['retryCount']).toBe(2);
+    expect(task['retryCount']).not.toBeUndefined();
+  });
 });
 
 // ─── POST /tasks/:id/report — Report Task Progress ─────────────────

--- a/packages/backend/tests/unit/agent-api-contract.test.ts
+++ b/packages/backend/tests/unit/agent-api-contract.test.ts
@@ -33,6 +33,7 @@ const mockSnakeCaseTaskRow = {
   started_at: null,
   completed_at: null,
   failure_reason: null,
+  retry_count: 0,
   created_at: '2026-03-24T00:00:00.000Z',
   updated_at: '2026-03-24T00:00:00.000Z',
 };
@@ -108,6 +109,7 @@ const mockCamelCaseTask = {
   startedAt: mockSnakeCaseTaskRow.started_at,
   completedAt: mockSnakeCaseTaskRow.completed_at,
   failureReason: mockSnakeCaseTaskRow.failure_reason,
+  retryCount: mockSnakeCaseTaskRow.retry_count,
   createdAt: mockSnakeCaseTaskRow.created_at,
   updatedAt: mockSnakeCaseTaskRow.updated_at,
 };
@@ -504,10 +506,18 @@ describe('Agent API: POST /tasks/next', () => {
     expect(task['campaignId']).toBeDefined();
     expect(task['workRange']).toBeDefined();
 
+    // retryCount is part of the documented TaskDescriptor contract and
+    // is always present (backed by a NOT NULL DEFAULT 0 column). Assert
+    // the field is exposed with the expected value so generated agent
+    // clients can rely on it.
+    expect(task).toHaveProperty('retryCount');
+    expect(task['retryCount']).toBe(mockSnakeCaseTaskRow.retry_count);
+
     // snake_case keys should be absent
     expect(task['attack_id']).toBeUndefined();
     expect(task['campaign_id']).toBeUndefined();
     expect(task['work_range']).toBeUndefined();
+    expect(task['retry_count']).toBeUndefined();
   });
 });
 

--- a/packages/backend/tests/unit/tasks.test.ts
+++ b/packages/backend/tests/unit/tasks.test.ts
@@ -50,7 +50,9 @@ if (isIsolated) {
   // implementation is a chain that returns nothing; the rebalance tests
   // override `mockUpdateSet` to record each call's payload.
   mockUpdateSet = mock(() => ({ where: mockUpdateWhere }));
-  mockUpdateWhere = mock(() => ({ returning: mock(() => Promise.resolve([])) }));
+  mockUpdateWhere = mock(() => ({
+    returning: mock(() => Promise.resolve([])),
+  }));
 
   mock.module('../../src/db/index.js', () => ({
     db: {
@@ -151,7 +153,12 @@ if (isIsolated) {
         campaignId: 5,
         agentId: 1,
         status: 'assigned',
-        workRange: { start: 0, end: 10000000, total: 10000000, agentSpeedHs: 1_000_000 },
+        workRange: {
+          start: 0,
+          end: 10000000,
+          total: 10000000,
+          agentSpeedHs: 1_000_000,
+        },
         progress: {},
         resultStats: {},
         requiredCapabilities: { hashcatMode: 1000 },
@@ -232,7 +239,12 @@ if (isIsolated) {
     // the two count queries that decide the reason.
     test('skip-diagnosis: no_pending_tasks when project has no pending tasks', async () => {
       mockLimit.mockResolvedValueOnce([
-        { id: 1, projectId: 1, status: 'online', capabilities: { hashModes: [0] } },
+        {
+          id: 1,
+          projectId: 1,
+          status: 'online',
+          capabilities: { hashModes: [0] },
+        },
       ]);
       mockExecute.mockResolvedValueOnce([]); // CTE returns no claim
       // Diagnostic count #1 (any pending in project): 0 -> no_pending_tasks.
@@ -244,7 +256,12 @@ if (isIsolated) {
 
     test('skip-diagnosis: no_matching_capability when pending tasks exist but capabilities mismatch', async () => {
       mockLimit.mockResolvedValueOnce([
-        { id: 1, projectId: 1, status: 'online', capabilities: { hashModes: [0] } },
+        {
+          id: 1,
+          projectId: 1,
+          status: 'online',
+          capabilities: { hashModes: [0] },
+        },
       ]);
       mockExecute.mockResolvedValueOnce([]); // CTE: no claim
       // Diagnostic #1: 5 pending; diagnostic #2: 0 matching.
@@ -257,7 +274,12 @@ if (isIsolated) {
 
     test('skip-diagnosis: claim_race_lost when matching tasks exist but were locked', async () => {
       mockLimit.mockResolvedValueOnce([
-        { id: 1, projectId: 1, status: 'online', capabilities: { hashModes: [0] } },
+        {
+          id: 1,
+          projectId: 1,
+          status: 'online',
+          capabilities: { hashModes: [0] },
+        },
       ]);
       mockExecute.mockResolvedValueOnce([]); // CTE: no claim
       mockLimit.mockResolvedValueOnce([{ n: 5 }]); // any-pending: 5
@@ -273,7 +295,12 @@ if (isIsolated) {
       // claim path. Simulate the diagnostic blowing up - assignNextTask
       // must still return null cleanly.
       mockLimit.mockResolvedValueOnce([
-        { id: 1, projectId: 1, status: 'online', capabilities: { hashModes: [0] } },
+        {
+          id: 1,
+          projectId: 1,
+          status: 'online',
+          capabilities: { hashModes: [0] },
+        },
       ]);
       mockExecute.mockResolvedValueOnce([]); // CTE: no claim
       // Diagnostic query rejects -> caught, fallback to claim_race_lost log.
@@ -312,7 +339,9 @@ if (isIsolated) {
         },
       ]);
       mockExecute.mockResolvedValueOnce([rawDbRow]);
-      mockGetAgentBenchmarkForMode.mockResolvedValueOnce({ speedHs: 5_000_000 });
+      mockGetAgentBenchmarkForMode.mockResolvedValueOnce({
+        speedHs: 5_000_000,
+      });
 
       const result = await assignNextTask(1);
       expect(result).not.toBeNull();
@@ -393,7 +422,10 @@ if (isIsolated) {
       const whereReturning = mock(() => Promise.resolve(rows));
       const secondInnerJoin = mock(() => ({ where: whereReturning }));
       const firstInnerJoin = mock(() => ({ innerJoin: secondInnerJoin }));
-      mockFrom.mockImplementationOnce(() => ({ innerJoin: firstInnerJoin, where: mock() }));
+      mockFrom.mockImplementationOnce(() => ({
+        innerJoin: firstInnerJoin,
+        where: mock(),
+      }));
     }
 
     // Captures every .set() payload so each test can assert which branch fired.
@@ -404,9 +436,9 @@ if (isIsolated) {
         setCalls.push(payload);
         return { where: mockUpdateWhere };
       });
-      mockUpdateWhere
-        .mockReset()
-        .mockImplementation(() => ({ returning: mock(() => Promise.resolve([])) }));
+      mockUpdateWhere.mockReset().mockImplementation(() => ({
+        returning: mock(() => Promise.resolve([])),
+      }));
     });
 
     test('marks task failed when keyspaceProgress equals total (un-acked completion)', async () => {
@@ -621,7 +653,10 @@ if (isIsolated) {
             returning: mock(() =>
               Promise.resolve(
                 Array.isArray(rows)
-                  ? rows.map((r, i) => ({ ...(r as Record<string, unknown>), id: 1000 + i }))
+                  ? rows.map((r, i) => ({
+                      ...(r as Record<string, unknown>),
+                      id: 1000 + i,
+                    }))
                   : [{ ...(rows as Record<string, unknown>), id: 1000 }]
               )
             ),
@@ -651,7 +686,10 @@ if (isIsolated) {
       // pickChunkSize falls back to FALLBACK_CHUNK_SIZE (10_000_000), which
       // exceeds the 10_000 keyspace - chunks should clamp at totalKeyspace.
       const benchmarkWhereReturning = mock(() => Promise.resolve([]));
-      mockFrom.mockImplementationOnce(() => ({ where: mockWhere, innerJoin: mock() }));
+      mockFrom.mockImplementationOnce(() => ({
+        where: mockWhere,
+        innerJoin: mock(),
+      }));
       mockFrom.mockImplementationOnce(() => ({
         innerJoin: mock(() => ({ where: benchmarkWhereReturning })),
       }));
@@ -688,7 +726,10 @@ if (isIsolated) {
       // 60_000 per chunk. Total = 1_000_000 -> 17 chunks (16 full + 1 trailing
       // 40_000-unit chunk).
       const benchmarkWhereReturning = mock(() => Promise.resolve([{ speedHs: 1000 }]));
-      mockFrom.mockImplementationOnce(() => ({ where: mockWhere, innerJoin: mock() }));
+      mockFrom.mockImplementationOnce(() => ({
+        where: mockWhere,
+        innerJoin: mock(),
+      }));
       mockFrom.mockImplementationOnce(() => ({
         innerJoin: mock(() => ({ where: benchmarkWhereReturning })),
       }));

--- a/packages/backend/tests/unit/tasks.test.ts
+++ b/packages/backend/tests/unit/tasks.test.ts
@@ -442,8 +442,13 @@ if (isIsolated) {
         setCalls.push(payload);
         return { where: mockUpdateWhere };
       });
+      // Sweep branches now gate event emission and counter increments on
+      // `.returning()` rowcount > 0 — the default mock must report a row
+      // matched so the existing happy-path tests still observe the side
+      // effects. Tests that exercise the concurrent-sweep no-op override
+      // this to return [].
       mockUpdateWhere.mockReset().mockImplementation(() => ({
-        returning: mock(() => Promise.resolve([])),
+        returning: mock(() => Promise.resolve([{ id: 1 }])),
       }));
       mockEmitTaskUpdate.mockReset();
       mockUpdateCampaignProgress.mockReset();
@@ -746,16 +751,17 @@ if (isIsolated) {
         },
       ]);
 
-      // Drizzle's UPDATE chain is awaited directly without `.returning()` in
-      // reassignStaleTasks. The second per-task UPDATE rejects so the
-      // try/catch path is exercised; the first and third resolve.
+      // Sweep paths now call `.where(...).returning({id})`. The second
+      // per-task UPDATE rejects from `.returning()` so the try/catch path
+      // is exercised; the first and third resolve with a single-row array
+      // so the success path runs.
       let callIdx = 0;
       mockUpdateWhere.mockReset().mockImplementation(() => {
         const i = callIdx++;
         if (i === 1) {
-          return Promise.reject(new Error('db blip'));
+          return { returning: mock(() => Promise.reject(new Error('db blip'))) };
         }
-        return Promise.resolve([]);
+        return { returning: mock(() => Promise.resolve([{ id: 1 }])) };
       });
 
       const result = await reassignStaleTasks();

--- a/packages/backend/tests/unit/tasks.test.ts
+++ b/packages/backend/tests/unit/tasks.test.ts
@@ -141,6 +141,7 @@ if (isIsolated) {
         started_at: null,
         completed_at: null,
         failure_reason: null,
+        retry_count: 0,
         created_at: now,
         updated_at: now,
       };
@@ -158,6 +159,7 @@ if (isIsolated) {
         startedAt: null,
         completedAt: null,
         failureReason: null,
+        retryCount: 0,
         createdAt: now,
         updatedAt: now,
       };
@@ -424,7 +426,12 @@ if (isIsolated) {
 
       const result = await reassignStaleTasks();
 
-      expect(result).toEqual({ reassigned: 0, rebalanced: 0, failedOverrun: 1 });
+      expect(result).toEqual({
+        reassigned: 0,
+        rebalanced: 0,
+        failedOverrun: 1,
+        failedMaxRetries: 0,
+      });
       expect(setCalls).toHaveLength(1);
       expect(setCalls[0]?.['status']).toBe('failed');
       expect(setCalls[0]?.['failureReason']).toBe('keyspace_progress_overrun');
@@ -444,7 +451,12 @@ if (isIsolated) {
 
       const result = await reassignStaleTasks();
 
-      expect(result).toEqual({ reassigned: 0, rebalanced: 0, failedOverrun: 1 });
+      expect(result).toEqual({
+        reassigned: 0,
+        rebalanced: 0,
+        failedOverrun: 1,
+        failedMaxRetries: 0,
+      });
       expect(setCalls).toHaveLength(1);
       expect(setCalls[0]?.['status']).toBe('failed');
       expect(setCalls[0]?.['failureReason']).toBe('keyspace_progress_overrun');
@@ -465,7 +477,12 @@ if (isIsolated) {
 
       const result = await reassignStaleTasks();
 
-      expect(result).toEqual({ reassigned: 0, rebalanced: 1, failedOverrun: 0 });
+      expect(result).toEqual({
+        reassigned: 0,
+        rebalanced: 1,
+        failedOverrun: 0,
+        failedMaxRetries: 0,
+      });
       expect(setCalls).toHaveLength(1);
       expect(setCalls[0]?.['status']).toBe('pending');
       expect(setCalls[0]?.['agentId']).toBe(null);
@@ -478,6 +495,8 @@ if (isIsolated) {
       expect(wr['total']).toBe(750_000);
       // Reported progress reset so the next agent starts at 0 within the trimmed range.
       expect(setCalls[0]?.['progress']).toEqual({});
+      // Retry counter bumped via SQL expression (`tasks.retry_count + 1`).
+      expect(setCalls[0]?.['retryCount']).toBeDefined();
     });
 
     test('falls through to reset-to-pending on 0% progress', async () => {
@@ -494,7 +513,12 @@ if (isIsolated) {
 
       const result = await reassignStaleTasks();
 
-      expect(result).toEqual({ reassigned: 1, rebalanced: 0, failedOverrun: 0 });
+      expect(result).toEqual({
+        reassigned: 1,
+        rebalanced: 0,
+        failedOverrun: 0,
+        failedMaxRetries: 0,
+      });
       expect(setCalls).toHaveLength(1);
       // Existing reset path: clear claim metadata but leave workRange/progress alone.
       expect(setCalls[0]?.['status']).toBe('pending');
@@ -503,6 +527,8 @@ if (isIsolated) {
       expect(setCalls[0]?.['startedAt']).toBe(null);
       expect(setCalls[0]?.['workRange']).toBeUndefined();
       expect(setCalls[0]?.['progress']).toBeUndefined();
+      // Retry counter bumped via SQL expression (`tasks.retry_count + 1`).
+      expect(setCalls[0]?.['retryCount']).toBeDefined();
     });
 
     test('handles string-encoded workRange values (bigint overflow case)', async () => {
@@ -525,7 +551,12 @@ if (isIsolated) {
 
       const result = await reassignStaleTasks();
 
-      expect(result).toEqual({ reassigned: 0, rebalanced: 1, failedOverrun: 0 });
+      expect(result).toEqual({
+        reassigned: 0,
+        rebalanced: 1,
+        failedOverrun: 0,
+        failedMaxRetries: 0,
+      });
       expect(setCalls).toHaveLength(1);
       const wr = setCalls[0]?.['workRange'] as Record<string, unknown>;
       // New start = 0 + 1e18 = "1000000000000000000" (decimal string, bigint-safe).
@@ -539,7 +570,12 @@ if (isIsolated) {
     test('emits zero counts when no stale tasks exist', async () => {
       seedStaleTasks([]);
       const result = await reassignStaleTasks();
-      expect(result).toEqual({ reassigned: 0, rebalanced: 0, failedOverrun: 0 });
+      expect(result).toEqual({
+        reassigned: 0,
+        rebalanced: 0,
+        failedOverrun: 0,
+        failedMaxRetries: 0,
+      });
       expect(setCalls).toHaveLength(0);
     });
   });

--- a/packages/backend/tests/unit/tasks.test.ts
+++ b/packages/backend/tests/unit/tasks.test.ts
@@ -15,6 +15,8 @@ let mockExecute: ReturnType<typeof mock>;
 let mockGetAgentBenchmarkForMode: ReturnType<typeof mock>;
 let mockUpdateSet: ReturnType<typeof mock>;
 let mockUpdateWhere: ReturnType<typeof mock>;
+let mockEmitTaskUpdate: ReturnType<typeof mock>;
+let mockUpdateCampaignProgress: ReturnType<typeof mock>;
 
 if (isIsolated) {
   // ─── Config / logger mocks (prevent env validation during import) ──
@@ -66,13 +68,15 @@ if (isIsolated) {
     },
   }));
 
+  mockEmitTaskUpdate = mock();
   mock.module('../../src/services/events.js', () => ({
     emitCrackResult: mock(),
-    emitTaskUpdate: mock(),
+    emitTaskUpdate: mockEmitTaskUpdate,
   }));
 
+  mockUpdateCampaignProgress = mock();
   mock.module('../../src/services/campaigns.js', () => ({
-    updateCampaignProgress: mock(),
+    updateCampaignProgress: mockUpdateCampaignProgress,
   }));
 
   mockGetAgentBenchmarkForMode = mock(() => Promise.resolve(null));
@@ -80,7 +84,9 @@ if (isIsolated) {
     getAgentBenchmarkForMode: mockGetAgentBenchmarkForMode,
   }));
 
-  const { assignNextTask, reassignStaleTasks } = await import('../../src/services/tasks.js');
+  const { assignNextTask, handleTaskFailure, reassignStaleTasks } = await import(
+    '../../src/services/tasks.js'
+  );
   const { db } = await import('../../src/db/index.js');
 
   describe('assignNextTask', () => {
@@ -439,6 +445,8 @@ if (isIsolated) {
       mockUpdateWhere.mockReset().mockImplementation(() => ({
         returning: mock(() => Promise.resolve([])),
       }));
+      mockEmitTaskUpdate.mockReset();
+      mockUpdateCampaignProgress.mockReset();
     });
 
     test('marks task failed when keyspaceProgress equals total (un-acked completion)', async () => {
@@ -463,6 +471,7 @@ if (isIsolated) {
         rebalanced: 0,
         failedOverrun: 1,
         failedMaxRetries: 0,
+        errored: 0,
       });
       expect(setCalls).toHaveLength(1);
       expect(setCalls[0]?.['status']).toBe('failed');
@@ -488,6 +497,7 @@ if (isIsolated) {
         rebalanced: 0,
         failedOverrun: 1,
         failedMaxRetries: 0,
+        errored: 0,
       });
       expect(setCalls).toHaveLength(1);
       expect(setCalls[0]?.['status']).toBe('failed');
@@ -514,6 +524,7 @@ if (isIsolated) {
         rebalanced: 1,
         failedOverrun: 0,
         failedMaxRetries: 0,
+        errored: 0,
       });
       expect(setCalls).toHaveLength(1);
       expect(setCalls[0]?.['status']).toBe('pending');
@@ -550,6 +561,7 @@ if (isIsolated) {
         rebalanced: 0,
         failedOverrun: 0,
         failedMaxRetries: 0,
+        errored: 0,
       });
       expect(setCalls).toHaveLength(1);
       // Existing reset path: clear claim metadata but leave workRange/progress alone.
@@ -588,6 +600,7 @@ if (isIsolated) {
         rebalanced: 1,
         failedOverrun: 0,
         failedMaxRetries: 0,
+        errored: 0,
       });
       expect(setCalls).toHaveLength(1);
       const wr = setCalls[0]?.['workRange'] as Record<string, unknown>;
@@ -607,8 +620,259 @@ if (isIsolated) {
         rebalanced: 0,
         failedOverrun: 0,
         failedMaxRetries: 0,
+        errored: 0,
       });
       expect(setCalls).toHaveLength(0);
+    });
+
+    test('terminal-fails partial-progress task when retry budget exhausted', async () => {
+      seedStaleTasks([
+        {
+          taskId: 77,
+          agentId: 4,
+          projectId: 9,
+          campaignId: 42,
+          workRange: { start: 0, end: 1_000_000, total: 1_000_000 },
+          progress: { keyspaceProgress: 250_000 }, // partial-progress branch
+          retryCount: 3, // at MAX_RETRIES — exceededRetries is true
+        },
+      ]);
+
+      const result = await reassignStaleTasks();
+
+      expect(result).toEqual({
+        reassigned: 0,
+        rebalanced: 0,
+        failedOverrun: 0,
+        failedMaxRetries: 1,
+        errored: 0,
+      });
+      expect(setCalls).toHaveLength(1);
+      expect(setCalls[0]?.['status']).toBe('failed');
+      expect(setCalls[0]?.['failureReason']).toBe('max_retries_exceeded');
+      expect(setCalls[0]?.['completedAt']).toBeInstanceOf(Date);
+      // Terminal fail must not touch workRange/progress — the row is dead.
+      expect(setCalls[0]?.['workRange']).toBeUndefined();
+      expect(setCalls[0]?.['progress']).toBeUndefined();
+      expect(mockEmitTaskUpdate).toHaveBeenCalledWith(9, 77, 'failed', {
+        campaignId: 42,
+      });
+      expect(mockUpdateCampaignProgress).toHaveBeenCalledWith(42);
+    });
+
+    test('terminal-fails zero-progress task when retry budget exhausted', async () => {
+      seedStaleTasks([
+        {
+          taskId: 78,
+          agentId: 5,
+          projectId: 9,
+          campaignId: 43,
+          workRange: { start: 0, end: 1000, total: 1000 },
+          progress: {}, // 0% / unreadable
+          retryCount: 4, // above cap (defensive bound)
+        },
+      ]);
+
+      const result = await reassignStaleTasks();
+
+      expect(result).toEqual({
+        reassigned: 0,
+        rebalanced: 0,
+        failedOverrun: 0,
+        failedMaxRetries: 1,
+        errored: 0,
+      });
+      expect(setCalls[0]?.['status']).toBe('failed');
+      expect(setCalls[0]?.['failureReason']).toBe('max_retries_exceeded');
+      expect(mockEmitTaskUpdate).toHaveBeenCalledWith(9, 78, 'failed', {
+        campaignId: 43,
+      });
+      expect(mockUpdateCampaignProgress).toHaveBeenCalledWith(43);
+    });
+
+    test('does NOT terminal-fail at the boundary (retryCount = MAX_RETRIES - 1)', async () => {
+      // Boundary guard: predicate is `>= MAX_RETRIES`, so retryCount=2 must
+      // still rebalance, not terminal-fail. Catches an off-by-one regression.
+      seedStaleTasks([
+        {
+          taskId: 79,
+          agentId: 6,
+          projectId: 9,
+          campaignId: 44,
+          workRange: { start: 0, end: 1000, total: 1000 },
+          progress: { keyspaceProgress: 250 },
+          retryCount: 2,
+        },
+      ]);
+
+      const result = await reassignStaleTasks();
+
+      expect(result.failedMaxRetries).toBe(0);
+      expect(result.rebalanced).toBe(1);
+      expect(setCalls[0]?.['status']).toBe('pending');
+      expect(setCalls[0]?.['failureReason']).toBeUndefined();
+    });
+
+    test('isolates per-task errors so siblings still process', async () => {
+      // Three stale tasks; the second's UPDATE rejects. The first and third
+      // must still complete and the envelope reports errored=1.
+      seedStaleTasks([
+        {
+          taskId: 101,
+          agentId: 11,
+          projectId: 1,
+          campaignId: 1,
+          workRange: { start: 0, end: 1000, total: 1000 },
+          progress: {},
+          retryCount: 0,
+        },
+        {
+          taskId: 102,
+          agentId: 12,
+          projectId: 1,
+          campaignId: 1,
+          workRange: { start: 0, end: 1000, total: 1000 },
+          progress: {},
+          retryCount: 0,
+        },
+        {
+          taskId: 103,
+          agentId: 13,
+          projectId: 1,
+          campaignId: 1,
+          workRange: { start: 0, end: 1000, total: 1000 },
+          progress: {},
+          retryCount: 0,
+        },
+      ]);
+
+      // Drizzle's UPDATE chain is awaited directly without `.returning()` in
+      // reassignStaleTasks. The second per-task UPDATE rejects so the
+      // try/catch path is exercised; the first and third resolve.
+      let callIdx = 0;
+      mockUpdateWhere.mockReset().mockImplementation(() => {
+        const i = callIdx++;
+        if (i === 1) {
+          return Promise.reject(new Error('db blip'));
+        }
+        return Promise.resolve([]);
+      });
+
+      const result = await reassignStaleTasks();
+
+      expect(result.reassigned).toBe(2);
+      expect(result.errored).toBe(1);
+    });
+  });
+
+  // ─── handleTaskFailure ────────────────────────────────────────────
+  //
+  // Exercises the retry-budget gating, the source-of-truth migration from
+  // result_stats.retryCount to the new tasks.retry_count column, and the
+  // terminal-fail branch that now also refreshes the campaign aggregate.
+  describe('handleTaskFailure', () => {
+    let setCalls: Array<Record<string, unknown>>;
+
+    beforeEach(() => {
+      setCalls = [];
+      mockSelect.mockReset().mockImplementation(() => ({ from: mockFrom }));
+      mockFrom.mockReset().mockImplementation(() => ({ where: mockWhere, innerJoin: mock() }));
+      mockWhere.mockReset().mockImplementation(() => ({ limit: mockLimit, innerJoin: mock() }));
+      mockLimit.mockReset().mockImplementation(() => Promise.resolve([]));
+      mockUpdateSet.mockReset().mockImplementation((payload: Record<string, unknown>) => {
+        setCalls.push(payload);
+        return { where: mockUpdateWhere };
+      });
+      mockUpdateWhere.mockReset().mockImplementation(() => ({
+        returning: mock(() => Promise.resolve([])),
+      }));
+      mockEmitTaskUpdate.mockReset();
+      mockUpdateCampaignProgress.mockReset();
+    });
+
+    test('retries (sets retryCount = current + 1) when below MAX_RETRIES', async () => {
+      const task = {
+        id: 50,
+        agentId: 8,
+        campaignId: 12,
+        resultStats: { lastFailure: 'prior' },
+        retryCount: 1,
+      };
+      // First .limit() returns the task; second returns the campaign.
+      mockLimit.mockResolvedValueOnce([task]);
+      mockLimit.mockResolvedValueOnce([{ projectId: 3 }]);
+      mockUpdateWhere.mockImplementationOnce(() => ({
+        returning: mock(() =>
+          Promise.resolve([{ ...task, status: 'pending', retryCount: 2, agentId: null }])
+        ),
+      }));
+
+      const result = await handleTaskFailure(50, 8, 'agent_timeout');
+
+      expect(result).toMatchObject({ retried: true });
+      expect(setCalls).toHaveLength(1);
+      expect(setCalls[0]?.['status']).toBe('pending');
+      expect(setCalls[0]?.['retryCount']).toBe(2);
+      expect(setCalls[0]?.['failureReason']).toBe('agent_timeout');
+      // result_stats.retryCount must NOT be written anymore.
+      const stats = setCalls[0]?.['resultStats'] as Record<string, unknown>;
+      expect(stats['retryCount']).toBeUndefined();
+      expect(stats['lastFailure']).toBe('agent_timeout');
+    });
+
+    test('terminal-fails when retryCount equals MAX_RETRIES and refreshes campaign', async () => {
+      const task = {
+        id: 51,
+        agentId: 9,
+        campaignId: 12,
+        resultStats: {},
+        retryCount: 3,
+      };
+      mockLimit.mockResolvedValueOnce([task]);
+      mockLimit.mockResolvedValueOnce([{ projectId: 3 }]);
+      mockUpdateWhere.mockImplementationOnce(() => ({
+        returning: mock(() => Promise.resolve([{ ...task, status: 'failed' }])),
+      }));
+
+      const result = await handleTaskFailure(51, 9, 'agent_timeout');
+
+      expect(result).toMatchObject({ retried: false });
+      expect(setCalls[0]?.['status']).toBe('failed');
+      expect(setCalls[0]?.['failureReason']).toBe('agent_timeout');
+      expect(setCalls[0]?.['completedAt']).toBeInstanceOf(Date);
+      expect(mockEmitTaskUpdate).toHaveBeenCalledWith(3, 51, 'failed', {
+        agentId: 9,
+        campaignId: 12,
+      });
+      // Terminal fail must refresh the campaign aggregate so the dashboard
+      // does not lag a sweep cycle (symmetric with the sweep terminal-fail).
+      expect(mockUpdateCampaignProgress).toHaveBeenCalledWith(12);
+    });
+
+    test('reads retryCount from the column, not result_stats (back-compat)', async () => {
+      // A row migrated from the legacy schema may still carry a stale
+      // result_stats.retryCount; the new code must IGNORE it and only honor
+      // the column. Otherwise pre-migration tasks one-failure-from-terminal
+      // would silently fail immediately on first post-migration retry.
+      const task = {
+        id: 52,
+        agentId: 10,
+        campaignId: 12,
+        resultStats: { retryCount: 99, lastFailure: 'stale_legacy_value' },
+        retryCount: 0,
+      };
+      mockLimit.mockResolvedValueOnce([task]);
+      mockLimit.mockResolvedValueOnce([{ projectId: 3 }]);
+      mockUpdateWhere.mockImplementationOnce(() => ({
+        returning: mock(() => Promise.resolve([{ ...task, retryCount: 1 }])),
+      }));
+
+      const result = await handleTaskFailure(52, 10, 'agent_timeout');
+
+      // Despite resultStats.retryCount=99, the column says 0 -> still retry.
+      expect(result).toMatchObject({ retried: true });
+      expect(setCalls[0]?.['retryCount']).toBe(1);
+      expect(setCalls[0]?.['status']).toBe('pending');
     });
   });
 

--- a/packages/backend/tests/unit/tasks.test.ts
+++ b/packages/backend/tests/unit/tasks.test.ts
@@ -838,7 +838,14 @@ if (isIsolated) {
 
       expect(result).toMatchObject({ retried: false });
       expect(setCalls[0]?.['status']).toBe('failed');
-      expect(setCalls[0]?.['failureReason']).toBe('agent_timeout');
+      // Stable terminal code so this row is distinguishable from a one-shot
+      // failure with the same agent-reported reason; sweep terminal branches
+      // use the same code so both paths look identical to downstream code.
+      expect(setCalls[0]?.['failureReason']).toBe('max_retries_exceeded');
+      // The agent-reported reason that tipped the budget is preserved in
+      // resultStats.lastFailure for debugging.
+      const stats = setCalls[0]?.['resultStats'] as Record<string, unknown>;
+      expect(stats['lastFailure']).toBe('agent_timeout');
       expect(setCalls[0]?.['completedAt']).toBeInstanceOf(Date);
       expect(mockEmitTaskUpdate).toHaveBeenCalledWith(3, 51, 'failed', {
         agentId: 9,

--- a/packages/openapi/agent-api.yaml
+++ b/packages/openapi/agent-api.yaml
@@ -421,6 +421,7 @@ components:
 
     TaskDescriptor:
       type: object
+      required: [retryCount]
       properties:
         id:
           type: integer
@@ -433,6 +434,16 @@ components:
           description: hashcat attack mode
         hashTypeId:
           type: integer
+        retryCount:
+          type: integer
+          minimum: 0
+          description: |
+            Number of times this task has been retried after a previous
+            assignment failed (e.g. agent timeout, error report, or stale
+            reclaim). `0` for first-time assignments. Backed by the
+            `tasks.retry_count` column, which is `NOT NULL DEFAULT 0`, so
+            this property is always present on a task descriptor returned
+            from `/tasks/next`.
         workRange:
           type: object
           properties:

--- a/packages/openapi/agent-api.yaml
+++ b/packages/openapi/agent-api.yaml
@@ -422,31 +422,50 @@ components:
 
     TaskDescriptor:
       type: object
-      required: [retryCount]
+      description: |
+        Canonical task descriptor returned from `POST /tasks/next`. Mirrors
+        the `AssignedTask` shape in `packages/shared` (derived from
+        `assignedTaskSchema`). All timestamp fields are ISO-8601 strings
+        on the wire; `progress` and `resultStats` are opaque JSONB blobs
+        and clients should not assume a fixed shape. `requiredCapabilities`
+        is the task's capability requirements (currently `gpu` and
+        `hashcatMode`); clients tolerate additional keys for forward
+        compatibility.
+      required:
+        - id
+        - attackId
+        - campaignId
+        - agentId
+        - status
+        - workRange
+        - retryCount
+        - createdAt
+        - updatedAt
       properties:
         id:
           type: integer
+          minimum: 1
         attackId:
           type: integer
+          minimum: 1
         campaignId:
           type: integer
-        mode:
+          minimum: 1
+        agentId:
           type: integer
-          description: hashcat attack mode
-        hashTypeId:
-          type: integer
-        retryCount:
-          type: integer
-          minimum: 0
+          minimum: 1
           description: |
-            Number of times this task has been retried after a previous
-            assignment failed (e.g. agent timeout, error report, or stale
-            reclaim). `0` for first-time assignments. Backed by the
-            `tasks.retry_count` column, which is `NOT NULL DEFAULT 0`, so
-            this property is always present on a task descriptor returned
-            from `/tasks/next`.
+            The agent the task is currently assigned to (the requester
+            agent on a fresh claim).
+        status:
+          type: string
+          description: |
+            Task lifecycle state. Common values are `assigned`, `running`,
+            `completed`, `failed`, `exhausted`. The set is open — clients
+            should accept new values without crashing.
         workRange:
           type: object
+          required: [start, end, total, agentSpeedHs]
           properties:
             start:
               oneOf:
@@ -478,22 +497,78 @@ components:
             agentSpeedHs:
               type: integer
               minimum: 0
-              description: Agent benchmark speed in hashes/second for the task's hash mode (fallback 1 MH/s if no benchmark)
-        resources:
-          type: object
-          properties:
-            hashListUrl:
-              type: string
-              format: uri
-            wordlistUrl:
-              type: string
-              format: uri
-            rulelistUrl:
-              type: string
-              format: uri
-            masklistUrl:
-              type: string
-              format: uri
+              description: Agent benchmark speed in hashes/second for the task's hash mode (fallback 1 MH/s if no benchmark).
+        progress:
+          description: |
+            Opaque per-task progress payload. Carries `keyspaceProgress`
+            (number or decimal string), `speed`, `temperature`, and any
+            forward-compat fields. Shape is not stable; consumers should
+            extract by key rather than positional structure.
+        resultStats:
+          description: |
+            Opaque per-task result-summary blob. Carries `lastFailure`
+            (string) when applicable; forward-compat fields may be added.
+            Shape is not stable.
+        requiredCapabilities:
+          oneOf:
+            - type: object
+              properties:
+                gpu:
+                  type: boolean
+                hashcatMode:
+                  type: integer
+                  minimum: 0
+              additionalProperties: true
+            - type: "null"
+          description: |
+            Capability requirements the assigning code matched against
+            the agent. Mirrors `requiredCapabilitiesSchema` in
+            `packages/shared`; tolerant of new keys.
+        assignedAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - type: "null"
+          description: ISO-8601 timestamp when the task was claimed; `null` before first assignment.
+        startedAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - type: "null"
+          description: ISO-8601 timestamp when the agent first reported running this task; `null` until reported.
+        completedAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - type: "null"
+          description: ISO-8601 timestamp of terminal transition (`completed` / `failed` / `exhausted`); `null` until the task reaches a terminal state.
+        failureReason:
+          oneOf:
+            - type: string
+            - type: "null"
+          description: |
+            Reason recorded on terminal failure transitions. The stable
+            terminal code `max_retries_exceeded` is used when the retry
+            budget is exhausted; agent-reported reasons are preserved in
+            `resultStats.lastFailure`. `null` for non-failed states.
+        retryCount:
+          type: integer
+          minimum: 0
+          description: |
+            Number of times this task has been retried after a previous
+            assignment failed (e.g. agent timeout, error report, or stale
+            reclaim). `0` for first-time assignments. Backed by the
+            `tasks.retry_count` column, which is `NOT NULL DEFAULT 0`, so
+            this property is always present on a task descriptor returned
+            from `/tasks/next`.
+        createdAt:
+          type: string
+          format: date-time
+          description: ISO-8601 timestamp when the task row was first persisted.
+        updatedAt:
+          type: string
+          format: date-time
+          description: ISO-8601 timestamp of the last mutation to the task row.
 
     TaskReport:
       type: object

--- a/packages/openapi/agent-api.yaml
+++ b/packages/openapi/agent-api.yaml
@@ -263,7 +263,7 @@ components:
                 engines may be advertised when an agent runs more than one
                 cracker (e.g., hashcat + john).
               items:
-                $ref: '#/components/schemas/EngineDescriptor'
+                $ref: "#/components/schemas/EngineDescriptor"
             gpuDevices:
               type: array
               items:
@@ -399,7 +399,8 @@ components:
             engine:
               type: string
         - type: object
-          required: [updateAvailable, engine, latestVersion, downloadUrl, expiresIn]
+          required:
+            [updateAvailable, engine, latestVersion, downloadUrl, expiresIn]
           description: Update available — agent should download the binary at `downloadUrl`.
           properties:
             updateAvailable:
@@ -453,7 +454,7 @@ components:
                   minimum: 0
                   maximum: 9007199254740991
                 - type: string
-                  pattern: '^[0-9]+$'
+                  pattern: "^[0-9]+$"
                   maxLength: 64
               description: Keyspace start position. Non-negative integer in JS-safe range (max 2^53 - 1 = 9007199254740991); decimal-string when the value exceeds that (mask attacks with large keyspaces). Clients must accept either form and coerce to a bigint-equivalent before arithmetic; integer values above the safe-integer maximum are forbidden because precision would already be lost.
             end:
@@ -462,7 +463,7 @@ components:
                   minimum: 0
                   maximum: 9007199254740991
                 - type: string
-                  pattern: '^[0-9]+$'
+                  pattern: "^[0-9]+$"
                   maxLength: 64
               description: Keyspace end position. Same number-or-string rule as start.
             total:
@@ -471,7 +472,7 @@ components:
                   minimum: 0
                   maximum: 9007199254740991
                 - type: string
-                  pattern: '^[0-9]+$'
+                  pattern: "^[0-9]+$"
                   maxLength: 64
               description: Total keyspace units in this chunk (end - start). Same number-or-string rule as start.
             agentSpeedHs:
@@ -510,7 +511,7 @@ components:
                   minimum: 0
                   maximum: 9007199254740991
                 - type: string
-                  pattern: '^[0-9]+$'
+                  pattern: "^[0-9]+$"
                   maxLength: 64
               description: Absolute count of keyspace units already cracked within the task's `workRange.total`. Non-negative integer in JS-safe range (max 2^53 - 1 = 9007199254740991); decimal-string of digits only when the value exceeds that. Clients must NOT send integer values above the safe-integer maximum - precision is already lost by the time they cross the wire. Server divides by `workRange.total` to derive the [0, 1] fraction the campaign aggregate consumes.
             speed:

--- a/packages/shared/src/db/migrations/0008_gifted_ultragirl.sql
+++ b/packages/shared/src/db/migrations/0008_gifted_ultragirl.sql
@@ -1,1 +1,13 @@
+-- Safe on populated tables: Postgres >= 11 stores the constant default as
+-- table metadata and does not rewrite existing rows.
 ALTER TABLE "tasks" ADD COLUMN "retry_count" integer DEFAULT 0 NOT NULL;
+--> statement-breakpoint
+-- Backfill the new column from the legacy result_stats.retryCount field so
+-- in-flight tasks that already exhausted part of their retry budget do not
+-- silently reset to 0 at cutover. Idempotent: re-running picks the same
+-- COALESCE result. Cast goes through text first so non-integer JSONB values
+-- (which should not exist but are technically possible) become NULL and
+-- fall through to the existing retry_count value via COALESCE.
+UPDATE "tasks"
+SET "retry_count" = COALESCE(NULLIF(("result_stats" ->> 'retryCount'), '')::int, "retry_count")
+WHERE "result_stats" ? 'retryCount';

--- a/packages/shared/src/db/migrations/0008_gifted_ultragirl.sql
+++ b/packages/shared/src/db/migrations/0008_gifted_ultragirl.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "tasks" ADD COLUMN "retry_count" integer DEFAULT 0 NOT NULL;

--- a/packages/shared/src/db/migrations/0008_gifted_ultragirl.sql
+++ b/packages/shared/src/db/migrations/0008_gifted_ultragirl.sql
@@ -5,9 +5,17 @@ ALTER TABLE "tasks" ADD COLUMN "retry_count" integer DEFAULT 0 NOT NULL;
 -- Backfill the new column from the legacy result_stats.retryCount field so
 -- in-flight tasks that already exhausted part of their retry budget do not
 -- silently reset to 0 at cutover. Idempotent: re-running picks the same
--- COALESCE result. Cast goes through text first so non-integer JSONB values
--- (which should not exist but are technically possible) become NULL and
--- fall through to the existing retry_count value via COALESCE.
+-- result. Guard the ::int cast with a non-negative-integer regex so a
+-- single malformed JSONB row (e.g. 'abc', '3.5', '-1') cannot abort the
+-- migration; non-matching values fall through to the existing retry_count
+-- via COALESCE.
 UPDATE "tasks"
-SET "retry_count" = COALESCE(NULLIF(("result_stats" ->> 'retryCount'), '')::int, "retry_count")
+SET "retry_count" = COALESCE(
+  CASE
+    WHEN ("result_stats" ->> 'retryCount') ~ '^[0-9]+$'
+      THEN ("result_stats" ->> 'retryCount')::int
+    ELSE NULL
+  END,
+  "retry_count"
+)
 WHERE "result_stats" ? 'retryCount';

--- a/packages/shared/src/db/migrations/meta/0008_snapshot.json
+++ b/packages/shared/src/db/migrations/meta/0008_snapshot.json
@@ -1,0 +1,2503 @@
+{
+  "id": "41adbebd-8de3-4e0f-a35c-93d34aa82e10",
+  "prevId": "43d3860c-d47a-47c8-85db-5e7541ab0c10",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_benchmarks": {
+      "name": "agent_benchmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashcat_mode": {
+          "name": "hashcat_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash_type": {
+          "name": "hash_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "speed_hs": {
+          "name": "speed_hs",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "benchmarked_at": {
+          "name": "benchmarked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_benchmarks_agent_id_idx": {
+          "name": "agent_benchmarks_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_benchmarks_agent_id_hashcat_mode_idx": {
+          "name": "agent_benchmarks_agent_id_hashcat_mode_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hashcat_mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_benchmarks_agent_id_agents_id_fk": {
+          "name": "agent_benchmarks_agent_id_agents_id_fk",
+          "tableFrom": "agent_benchmarks",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_errors": {
+      "name": "agent_errors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'error'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_errors_agent_id_created_at_idx": {
+          "name": "agent_errors_agent_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_errors_agent_id_agents_id_fk": {
+          "name": "agent_errors_agent_id_agents_id_fk",
+          "tableFrom": "agent_errors",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_errors_task_id_tasks_id_fk": {
+          "name": "agent_errors_task_id_tasks_id_fk",
+          "tableFrom": "agent_errors",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operating_system_id": {
+          "name": "operating_system_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_token": {
+          "name": "auth_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "hardware_profile": {
+          "name": "hardware_profile",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "cracker_version": {
+          "name": "cracker_version",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agents_project_id_idx": {
+          "name": "agents_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_status_idx": {
+          "name": "agents_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_auth_token_idx": {
+          "name": "agents_auth_token_idx",
+          "columns": [
+            {
+              "expression": "auth_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_project_id_projects_id_fk": {
+          "name": "agents_project_id_projects_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agents_operating_system_id_operating_systems_id_fk": {
+          "name": "agents_operating_system_id_operating_systems_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "operating_systems",
+          "columnsFrom": ["operating_system_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_auth_token_unique": {
+          "name": "agents_auth_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["auth_token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attack_templates": {
+      "name": "attack_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash_type_id": {
+          "name": "hash_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wordlist_id": {
+          "name": "wordlist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rulelist_id": {
+          "name": "rulelist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "masklist_id": {
+          "name": "masklist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advanced_configuration": {
+          "name": "advanced_configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attack_templates_project_name_idx": {
+          "name": "attack_templates_project_name_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attack_templates_project_id_idx": {
+          "name": "attack_templates_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attack_templates_project_id_projects_id_fk": {
+          "name": "attack_templates_project_id_projects_id_fk",
+          "tableFrom": "attack_templates",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attack_templates_hash_type_id_hash_types_id_fk": {
+          "name": "attack_templates_hash_type_id_hash_types_id_fk",
+          "tableFrom": "attack_templates",
+          "tableTo": "hash_types",
+          "columnsFrom": ["hash_type_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attack_templates_wordlist_id_word_lists_id_fk": {
+          "name": "attack_templates_wordlist_id_word_lists_id_fk",
+          "tableFrom": "attack_templates",
+          "tableTo": "word_lists",
+          "columnsFrom": ["wordlist_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attack_templates_rulelist_id_rule_lists_id_fk": {
+          "name": "attack_templates_rulelist_id_rule_lists_id_fk",
+          "tableFrom": "attack_templates",
+          "tableTo": "rule_lists",
+          "columnsFrom": ["rulelist_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attack_templates_masklist_id_mask_lists_id_fk": {
+          "name": "attack_templates_masklist_id_mask_lists_id_fk",
+          "tableFrom": "attack_templates",
+          "tableTo": "mask_lists",
+          "columnsFrom": ["masklist_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attack_templates_created_by_users_id_fk": {
+          "name": "attack_templates_created_by_users_id_fk",
+          "tableFrom": "attack_templates",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attacks": {
+      "name": "attacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash_type_id": {
+          "name": "hash_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wordlist_id": {
+          "name": "wordlist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rulelist_id": {
+          "name": "rulelist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "masklist_id": {
+          "name": "masklist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advanced_configuration": {
+          "name": "advanced_configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "keyspace": {
+          "name": "keyspace",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attacks_campaign_id_idx": {
+          "name": "attacks_campaign_id_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attacks_campaign_id_campaigns_id_fk": {
+          "name": "attacks_campaign_id_campaigns_id_fk",
+          "tableFrom": "attacks",
+          "tableTo": "campaigns",
+          "columnsFrom": ["campaign_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attacks_project_id_projects_id_fk": {
+          "name": "attacks_project_id_projects_id_fk",
+          "tableFrom": "attacks",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attacks_hash_type_id_hash_types_id_fk": {
+          "name": "attacks_hash_type_id_hash_types_id_fk",
+          "tableFrom": "attacks",
+          "tableTo": "hash_types",
+          "columnsFrom": ["hash_type_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attacks_wordlist_id_word_lists_id_fk": {
+          "name": "attacks_wordlist_id_word_lists_id_fk",
+          "tableFrom": "attacks",
+          "tableTo": "word_lists",
+          "columnsFrom": ["wordlist_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attacks_rulelist_id_rule_lists_id_fk": {
+          "name": "attacks_rulelist_id_rule_lists_id_fk",
+          "tableFrom": "attacks",
+          "tableTo": "rule_lists",
+          "columnsFrom": ["rulelist_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attacks_masklist_id_mask_lists_id_fk": {
+          "name": "attacks_masklist_id_mask_lists_id_fk",
+          "tableFrom": "attacks",
+          "tableTo": "mask_lists",
+          "columnsFrom": ["masklist_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ba_accounts": {
+      "name": "ba_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ba_accounts_user_id_idx": {
+          "name": "ba_accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ba_accounts_user_id_provider_id_idx": {
+          "name": "ba_accounts_user_id_provider_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ba_accounts_user_id_users_id_fk": {
+          "name": "ba_accounts_user_id_users_id_fk",
+          "tableFrom": "ba_accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ba_sessions": {
+      "name": "ba_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ba_sessions_user_id_idx": {
+          "name": "ba_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ba_sessions_user_id_users_id_fk": {
+          "name": "ba_sessions_user_id_users_id_fk",
+          "tableFrom": "ba_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ba_sessions_token_unique": {
+          "name": "ba_sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ba_verifications": {
+      "name": "ba_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ba_verifications_identifier_idx": {
+          "name": "ba_verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.campaigns": {
+      "name": "campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash_list_id": {
+          "name": "hash_list_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "campaigns_project_id_status_idx": {
+          "name": "campaigns_project_id_status_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "campaigns_project_id_projects_id_fk": {
+          "name": "campaigns_project_id_projects_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "campaigns_hash_list_id_hash_lists_id_fk": {
+          "name": "campaigns_hash_list_id_hash_lists_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "hash_lists",
+          "columnsFrom": ["hash_list_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "campaigns_created_by_users_id_fk": {
+          "name": "campaigns_created_by_users_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cracker_binaries": {
+      "name": "cracker_binaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "engine": {
+          "name": "engine",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'hashcat'"
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_ref": {
+          "name": "file_ref",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cracker_binaries_engine_version_platform_idx": {
+          "name": "cracker_binaries_engine_version_platform_idx",
+          "columns": [
+            {
+              "expression": "engine",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cracker_binaries_engine_platform_idx": {
+          "name": "cracker_binaries_engine_platform_idx",
+          "columns": [
+            {
+              "expression": "engine",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cracker_binaries_is_active_idx": {
+          "name": "cracker_binaries_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hash_items": {
+      "name": "hash_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "hash_list_id": {
+          "name": "hash_list_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash_value": {
+          "name": "hash_value",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plaintext": {
+          "name": "plaintext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cracked_at": {
+          "name": "cracked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attack_id": {
+          "name": "attack_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "hash_items_hash_list_id_hash_value_idx": {
+          "name": "hash_items_hash_list_id_hash_value_idx",
+          "columns": [
+            {
+              "expression": "hash_list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hash_value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hash_items_hash_list_id_idx": {
+          "name": "hash_items_hash_list_id_idx",
+          "columns": [
+            {
+              "expression": "hash_list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hash_items_cracked_at_idx": {
+          "name": "hash_items_cracked_at_idx",
+          "columns": [
+            {
+              "expression": "cracked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hash_items_campaign_id_idx": {
+          "name": "hash_items_campaign_id_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hash_items_hash_list_cracked_idx": {
+          "name": "hash_items_hash_list_cracked_idx",
+          "columns": [
+            {
+              "expression": "hash_list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cracked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hash_items_hash_list_id_hash_lists_id_fk": {
+          "name": "hash_items_hash_list_id_hash_lists_id_fk",
+          "tableFrom": "hash_items",
+          "tableTo": "hash_lists",
+          "columnsFrom": ["hash_list_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "hash_items_campaign_id_campaigns_id_fk": {
+          "name": "hash_items_campaign_id_campaigns_id_fk",
+          "tableFrom": "hash_items",
+          "tableTo": "campaigns",
+          "columnsFrom": ["campaign_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "hash_items_attack_id_attacks_id_fk": {
+          "name": "hash_items_attack_id_attacks_id_fk",
+          "tableFrom": "hash_items",
+          "tableTo": "attacks",
+          "columnsFrom": ["attack_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "hash_items_task_id_tasks_id_fk": {
+          "name": "hash_items_task_id_tasks_id_fk",
+          "tableFrom": "hash_items",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "hash_items_agent_id_agents_id_fk": {
+          "name": "hash_items_agent_id_agents_id_fk",
+          "tableFrom": "hash_items",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hash_lists": {
+      "name": "hash_lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash_type_id": {
+          "name": "hash_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upload'"
+        },
+        "file_ref": {
+          "name": "file_ref",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "statistics": {
+          "name": "statistics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "hash_lists_project_id_idx": {
+          "name": "hash_lists_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hash_lists_status_idx": {
+          "name": "hash_lists_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hash_lists_project_id_projects_id_fk": {
+          "name": "hash_lists_project_id_projects_id_fk",
+          "tableFrom": "hash_lists",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "hash_lists_hash_type_id_hash_types_id_fk": {
+          "name": "hash_lists_hash_type_id_hash_types_id_fk",
+          "tableFrom": "hash_lists",
+          "tableTo": "hash_types",
+          "columnsFrom": ["hash_type_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hash_types": {
+      "name": "hash_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashcat_mode": {
+          "name": "hashcat_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "example": {
+          "name": "example",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hash_types_hashcat_mode_unique": {
+          "name": "hash_types_hashcat_mode_unique",
+          "nullsNotDistinct": false,
+          "columns": ["hashcat_mode"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mask_lists": {
+      "name": "mask_lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_ref": {
+          "name": "file_ref",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "line_count": {
+          "name": "line_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mask_lists_project_id_projects_id_fk": {
+          "name": "mask_lists_project_id_projects_id_fk",
+          "tableFrom": "mask_lists",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operating_systems": {
+      "name": "operating_systems",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_users": {
+      "name": "project_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roles": {
+          "name": "roles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_users_user_project_idx": {
+          "name": "project_users_user_project_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_users_user_id_users_id_fk": {
+          "name": "project_users_user_id_users_id_fk",
+          "tableFrom": "project_users",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "project_users_project_id_projects_id_fk": {
+          "name": "project_users_project_id_projects_id_fk",
+          "tableFrom": "project_users",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_created_by_users_id_fk": {
+          "name": "projects_created_by_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_slug_unique": {
+          "name": "projects_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rule_lists": {
+      "name": "rule_lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_ref": {
+          "name": "file_ref",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "line_count": {
+          "name": "line_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rule_lists_project_id_projects_id_fk": {
+          "name": "rule_lists_project_id_projects_id_fk",
+          "tableFrom": "rule_lists",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "attack_id": {
+          "name": "attack_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "work_range": {
+          "name": "work_range",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "result_stats": {
+          "name": "result_stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "required_capabilities": {
+          "name": "required_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tasks_campaign_id_idx": {
+          "name": "tasks_campaign_id_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_agent_id_idx": {
+          "name": "tasks_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_status_idx": {
+          "name": "tasks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_status_campaign_id_idx": {
+          "name": "tasks_status_campaign_id_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_campaign_id_status_idx": {
+          "name": "tasks_campaign_id_status_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_attack_id_attacks_id_fk": {
+          "name": "tasks_attack_id_attacks_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "attacks",
+          "columnsFrom": ["attack_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_campaign_id_campaigns_id_fk": {
+          "name": "tasks_campaign_id_campaigns_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "campaigns",
+          "columnsFrom": ["campaign_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_agent_id_agents_id_fk": {
+          "name": "tasks_agent_id_agents_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_hash": {
+          "name": "api_key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_last_used_at": {
+          "name": "api_key_last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "users_api_key_hash_unique": {
+          "name": "users_api_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["api_key_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.word_lists": {
+      "name": "word_lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_ref": {
+          "name": "file_ref",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "line_count": {
+          "name": "line_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "word_lists_project_id_projects_id_fk": {
+          "name": "word_lists_project_id_projects_id_fk",
+          "tableFrom": "word_lists",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/shared/src/db/migrations/meta/_journal.json
+++ b/packages/shared/src/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1779152939557,
       "tag": "0007_light_ulik",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1779426146854,
+      "tag": "0008_gifted_ultragirl",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -86,8 +86,12 @@ export const baAccounts = pgTable(
     providerId: text('provider_id').notNull(),
     accessToken: text('access_token'),
     refreshToken: text('refresh_token'),
-    accessTokenExpiresAt: timestamp('access_token_expires_at', { withTimezone: true }),
-    refreshTokenExpiresAt: timestamp('refresh_token_expires_at', { withTimezone: true }),
+    accessTokenExpiresAt: timestamp('access_token_expires_at', {
+      withTimezone: true,
+    }),
+    refreshTokenExpiresAt: timestamp('refresh_token_expires_at', {
+      withTimezone: true,
+    }),
     scope: text('scope'),
     idToken: text('id_token'),
     password: text('password'),
@@ -173,7 +177,9 @@ export const agentErrors = pgTable(
     // checks (services/agents.ts `processHeartbeat`) prevent agents from
     // attributing errors to tasks they don't own; the FK is the
     // last-line guard so dangling task_ids cannot accumulate.
-    taskId: integer('task_id').references(() => tasks.id, { onDelete: 'set null' }),
+    taskId: integer('task_id').references(() => tasks.id, {
+      onDelete: 'set null',
+    }),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -404,6 +404,7 @@ export const tasks = pgTable(
     startedAt: timestamp('started_at', { withTimezone: true }),
     completedAt: timestamp('completed_at', { withTimezone: true }),
     failureReason: text('failure_reason'),
+    retryCount: integer('retry_count').notNull().default(0),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -538,13 +538,13 @@ export const requiredCapabilitiesSchema = z
 
 /**
  * Canonical shape of a task descriptor returned from `assignNextTask`
- * and surfaced on the agent API `/tasks/next` route. The Date fields
- * are real JS Dates as they live in memory between drizzle and the
- * route handler — the JSON serializer turns them into ISO-8601
- * strings at the wire boundary (governed by `agent-api.yaml`). Keep
- * this in lockstep with the OpenAPI `TaskDescriptor` schema; the
- * `tasks.retry_count` column is `NOT NULL DEFAULT 0`, so `retryCount`
- * is always present.
+ * and surfaced on the agent API `/tasks/next` route. Timestamp fields
+ * use `z.coerce.date()` so the same schema parses both the backend's
+ * in-memory `Date` objects (from drizzle) and the ISO-8601 strings
+ * frontend/agent clients receive after JSON serialization. Inferred
+ * type is `Date` in both cases. Keep in lockstep with the OpenAPI
+ * `TaskDescriptor` schema; the `tasks.retry_count` column is
+ * `NOT NULL DEFAULT 0`, so `retryCount` is always present.
  */
 export const assignedTaskSchema = z.object({
   id: z.number().int().positive(),
@@ -556,13 +556,13 @@ export const assignedTaskSchema = z.object({
   progress: z.unknown(),
   resultStats: z.unknown(),
   requiredCapabilities: requiredCapabilitiesSchema.nullable(),
-  assignedAt: z.date().nullable(),
-  startedAt: z.date().nullable(),
-  completedAt: z.date().nullable(),
+  assignedAt: z.coerce.date().nullable(),
+  startedAt: z.coerce.date().nullable(),
+  completedAt: z.coerce.date().nullable(),
   failureReason: z.string().nullable(),
   retryCount: z.number().int().nonnegative(),
-  createdAt: z.date(),
-  updatedAt: z.date(),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
 });
 
 // ─── Campaign Dashboard Surface ─────────────────────────────────────

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -523,6 +523,48 @@ export const workRangeSchema = z.object({
   agentSpeedHs: z.number().int().nonnegative(),
 });
 
+/**
+ * Capability requirements that a task may impose on the agent that
+ * claims it. `gpu` and `hashcatMode` are the two recognized keys today;
+ * unknown keys are tolerated (passthrough) so agents on older clients
+ * keep working when the server adds new requirement axes.
+ */
+export const requiredCapabilitiesSchema = z
+  .object({
+    gpu: z.boolean().optional(),
+    hashcatMode: z.number().int().nonnegative().optional(),
+  })
+  .passthrough();
+
+/**
+ * Canonical shape of a task descriptor returned from `assignNextTask`
+ * and surfaced on the agent API `/tasks/next` route. The Date fields
+ * are real JS Dates as they live in memory between drizzle and the
+ * route handler — the JSON serializer turns them into ISO-8601
+ * strings at the wire boundary (governed by `agent-api.yaml`). Keep
+ * this in lockstep with the OpenAPI `TaskDescriptor` schema; the
+ * `tasks.retry_count` column is `NOT NULL DEFAULT 0`, so `retryCount`
+ * is always present.
+ */
+export const assignedTaskSchema = z.object({
+  id: z.number().int().positive(),
+  attackId: z.number().int().positive(),
+  campaignId: z.number().int().positive(),
+  agentId: z.number().int().positive(),
+  status: z.string(),
+  workRange: workRangeSchema,
+  progress: z.unknown(),
+  resultStats: z.unknown(),
+  requiredCapabilities: requiredCapabilitiesSchema.nullable(),
+  assignedAt: z.date().nullable(),
+  startedAt: z.date().nullable(),
+  completedAt: z.date().nullable(),
+  failureReason: z.string().nullable(),
+  retryCount: z.number().int().nonnegative(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
 // ─── Campaign Dashboard Surface ─────────────────────────────────────
 
 /**

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -8,6 +8,7 @@ import type {
   agentStatusSchema,
   agentTaskSummarySchema,
   agentWorstSeveritySchema,
+  assignedTaskSchema,
   benchmarkSubmissionSchema,
   campaignActiveAgentSchema,
   campaignAttackRowSchema,
@@ -46,6 +47,7 @@ import type {
   insertWordListSchema,
   instantiateAttackTemplateResponseSchema,
   loginRequestSchema,
+  requiredCapabilitiesSchema,
   selectAgentBenchmarkSchema,
   selectAgentErrorSchema,
   selectAgentSchema,
@@ -189,29 +191,20 @@ export { KNOWN_ENGINES, KNOWN_PLATFORMS } from '../schemas/index.js';
  */
 export type WorkRange = z.infer<typeof workRangeSchema>;
 
-export interface RequiredCapabilities {
-  gpu?: boolean;
-  hashcatMode?: number;
-}
+/**
+ * Capability requirements imposed by a task. Inferred from
+ * `requiredCapabilitiesSchema` in `@hashhive/shared`. Passthrough
+ * keys may carry future requirement axes — consumers should not
+ * exhaustively switch on a closed set.
+ */
+export type RequiredCapabilities = z.infer<typeof requiredCapabilitiesSchema>;
 
-export interface AssignedTask {
-  id: number;
-  attackId: number;
-  campaignId: number;
-  agentId: number;
-  status: string;
-  workRange: WorkRange;
-  progress: unknown;
-  resultStats: unknown;
-  requiredCapabilities: RequiredCapabilities | null;
-  assignedAt: Date | null;
-  startedAt: Date | null;
-  completedAt: Date | null;
-  failureReason: string | null;
-  retryCount: number;
-  createdAt: Date;
-  updatedAt: Date;
-}
+/**
+ * Canonical assigned-task shape returned from the agent API
+ * `/tasks/next`. Inferred from `assignedTaskSchema` so the wire
+ * shape and the in-process TypeScript type cannot drift.
+ */
+export type AssignedTask = z.infer<typeof assignedTaskSchema>;
 
 // ─── API Request Types ──────────────────────────────────────────────
 

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -208,6 +208,7 @@ export interface AssignedTask {
   startedAt: Date | null;
   completedAt: Date | null;
   failureReason: string | null;
+  retryCount: number;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -240,7 +240,11 @@ export type InstantiateAttackTemplateResponse = z.infer<
  */
 export type ApiKeyMetadata =
   | { readonly hasKey: false }
-  | { readonly hasKey: true; readonly prefix: string; readonly lastUsedAt: string | null };
+  | {
+      readonly hasKey: true;
+      readonly prefix: string;
+      readonly lastUsedAt: string | null;
+    };
 
 /**
  * Response from `POST /api/v1/dashboard/auth/me/api-key` (issue/rotate).


### PR DESCRIPTION
## Summary

Implements the [Task Distribution & Assignment](../blob/Task_Distribution_Assignment/spec/tickets/Task_Distribution_%26_Assignment.md) ticket and hardens the surrounding code based on three multi-agent review rounds.

The feature makes task retries first-class in the DB/API, tightens stale-task reclaim against concurrent-sweep races, and adds a capability-aware heartbeat hint so agents only get told about work they can actually claim.

**Stats**: 15 files / 1,325 substantive lines (3,828 raw — 2,503 is the drizzle migration snapshot). 7 commits. Backend 397 / frontend 319 tests pass under `just ci-check`.

## What changed

### Retry budget (first-class)
- New `tasks.retry_count` column (`migrations/0008`) — additive, `NOT NULL DEFAULT 0`, Postgres-≥11 metadata-only on populated tables.
- Migration backfills from legacy `result_stats.retryCount`, guarded by a regex so a malformed JSONB row cannot abort the deploy.
- `handleTaskFailure` and `reassignStaleTasks` now read/write the column. Terminal failures emit the stable code `failureReason: 'max_retries_exceeded'`; agent-reported cause preserved in `resultStats.lastFailure`.

### Stale-task sweep hardening (`reassignStaleTasks`)
- Per-task try/catch so a single transient failure no longer strands the rest of the batch until the next 2-minute tick. New `errored` counter on the envelope.
- NULL-safe `assigned_at` race guard: `(assigned_at IS NULL OR assigned_at < threshold)` — legacy/migrated rows are no longer silently stranded forever.
- Per-task UPDATE conditional on `status IN ('assigned','running') AND agent_id = staleTask.agentId`, and the `.returning()` rowcount gates emit/aggregate-refresh/counter increment so a concurrent-sweep no-op produces no phantom transitions.
- Three near-identical terminal-fail blocks refactored into `terminalFailStaleTask` helper.

### Heartbeat capability hint (`processHeartbeat`)
- Gated on `online`/`benchmarked` post-transition status; an agent moving to `error` no longer gets told to claim more work.
- Capability filter (`buildCapabilityPredicate`) reused from the canonical `assignNextTask` claim path so the hint never advertises work the agent cannot actually claim.
- Lazy-import paths (`getHandleTaskFailure`, `getBuildCapabilityPredicate`) wrapped in try/catch with a `typeof === 'function'` check. On import failure the heartbeat degrades gracefully (hint omitted, fatal-fan-out logged) instead of 500-ing every agent until restart. `=== null` cache check fixed to `!= null` so a cached `undefined` cannot be called as a function.
- Once-per-agent warn-log fires for empty/non-object capabilities OR objects lacking usable `hashModes` — the predicate would silently zero-match otherwise.

### Scheduler & worker observability
- Heartbeat scheduler cadence extracted to `HEARTBEAT_SCHEDULER_INTERVAL_MS = 2 * 60 * 1000`. Comment documents the relationship to the 5-minute offline threshold.
- `heartbeat-monitor` worker now surfaces every non-zero sweep counter (`reassigned`/`rebalanced`/`failedOverrun`/`failedMaxRetries`/`errored`) at `warn` when failure-class counters are non-zero, `info` otherwise.
- `MAX_RETRIES = 3` exported and documented.

### Wire contract (`packages/openapi/agent-api.yaml`)
- `TaskDescriptor` rewritten to match what `/tasks/next` actually returns. Adds `agentId`, `status`, `progress`, `resultStats`, `requiredCapabilities`, `assignedAt`, `startedAt`, `completedAt`, `failureReason`, `createdAt`, `updatedAt`, `retryCount`. Removes stale `mode`/`hashTypeId`/`resources` fields that the route has never returned.
- Documents timestamp ISO-8601 format and explicit nullability for `assignedAt`/`startedAt`/`completedAt`/`failureReason`/`requiredCapabilities`.

### Shared types (`packages/shared`)
- New `assignedTaskSchema` + `requiredCapabilitiesSchema` in `schemas/index.ts`. `AssignedTask` and `RequiredCapabilities` now derived via `z.infer`, matching AGENTS.md's wire-shape convention.
- Timestamps use `z.coerce.date()` so the same schema parses both backend `Date` objects and the ISO-8601 strings clients receive after JSON serialization.

## Testing

`just ci-check` green: **397 backend tests / 0 fail** (440 total, 44 skipped isolated-phase), **319 frontend tests / 0 fail**.

New behavioral coverage added in this PR:
- `reassignStaleTasks`: partial-progress + zero-progress terminal-at-budget, boundary at `retryCount = MAX_RETRIES − 1`, per-task error isolation, rowcount-gated emit verification.
- `handleTaskFailure`: retry-below-cap writes column not `resultStats`, terminal-at-cap calls `updateCampaignProgress`, back-compat regression guard for legacy `result_stats.retryCount`.
- Heartbeat integration: predicate-call-with-agent-caps, status-gate short-circuit (`error`), warn-log for `null` capabilities, warn-log for empty `hashModes`.
- Agent API contract: non-zero `retryCount` round-trip through snake↔camel projection.

## Review history

This PR went through three multi-agent review rounds (CodeRabbit + Copilot + internal). 9 review threads were filed and resolved, 1 review-body nitpick was also fixed (the `z.infer` migration).

| Round | Commit | Findings addressed |
|---|---|---|
| Initial | `15fa92b` + `d1fbbc6` | Feature implementation + formatter reconciliation |
| Round 1 | `a2b441b` + `99cce03` | 20 review findings: per-task try/catch, NULL-safe guard, conditional UPDATE, lazy-import hardening, status gate, capabilities warn log, sweep counter logging, retry-count backfill, terminal `failureReason` symmetry |
| Round 2 | `fe9ba34` + `b4a4fec` | 7 findings: migration cast safety, terminal UPDATE ownership guard, rowcount-gated emissions in all three sweep branches, AssignedTask via `z.infer` |
| Round 3 | `304a060` | 3 findings: TaskDescriptor OpenAPI spec rewrite to match real response, `z.coerce.date()`, empty-`hashModes` capability detection |

## Risk assessment

🟡 **Medium** — bounded by:
- **Migration**: additive column + idempotent backfill, regex-guarded against malformed JSONB. PG-≥11 metadata-only on populated tables. Pre-deploy `result_stats.retryCount` is preserved into the new column.
- **Agent API**: additive on the response (new fields) and the spec finally matches reality. No breaking change for agents that ignore unknown fields. Validated by contract tests.
- **Concurrency**: every per-task UPDATE in the sweep is now guarded and rowcount-gated; a concurrent sweep produces a no-op, not a duplicate event or counter inflation.
- **Observability**: every failure-class counter now logs at `warn`, so operators see terminal-fail spikes immediately.

Not in scope (documented for the next ticket):
- Postgres advisory lock around the sweep — the conditional UPDATE is sufficient defense-in-depth for the current cadence overlap risk during rolling deploys.

## Checklist

- [x] `just check` (format, lint, type-check, build) — green
- [x] `just ci-check` (above + full test suite) — green (397+319/0 fail)
- [x] OpenAPI spec matches route response (`TaskDescriptor`)
- [x] Migration is additive + reversible-via-backfill, safe on populated tables
- [x] Wire shapes use `z.infer` per AGENTS.md
- [x] All review-thread feedback resolved (0 unresolved threads)
- [ ] Manual smoke: campaign start crossing the 100-task inline/async boundary against a real agent fleet
- [ ] Manual smoke: drop an agent mid-task, confirm the sweep transitions through `pending` → reassign → eventual `failed` after 3 retries