### PR TITLE
feat(health): rename minio → object_store + AC matrix for issue #156

### DIFF
--- a/docs/issues/156-ac-traceability-matrix.md
+++ b/docs/issues/156-ac-traceability-matrix.md
@@ -1,0 +1,100 @@
+# Issue #156 — AC ↔ Code ↔ Test Traceability Matrix
+
+> Built from issue #156 (20 acceptance checkboxes across 6 blocks). Drives the verification sweep and minio→object_store rename in plan `docs/plans/2026-05-25-001-feat-object-storage-verification-and-health-rename-plan.md`.
+
+Legend: ✅ Covered · 🟡 Partial · ❌ Orphan · ⚠️ Documented deviation · 🔧 Closed in this PR.
+
+---
+
+## AC 1 — S3 Client Configuration
+
+| # | AC | Production symbol | Test reference | Status |
+|---|----|-------------------|----------------|--------|
+| 1.1 | Client configured with endpoint, access key, secret key from environment variables | `packages/backend/src/config/storage.ts:26-44` (`new S3Client({ endpoint: env.S3_ENDPOINT, credentials: { accessKeyId: env.S3_ACCESS_KEY, secretAccessKey: env.S3_SECRET_KEY }, ... })`) | `packages/backend/tests/unit/health-service.test.ts` exercises probe against env-configured client | ✅ |
+| 1.2 | Bucket name sourced from `S3_BUCKET` | `config/env.ts:24-31` (Zod schema, `default('hashhive')`) consumed by every `file_ref` site | Implicit in upload/download integration tests | ✅ |
+| 1.3 | Same client code works against SeaweedFS and AWS S3 with no provider-specific branches | `config/storage.ts` — only `forcePathStyle: true` flag, no branching on endpoint | n/a (provider-neutrality is a code-shape assertion) | ✅ |
+
+---
+
+## AC 2 — File Upload
+
+| # | AC | Production symbol | Test reference | Status |
+|---|----|-------------------|----------------|--------|
+| 2.1 | Unique object keys `{project_id}/{resource_type}/{uuid}.{ext}` | `services/resources.ts:317` (`${hl.projectId}/hash-lists/${randomUUID()}${ext}`), `:540` (`${resource.projectId}/${prefix}/${randomUUID()}${ext}`), `:663` (`${projectId}/${prefix}/${randomUUID()}` — no ext) | `packages/backend/tests/unit/resources-*.test.ts` (key construction) | 🟡 — `:663` omits `${ext}`; verify intent during U4. |
+| 2.2 | `file_ref` JSONB stores `{ bucket, key, contentType, size, uploadedAt }` | `services/resources.ts:325-330`, `:548-553`, `:684-686`, `:763-768` | Multipart-upload + hash-list-parse integration tests | ✅ |
+| 2.3 | Bucket in `file_ref` matches env (no hardcoded `'hashhive'`) | Every `file_ref` site reads `env.S3_BUCKET`; `rg "'hashhive'" packages/backend/src/` returns one hit at `config/env.ts:31` (Zod default — fine) | n/a (grep-verifiable) | ✅ **The ticket's "Current Implementation Issue" warning is stale** — hardcoding was already removed (likely #122 or #153). |
+| 2.4 | Upload returns object metadata (bucket, key, size, content type) | `services/resources.ts:325-330` and sibling sites return the full `file_ref` shape | Integration tests | ✅ |
+
+---
+
+## AC 3 — Presigned URLs
+
+| # | AC | Production symbol | Test reference | Status |
+|---|----|-------------------|----------------|--------|
+| 3.1 | Presigned URLs with 1-hour expiration | `services/resources.ts:573-577` (`getDownloadUrl` → `getPresignedUrl(key, 3600, ...)`); **`services/resources.ts:587-613` (`getAgentDownloadUrl` uses `6 * 3600`)** | Storage/resource integration tests | ⚠️ — `getAgentDownloadUrl` deliberately exceeds 1h to support large-file agent downloads. Documented deviation. |
+| 3.2 | URLs work against SeaweedFS and AWS S3 unchanged | `config/storage.ts:121-134` uses `@aws-sdk/s3-request-presigner` (`getSignedUrl`) — provider-neutral | n/a (provider-neutrality is a code-shape assertion) | ✅ |
+| 3.3 | Content-disposition headers for downloads | `config/storage.ts:92-115` (`buildContentDisposition`) emits both `filename=` ASCII fallback + `filename*=UTF-8''<percent-encoded>` modern form; sanitizes hostile filenames | Inline unit coverage on the builder; integration test exercises real URL | ✅ |
+
+---
+
+## AC 4 — Health Checks
+
+| # | AC | Production symbol | Test reference | Status |
+|---|----|-------------------|----------------|--------|
+| 4.1 | Object-store connectivity check added to `/health` | `services/health.ts:339, 397-398` (probe wired in `runProbes`); route at `routes/control/health.ts` (and dashboard equivalent) | `tests/unit/health-service.test.ts`, `tests/unit/health.test.ts` | ✅ |
+| 4.2 | Health check verifies bucket exists and is accessible | `services/health.ts` — probe uses `HeadBucketCommand` against `env.S3_BUCKET` via `checkObjectStoreHealth` | `tests/unit/health-service.test.ts` (asserts connected + bucket field) | ✅ |
+| 4.3 | Status (connected/disconnected); log/field names use neutral terms (`object_store`, not `minio`) | **Currently uses `minio` wire identifier** per defensive preservation in PR #153 | n/a (current code violates the AC) | 🔧 **Closed in this PR** — U2/U3 rename. |
+
+---
+
+## AC 5 — 12-Factor Compliance
+
+| # | AC | Production symbol | Test reference | Status |
+|---|----|-------------------|----------------|--------|
+| 5.1 | All object-store config sourced from env vars | `config/env.ts` Zod schema covers `S3_ENDPOINT`, `S3_BUCKET`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_REGION` | Env validation tests | ✅ |
+| 5.2 | No hardcoded bucket names in code | Confirmed via `rg "'hashhive'" packages/backend/src/` (one hit = the Zod default) | n/a (grep-verifiable) | ✅ |
+| 5.3 | Config validated on startup (fail fast if misconfigured) | `config/env.ts:66-83` — Zod throws on parse failure; warn-once on `S3_BUCKET` falling back to default | Env-load tests | ✅ |
+
+---
+
+## AC 6 — Local Stack Migration
+
+| # | AC | Production symbol | Test reference | Status |
+|---|----|-------------------|----------------|--------|
+| 6.1 | `docker-compose.yml` replaces `minio` with `seaweedfs` running `weed server -s3`, S3 API on port 9000 | `docker-compose.yml` — `chrislusf/seaweedfs:4.27`, ports `9000:8333` (S3 API) + `127.0.0.1:9333` (master UI) | Smoke test via `docker compose up` | ✅ |
+| 6.2 | Default creds + bucket seeded on first start matching prior MinIO defaults | `docker/seaweedfs/s3-iam.json` provides `minioadmin/minioadmin`; bucket auto-created on first S3 call | `just db-seed` and integration tests work without env-var changes | ✅ **Keeping `minioadmin/minioadmin` per AC 6.2's "matching prior defaults" language.** Not renamed. |
+| 6.3 | `docs/development.md` updated: drop MinIO console refs, add SeaweedFS S3-API instructions | `docs/development.md:87, 94, 104` (already mentions SeaweedFS) | n/a (doc audit in U5) | 🟡 → 🔧 U5 audit ensures no residual MinIO operational instructions remain. |
+| 6.4 | `S3_ENDPOINT` default in `.env.example` / `env.ts` points at SeaweedFS; `S3_*` names retained | `.env.example:14` (`S3_ENDPOINT=http://localhost:9000`), `env.ts:24-31` (env-driven; defaults match compose) | n/a (config-verifiable) | ✅ |
+
+---
+
+## Pre-rename consumer audit
+
+`rg "services\.minio|body\['minio'\]|body\.minio" packages/`:
+
+**Backend code:**
+- `services/health.ts` — owner of the field; renamed in U2.
+- `tests/unit/health.test.ts`, `tests/unit/health-service.test.ts` — assertions, renamed in U2.
+
+**Frontend code:**
+- `packages/frontend/src/hooks/use-system-health.ts` — `ComponentName` type literal `'minio'` (renamed in U3).
+- `packages/frontend/src/components/features/system-health-card.tsx` — label map + `COMPONENT_ORDER` (renamed in U3).
+
+**OpenAPI:**
+- `packages/openapi/control-api.yaml` — 3 refs (description + required array + properties object); renamed in U3.
+
+**Shared:** no references.
+
+**External consumers:** none in the repo. HashHive is pre-prod; renaming the wire field is safe.
+
+---
+
+## Orphans
+
+| AC | Orphan | Closure |
+|----|--------|---------|
+| 2.1 | `services/resources.ts:663` omits `${ext}` from the key | U4 audit — verify intent; either fix or document. |
+| 4.3 | `minio` wire identifier survives | U2 + U3 rename. |
+| 6.3 | residual MinIO operational instructions in `docs/development.md` | U5 audit. |
+
+All other AC items are either ✅ or documented deviations.

--- a/docs/issues/156-ac-traceability-matrix.md
+++ b/docs/issues/156-ac-traceability-matrix.md
@@ -1,6 +1,6 @@
 # Issue #156 — AC ↔ Code ↔ Test Traceability Matrix
 
-> Built from issue #156 (20 acceptance checkboxes across 6 blocks). Drives the verification sweep and minio→object_store rename in plan `docs/plans/2026-05-25-001-feat-object-storage-verification-and-health-rename-plan.md`.
+> Built from issue #156 (20 acceptance checkboxes across 6 blocks). Drives the verification sweep and `minio` → `object_store` rename. The companion implementation plan is local-only (`docs/plans/` is gitignored); see `docs/issues/156-object-storage-file-management-spec.md` for the durable spec.
 
 Legend: ✅ Covered · 🟡 Partial · ❌ Orphan · ⚠️ Documented deviation · 🔧 Closed in this PR.
 

--- a/docs/issues/156-ac-traceability-matrix.md
+++ b/docs/issues/156-ac-traceability-matrix.md
@@ -31,7 +31,7 @@ Legend: ✅ Covered · 🟡 Partial · ❌ Orphan · ⚠️ Documented deviation
 
 | # | AC | Production symbol | Test reference | Status |
 |---|----|-------------------|----------------|--------|
-| 3.1 | Presigned URLs with 1-hour expiration | `services/resources.ts:573-577` (`getDownloadUrl` → `getPresignedUrl(key, 3600, ...)`); **`services/resources.ts:587-613` (`getAgentDownloadUrl` uses `6 * 3600`)** | Storage/resource integration tests | ⚠️ — `getAgentDownloadUrl` deliberately exceeds 1h to support large-file agent downloads. Documented deviation. |
+| 3.1 | Presigned URLs with 1-hour expiration | `services/resources.ts → getResourcePresignedUrl` (calls `getPresignedUrl(key, 3600, ...)`); **`services/resources.ts → getAgentDownloadUrl` uses `6 * 3600`** | Storage/resource integration tests | ⚠️ — `getAgentDownloadUrl` deliberately exceeds 1h to support large-file agent downloads. Documented deviation. |
 | 3.2 | URLs work against SeaweedFS and AWS S3 unchanged | `config/storage.ts:121-134` uses `@aws-sdk/s3-request-presigner` (`getSignedUrl`) — provider-neutral | n/a (provider-neutrality is a code-shape assertion) | ✅ |
 | 3.3 | Content-disposition headers for downloads | `config/storage.ts:92-115` (`buildContentDisposition`) emits both `filename=` ASCII fallback + `filename*=UTF-8''<percent-encoded>` modern form; sanitizes hostile filenames | Inline unit coverage on the builder; integration test exercises real URL | ✅ |
 
@@ -41,7 +41,7 @@ Legend: ✅ Covered · 🟡 Partial · ❌ Orphan · ⚠️ Documented deviation
 
 | # | AC | Production symbol | Test reference | Status |
 |---|----|-------------------|----------------|--------|
-| 4.1 | Object-store connectivity check added to `/health` | `services/health.ts:339, 397-398` (probe wired in `runProbes`); route at `routes/control/health.ts` (and dashboard equivalent) | `tests/unit/health-service.test.ts`, `tests/unit/health.test.ts` | ✅ |
+| 4.1 | Object-store connectivity check added to `/health` | `services/health.ts → executeProbes` wires the `object_store` probe via `buildDefaultProbes`; route at `routes/control/health.ts` (and dashboard equivalent) | `tests/unit/health-service.test.ts`, `tests/unit/health.test.ts` | ✅ |
 | 4.2 | Health check verifies bucket exists and is accessible | `services/health.ts` — probe uses `HeadBucketCommand` against `env.S3_BUCKET` via `checkObjectStoreHealth` | `tests/unit/health-service.test.ts` (asserts connected + bucket field) | ✅ |
 | 4.3 | Status (connected/disconnected); log/field names use neutral terms (`object_store`, not `minio`) | **Currently uses `minio` wire identifier** per defensive preservation in PR #153 | n/a (current code violates the AC) | 🔧 **Closed in this PR** — U2/U3 rename. |
 

--- a/docs/issues/156-object-storage-file-management-spec.md
+++ b/docs/issues/156-object-storage-file-management-spec.md
@@ -1,0 +1,190 @@
+# Technical Spec — Issue #156: Object Storage & File Management
+
+> **Source ticket:** [`spec/tickets/Object_Storage_&_File_Management.md`](../../spec/tickets/Object_Storage_&_File_Management.md)
+> **GitHub issue:** [#156](https://github.com/EvilBit-Labs/hash_hive/issues/156)
+> **Track:** Phase 1 — Foundation, Step 2 of 11 (Resource Pipeline)
+> **Date:** 2026-05-25
+
+---
+
+## 1. Issue Summary
+
+Configure an S3-compatible object store with env-driven buckets, presigned URLs, object-store health checks, and 12-factor config — now targeting **SeaweedFS** (Apache-2.0) instead of MinIO (archived upstream + AGPL-3.0). Unblocks the Resource Management API (issue #157).
+
+## 2. Problem Statement
+
+Per BACKLOG.md, "Some chunked-upload code exists from #122 but AC isn't fully met." Code exploration shows the **core infrastructure swap already landed in PR #153** (commit `b4fbc5a`):
+
+- `docker-compose.yml` runs `chrislusf/seaweedfs:4.27` with `weed server -s3`, mounting a static IAM config (`docker/seaweedfs/s3-iam.json`).
+- `packages/backend/src/config/storage.ts` uses `@aws-sdk/client-s3` with `forcePathStyle: true` and explicit connect/socket timeouts (5s connect / 30s socket — bounds worker slot exposure on a hung endpoint).
+- `env.S3_ENDPOINT`, `env.S3_BUCKET`, `env.S3_ACCESS_KEY`, `env.S3_SECRET_KEY`, `env.S3_REGION` are all env-driven with a startup warn-once on default fallback.
+- `services/resources.ts` builds `file_ref` with `{ bucket, key, contentType, size, uploadedAt }` using `env.S3_BUCKET`.
+- Object keys follow the ticket's `{project_id}/{resource_type}/{uuid}.{ext}` convention via `randomUUID()` from `node:crypto` (`services/resources.ts:317, 540, 663`).
+- Presigned `GetObject` URLs are emitted via `getPresignedUrl()` with full content-disposition (`filename=` ASCII fallback + `filename*=UTF-8''` modern form).
+- Chunked multipart upload (`CreateMultipartUpload`, `UploadPart`, `CompleteMultipartUploadCommand`, `AbortMultipartUploadCommand`, `ListPartsCommand`) is wired.
+
+The literal remaining work is therefore narrow: **verify the AC checklist passes against the current code, close any gaps surfaced by the verification, and reconcile the one explicit tension between the source ticket and the implementation choice in PR #153.**
+
+### Stale guidance in the ticket
+
+The ticket's "Technical Notes → Current Implementation Issue" section says `packages/backend/src/services/resources.ts` hard-codes `fileRef.bucket = 'hashhive'`. **This is no longer true.** Grep for the literal `'hashhive'` in `packages/backend/src/` returns exactly one hit — `env.ts:31`, the Zod default value — and every `file_ref` construction at `:325, :548, :684, :763` reads from `env.S3_BUCKET`. The hardcoding the ticket warned about has already been fixed (likely as part of #122 or #153). The verification sweep should confirm this and note it in the matrix rather than re-fixing.
+
+## 3. The one real reconciliation: health-check field naming
+
+**AC 4 says:** "log messages and field names use neutral terms (e.g., `object_store`, not `minio`)".
+
+**Current code (`services/health.ts:30-36`):**
+```typescript
+// 'minio' is preserved as the wire identifier across the SeaweedFS swap
+export type ComponentName = 'database' | 'redis' | 'minio' | 'queues'
+```
+
+PR #153 preserved `minio` as the wire identifier defensively, but **HashHive is pre-prod** — there are no external monitors reading `services.minio.*` whose contract needs honoring. The defensive preservation has outlived its usefulness; the new wire identifier should be neutral so future readers don't have to mentally translate `minio` → "actually SeaweedFS, or AWS S3 if hosted."
+
+**Recommendation: rename `minio` → `object_store` outright.**
+
+Concrete renames in scope:
+
+- `ComponentName` enum literal: `'minio'` → `'object_store'` (`services/health.ts:36`).
+- `ObjectStoreProbeDeps` and probe wiring: `minio` keys → `objectStore` (`services/health.ts:323, 339, 358, 375, 385, 397-398, 408`).
+- Legacy envelope `services.minio.bucket` → `services.object_store.bucket` (`services/health.ts:521, 545, 548, 558-559`).
+- Comments documenting the legacy contract: rewritten or removed — the back-compat note is now obsolete.
+- Log fields: any `{ component: 'minio' }` log line → `{ component: 'object_store' }`.
+- Shared schemas + OpenAPI exposing the health shape get the same rename in lock-step (per `docs/solutions/conventions/shared-zod-openapi-wire-contract-mirror-2026-05-25.md`).
+
+This is a breaking change to the `/health` response shape. Mitigation: confirm during Phase A that no in-repo dashboard, agent, or CLI code reads `services.minio.*`. If a consumer exists, that consumer is updated in the same PR.
+
+## 4. Technical Approach
+
+Verify-first, fix-only-where-needed. Mirrors the workflow established by PR #169 / issue #155 (see `docs/solutions/conventions/shared-zod-openapi-wire-contract-mirror-2026-05-25.md`):
+
+1. Build an AC↔code↔test matrix mapping each of the 6 AC blocks (15 checkboxes total across S3 client config, file upload, presigned URLs, health checks, 12-factor compliance, local-stack migration) to its production symbol + test.
+2. For each orphan, write a failing test first; either confirm the production code is correct or fix the gap.
+3. Reconcile AC 4's neutral-naming requirement via Option A above.
+4. Run `just check` and `just ci-check`; both must pass.
+
+## 5. Implementation Plan
+
+### Phase A — AC Traceability Matrix (read-only)
+
+The source ticket has **20 acceptance checkboxes** across 6 blocks (3 + 4 + 3 + 3 + 3 + 4). Map each to its production symbol:
+
+1. **AC 1.1-1.3 — S3 client config** → `packages/backend/src/config/storage.ts:26-44` + `env.ts:24-31`. Verify no provider-specific branches (`forcePathStyle: true` is the only provider-flavor flag and applies to both SeaweedFS and AWS S3 path-style).
+2. **AC 2.1-2.4 — file upload + `file_ref` shape** → `services/resources.ts:325-330`, `:548-553`, `:684-686`, `:763-768`. Key generation at `:317, :540, :663` uses `${projectId}/${prefix}/${randomUUID()}${ext}` (note: `:663` omits `${ext}`; verify whether that path needs an extension or is intentional).
+3. **AC 3.1-3.3 — presigned URLs** → `config/storage.ts:121-134` (`getPresignedUrl`) + `services/resources.ts:573-577` (`getDownloadUrl`, 1h) + `:587-613` (`getAgentDownloadUrl`, 6h). The 6h variant exceeds the AC's 1h expiration — verify whether this is an intentional override for large-file agent downloads (likely yes) and document the deviation.
+4. **AC 4.1-4.3 — health checks** → `services/health.ts:30-36`, `:323`, `:339`, `:385-408`, `:521-559`. The neutral-naming AC drives the rename in §3.
+5. **AC 5.1-5.3 — 12-factor compliance** → `config/env.ts` Zod schema + `:66-83` warn-once. Verify fail-fast on missing required vars (no defaults for `S3_ACCESS_KEY` / `S3_SECRET_KEY`).
+6. **AC 6.1-6.4 — local-stack migration**:
+   - `6.1` SeaweedFS service in compose → `docker-compose.yml` (host port 9000 → container 8333; master UI on 9333 loopback-bound).
+   - `6.2` Default credentials + bucket seeded on first start → `docker/seaweedfs/s3-iam.json` provides `minioadmin/minioadmin` matching prior MinIO defaults; bucket created via S3 API on first start. Verify `just db-seed` and integration tests work without env-var changes.
+   - `6.3` `docs/development.md` updated → already mentions "SeaweedFS (S3 API)" at line 87 and the MinIO archive note at line 94. Audit for any residual MinIO console references.
+   - `6.4` `.env.example` and `env.ts` defaults → `.env.example:14` sets `S3_ENDPOINT=http://localhost:9000`; `env.ts:31` defaults `S3_BUCKET=hashhive`. Existing `S3_*` names retained (provider-neutral).
+7. Output the matrix to `docs/issues/156-ac-traceability-matrix.md` listing every checkbox + status.
+
+### Side-question to settle in Phase A
+
+The seeded credentials in `docker/seaweedfs/s3-iam.json` are `minioadmin/minioadmin` (literally — the prior MinIO defaults). These are conceptually opaque keys and AC 6.2 explicitly says "matching the prior MinIO defaults so `just db-seed` and integration tests do not need new env wiring." Either:
+
+- **Keep** `minioadmin/minioadmin` — honors AC 6.2 verbatim; the literal is just an opaque dev secret.
+- **Rename** to `hashhiveadmin/hashhiveadmin` — consistent with the broader `minio` → `object_store` rename; requires updating `.env.example`, every test fixture, `just db-seed`, and any CI env vars.
+
+Recommend **keep** — the credential literal is not a "wire identifier" in the AC 4 sense (it's a secret, not a discoverable field name) and AC 6.2's "matching prior defaults" language was deliberate. Document the decision in the AC matrix so it does not get re-litigated.
+
+### Phase B — Close Orphans (TDD)
+
+Only the orphans the matrix surfaces get tests + fixes. Expected orphans based on the AC text vs. current code review:
+
+- **AC 4 — neutral naming.** Rename `minio` → `object_store` across the `ComponentName` enum, probe deps, legacy envelope, log fields, and any shared/OpenAPI schemas that expose the shape. Update tests to assert the new field; drop the legacy `minio` field assertions.
+- **AC 6.3 — `docs/development.md` updated.** Verify the doc mentions SeaweedFS S3-API; replace any lingering MinIO console references.
+- **AC 6.4 — `S3_ENDPOINT` default in `.env.example`.** Verify the default matches the SeaweedFS compose service.
+
+Before the AC 4 rename, grep the repo for any consumer reading `services.minio.*`:
+
+```bash
+rg "services\.minio|body\['minio'\]|body\.minio" packages/
+```
+
+If a consumer exists (frontend hook, agent code, CLI), update it in the same PR. If none exists (the expected outcome for a pre-prod repo), the rename is a clean drop-replace.
+
+Anything else the matrix flags gets the same TDD pattern: failing test → fix → re-run.
+
+### Phase C — Validation Gates
+
+1. `just check` (format + lint + type-check + build)
+2. `just ci-check` (full test suite)
+3. Manual smoke: `docker compose up seaweedfs`, `bun --filter @hashhive/backend test -- storage` to confirm the local stack still works end-to-end.
+
+## 6. Test Plan
+
+TDD per `~/.claude/rules/testing.md`. Each AC checkbox that becomes an orphan gets a failing test before any production change.
+
+### Unit (bun:test, backend)
+
+- `getPresignedUrl` — emits both `filename=` ASCII fallback and `filename*=UTF-8''` modern form when a filename is provided; emits neither when omitted.
+- `getPresignedUrl` — sanitizes hostile filenames (control chars, path-traversal sequences) before they hit the header.
+- `file_ref` shape — `bucket` field reads from `env.S3_BUCKET`, never hardcoded `'hashhive'` literal at any call site.
+- Env validation — startup fails fast when `S3_ACCESS_KEY` / `S3_SECRET_KEY` are absent; warn-once fires when `S3_BUCKET` falls back to the default.
+
+### Integration
+
+- Object-store health probe — `HeadBucketCommand` succeeds against the SeaweedFS compose service; failure surfaces as `status: 'disconnected'` with bucket detail.
+- Multipart upload round-trip — `CreateMultipartUpload` → `UploadPart` × N → `CompleteMultipartUpload` succeeds; partial upload + `AbortMultipartUpload` cleans up.
+- Presigned URL fetch — agent retrieves the file via the presigned URL with content-disposition honored by SeaweedFS.
+
+### Contract / health envelope
+
+- `GET /health` response — `services.object_store.status` field present (new); `services.minio.bucket` field preserved verbatim (legacy contract from #109).
+- `services.object_store` and `services.minio` reference the same underlying probe so the two fields cannot disagree.
+
+## 7. Files to Modify / Create
+
+| Path | Action |
+| ---- | ------ |
+| `docs/issues/156-ac-traceability-matrix.md` | Create — 15-checkbox AC↔code↔test matrix |
+| `packages/backend/src/services/health.ts` | Modify — rename `minio` → `object_store` across `ComponentName`, probe deps, legacy envelope, and comments |
+| `packages/shared/src/schemas/index.ts` | Modify — rename `minio` → `object_store` in the health response schema |
+| `packages/openapi/agent-api.yaml` / `packages/openapi/control-api.yaml` | Modify — rename in lock-step if the health shape is exposed |
+| `packages/frontend/src/**` and `packages/backend/src/routes/**` | Audit and update — anything reading `services.minio.*` flips to `services.object_store.*` |
+| `docs/development.md` | Modify — verify SeaweedFS S3-API instructions; drop any MinIO console refs |
+| `.env.example` | Verify — `S3_ENDPOINT` default points at the SeaweedFS compose service |
+| `packages/backend/tests/unit/health-service.test.ts` | Extend — assert dual `minio` + `object_store` fields |
+| `packages/backend/tests/integration/storage.test.ts` | Extend if matrix surfaces gaps in multipart or presigned-URL coverage |
+
+## 8. Success Criteria
+
+All **20** AC checkboxes (3 + 4 + 3 + 3 + 3 + 4) close with green tests and `just ci-check` clean:
+
+1. ✅ **S3 client config** (3) — env-driven endpoint/credentials/bucket; same client works against SeaweedFS and AWS S3; no provider-specific branches.
+2. ✅ **File upload** (4) — unique `{project_id}/{resource_type}/{uuid}.{ext}` keys, `file_ref: { bucket, key, contentType, size, uploadedAt }`, bucket from env, upload returns metadata.
+3. ✅ **Presigned URLs** (3) — 1h expiration (with 6h documented deviation for large-file agent downloads), provider-neutral, content-disposition headers present.
+4. ⚠️ **Health checks** (3) — `minio` renamed to `object_store` across the health envelope and all consumers; no legacy field retained. **This is the real work in this PR.**
+5. ✅ **12-factor compliance** (3) — all config env-driven; no hardcoded bucket; fail-fast on missing required vars.
+6. ✅ **Local-stack migration** (4) — SeaweedFS in compose with S3 API on port 9000; default creds/bucket seeded via `s3-iam.json`; docs mention SeaweedFS; `.env.example` and `env.ts` defaults point at SeaweedFS.
+
+Definition of done (per issue #156):
+
+- `just check` green.
+- `just ci-check` green.
+- Cross-API-boundary types live in `@hashhive/shared`.
+- OpenAPI specs updated in lock-step.
+
+## 9. Out of Scope
+
+- Hash list parsing logic (issue #157 — Resource Management API).
+- Resource UI (Phase 1 step 9 — Resource Management UI).
+- File versioning or backup strategies.
+- Migration of pre-existing MinIO data (HashHive is pre-prod; the dev MinIO bucket can be re-seeded).
+- AWS S3 hosted deployment validation (the contract is the S3 API; we trust SeaweedFS's S3-compatibility claim).
+
+## 10. Risks & Mitigations
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Rename misses an in-repo consumer of `services.minio.*` | Phase A grep sweep (`rg "services\.minio\|body\['minio'\]\|body\.minio"`) catches consumers before the rename lands; CI type-check + tests catch any missed call site. |
+| SeaweedFS multipart upload behaves subtly differently from AWS S3 on edge cases (part size, ETag format) | Run integration tests against the local compose stack; AWS S3 is out of scope for this sweep. |
+| `docker/seaweedfs/s3-iam.json` IAM config drift across dev / CI | The compose file mounts the file from the repo; any drift is a commit-time signal. |
+
+## 11. Open Questions
+
+- Is `/health` exposed via an OpenAPI surface that agent or dashboard clients consume? If yes, the rename propagates through `packages/openapi/*.yaml` and `@hashhive/shared` in lock-step per the wire-contract convention. If no (internal-only surface), the rename stays within the backend.
+- Is there value in adding a SeaweedFS-specific smoke test that exercises the `weed shell` provisioning flow? Likely out of scope (compose-service correctness is verified by `docker compose up && just check`).

--- a/docs/issues/156-object-storage-file-management-spec.md
+++ b/docs/issues/156-object-storage-file-management-spec.md
@@ -33,7 +33,7 @@ The ticket's "Technical Notes → Current Implementation Issue" section says `pa
 
 **AC 4 says:** "log messages and field names use neutral terms (e.g., `object_store`, not `minio`)".
 
-**Current code (`services/health.ts:30-36`):**
+**Pre-rename code from PR #153** (kept here as the historical state this spec was written against):
 ```typescript
 // 'minio' is preserved as the wire identifier across the SeaweedFS swap
 export type ComponentName = 'database' | 'redis' | 'minio' | 'queues'
@@ -41,7 +41,7 @@ export type ComponentName = 'database' | 'redis' | 'minio' | 'queues'
 
 PR #153 preserved `minio` as the wire identifier defensively, but **HashHive is pre-prod** — there are no external monitors reading `services.minio.*` whose contract needs honoring. The defensive preservation has outlived its usefulness; the new wire identifier should be neutral so future readers don't have to mentally translate `minio` → "actually SeaweedFS, or AWS S3 if hosted."
 
-**Recommendation: rename `minio` → `object_store` outright.**
+**Decision: rename `minio` → `object_store` outright.** Landed in this PR — the live code now reads `'database' | 'redis' | 'object_store' | 'queues'` and `HEALTH_VERSION` bumped to `2.0.0`.
 
 Concrete renames in scope:
 
@@ -133,8 +133,9 @@ TDD per `~/.claude/rules/testing.md`. Each AC checkbox that becomes an orphan ge
 
 ### Contract / health envelope
 
-- `GET /health` response — `services.object_store.status` field present (new); `services.minio.bucket` field preserved verbatim (legacy contract from #109).
-- `services.object_store` and `services.minio` reference the same underlying probe so the two fields cannot disagree.
+- `GET /health` response — `services.object_store.status` and `services.object_store.bucket` are present.
+- `services.minio` is **absent** from the response shape after the rename — no dual-write, no alias. Pre-2.0.0 probes keyed on the old name see `undefined`.
+- `HEALTH_VERSION` (in `services/health.ts`) bumps to `2.0.0` in lock-step with the OpenAPI `info.version` in `packages/openapi/control-api.yaml` so consumers can gate on the breaking change.
 
 ## 7. Files to Modify / Create
 
@@ -147,7 +148,7 @@ TDD per `~/.claude/rules/testing.md`. Each AC checkbox that becomes an orphan ge
 | `packages/frontend/src/**` and `packages/backend/src/routes/**` | Audit and update — anything reading `services.minio.*` flips to `services.object_store.*` |
 | `docs/development.md` | Modify — verify SeaweedFS S3-API instructions; drop any MinIO console refs |
 | `.env.example` | Verify — `S3_ENDPOINT` default points at the SeaweedFS compose service |
-| `packages/backend/tests/unit/health-service.test.ts` | Extend — assert dual `minio` + `object_store` fields |
+| `packages/backend/tests/unit/health-service.test.ts` | Extend — assert `object_store` fields and absence of `minio` |
 | `packages/backend/tests/integration/storage.test.ts` | Extend if matrix surfaces gaps in multipart or presigned-URL coverage |
 
 ## 8. Success Criteria

--- a/docs/solutions/conventions/shared-zod-openapi-wire-contract-mirror-2026-05-25.md
+++ b/docs/solutions/conventions/shared-zod-openapi-wire-contract-mirror-2026-05-25.md
@@ -1,0 +1,157 @@
+---
+module: packages/shared, packages/openapi, packages/backend
+date: 2026-05-25
+problem_type: convention
+component: api-contract
+severity: medium
+tags:
+  - zod
+  - openapi
+  - shared-types
+  - wire-contract
+  - agents-md
+  - verification-sweep
+  - contract-test
+applies_when:
+  - "Adding or changing a field on a shape that crosses the agent/dashboard/control API boundary"
+  - "A response field is intentionally omit-when-false (the field is absent rather than carrying an explicit false value)"
+  - "An issue's acceptance criteria are largely already met on main and the work is a verification sweep, not greenfield implementation"
+---
+
+# Mirror agent-API wire shapes across Zod + OpenAPI + route boundary
+
+## Context
+
+PR #169 closed issue #155 (Task Distribution & Assignment). Code exploration showed every behavioral AC was already implemented on `main` — the runtime path for strict assignment, hybrid generation, reassignment, retry logic, priority queuing, and the `hasHighPriorityTasks` heartbeat flag had been complete since prior scheduler work. What was missing was the AGENTS.md-mandated contract sync: `hasHighPriorityTasks` lived only in `packages/backend/src/services/agents.ts` and the route handler. There was no Zod schema in `@hashhive/shared`, no field in `packages/openapi/agent-api.yaml`, and no contract test asserting the response shape. Generated agent SDKs reading the spec had no typed access to a flag the server has been emitting for sprints.
+
+This isn't a one-off oversight pattern. The AGENTS.md rules exist precisely because it's easy to ship a backend-only field that violates the cross-boundary contract — `just check` and the unit tests stay green, agents still get the field on the wire, nothing breaks loudly. The drift compounds silently until a downstream SDK consumer tries to regenerate against the OpenAPI spec.
+
+## Guidance
+
+When a field crosses the agent/dashboard/control API boundary, land it in **three places in the same change**: the shared Zod schema, the OpenAPI spec, and a contract test that round-trips the route's actual response body through the shared schema.
+
+### 1. Shared Zod schema (`packages/shared/src/schemas/index.ts`)
+
+For a field with an omit-when-false wire policy, use `z.literal(true).optional()` (not `z.boolean().optional()`). The literal mirrors the OpenAPI `enum: [true]` constraint and makes a route refactor that emits `false` a compile error.
+
+Use `.strict()` to mirror OpenAPI's closed-by-default semantics — extra fields fail parse rather than slip through.
+
+```typescript
+export const agentHeartbeatResponseSchema = z
+  .object({
+    acknowledged: z.literal(true),
+    // The schema enforces "if present, value is true." The omit-when-false
+    // POLICY lives in the route's conditional spread; the schema does not
+    // enforce policy, only value shape.
+    hasHighPriorityTasks: z.literal(true).optional(),
+  })
+  .strict()
+```
+
+Export the inferred type from `packages/shared/src/types/index.ts`:
+
+```typescript
+export type AgentHeartbeatResponse = z.infer<typeof agentHeartbeatResponseSchema>
+```
+
+### 2. OpenAPI component schema (`packages/openapi/agent-api.yaml`)
+
+Mirror the Zod schema field-for-field. Use `enum: [true]` on a boolean to mirror `z.literal(true)`. Do **not** list omit-when-false fields in `required`.
+
+```yaml
+HeartbeatResponse:
+  type: object
+  required: [acknowledged]
+  properties:
+    acknowledged:
+      type: boolean
+      enum: [true]
+    hasHighPriorityTasks:
+      type: boolean
+      enum: [true]
+      description: |
+        Omitted (not `false`) when no high-priority work is available.
+        Agents must treat absence as "no priority signal."
+```
+
+Wire the endpoint's 200 response to this schema specifically rather than reusing a generic `Acknowledged` response — the heartbeat now carries more shape than other acknowledged endpoints.
+
+### 3. Route handler (`packages/backend/src/routes/agent/index.ts`)
+
+Annotate the response body with the shared inferred type **before** passing to `c.json`. This makes shape drift a compile error at the boundary:
+
+```typescript
+const body: AgentHeartbeatResponse = {
+  acknowledged: true,
+  ...(result.hasHighPriorityTasks ? { hasHighPriorityTasks: true } : {}),
+}
+return c.json(body)
+```
+
+The conditional spread is the omit-when-false policy. A naive `{ hasHighPriorityTasks: result.hasHighPriorityTasks }` would fail to type-check against `true | undefined`.
+
+### 4. Contract test (`packages/backend/tests/unit/agent-api-contract.test.ts`)
+
+Add both branches and parse the actual response body through the shared schema:
+
+```typescript
+it('omits hasHighPriorityTasks when service reports no priority work', async () => {
+  const res = await app.request(`${AGENT_BASE}/heartbeat`, { /* ... */ })
+  const body = (await res.json()) as Record<string, unknown>
+  expect(body['hasHighPriorityTasks']).toBeUndefined()
+  // Triple-sync proof: parse() success means route ↔ Zod ↔ OpenAPI agree.
+  expect(() => agentHeartbeatResponseSchema.parse(body)).not.toThrow()
+})
+
+it('surfaces hasHighPriorityTasks=true when service reports priority work', async () => {
+  ;(processHeartbeat as unknown as { mockImplementationOnce: (fn: () => unknown) => void })
+    .mockImplementationOnce(() => Promise.resolve({ hasHighPriorityTasks: true }))
+  const res = await app.request(`${AGENT_BASE}/heartbeat`, { /* ... */ })
+  const body = (await res.json()) as Record<string, unknown>
+  expect(body['hasHighPriorityTasks']).toBe(true)
+  const parsed = agentHeartbeatResponseSchema.parse(body)
+  expect(parsed.hasHighPriorityTasks).toBe(true)
+})
+```
+
+A `parse()` success against the schema is the actual contract proof — not just a `toBe` assertion on individual fields.
+
+## Why This Matters
+
+- **Generated agent SDKs read the OpenAPI spec, not the TypeScript type.** If the spec is missing a field, downstream Go/Python/Rust agent clients have no typed access to it even though it's on the wire. This is the silent class of drift that violates AGENTS.md.
+- **The Zod ↔ OpenAPI mirror is the single source of truth for the wire contract.** Either alone is insufficient: TypeScript types don't survive language boundaries; OpenAPI without Zod doesn't catch server-side regressions at compile time. The pair plus the contract test forms a triangle that fails loudly on any drift.
+- **`z.literal(true)` + `enum: [true]` + `.strict()` is the omit-when-false canon.** `z.boolean().optional()` looks equivalent but accepts `false`, which violates the omit policy. The literal pattern makes the policy a property of the type system, not a property of the route handler's branching.
+
+## When to Apply
+
+- Any new field on an `/api/v1/agent/*`, `/api/v1/dashboard/*`, or `/api/v1/control/*` response — even if it's "just a hint" the server emits.
+- Any time a backend service starts producing a value that wasn't on the original response shape.
+- When closing a verification-sweep ticket where most ACs are already met: the AC↔code↔test matrix often surfaces undocumented wire fields as the real remaining work.
+
+## Examples
+
+### The verification-sweep matrix as a pre-implementation step
+
+For issues where most acceptance criteria are claimed to be already met (e.g., "the work is mostly done; finish it"), build a literal AC↔code↔test matrix **before** writing any code:
+
+| # | Acceptance criterion | Production symbol | Test reference | Status |
+|---|---|---|---|---|
+| 1.1 | Filters by `project_id` AND capabilities in WHERE | `services/tasks.ts:430-440` | `tests/unit/tasks.test.ts:393` | ✅ |
+| 6 — Shared schema | No `agentHeartbeatResponseSchema` in `@hashhive/shared` | — | — | ❌ Orphan |
+
+This converts a vague "implement issue #155" into a precise diff: most rows have ✅; the real work is whatever's marked ❌ or 🟡. Saved an entire re-implementation pass on PR #169 and surfaced the only legitimate gap (contract artifacts) as the highest-leverage work.
+
+The matrix lives in the PR's `docs/issues/<n>-ac-traceability-matrix.md` so reviewers can verify the "already done" claims independently.
+
+### Before / after of a contract gap
+
+**Before (PR #169 base):** field present in route + service + tests; absent from OpenAPI and shared schema. AGENTS.md violation. Silent.
+
+**After:** field present in all three locations + contract test parses route response through shared schema. Drift in any one corner is now a compile error or a contract-test failure.
+
+## Related
+
+- **AGENTS.md** — "Wire shapes live in `@hashhive/shared` as `z.infer` from Zod schemas" and "Keep the OpenAPI spec in sync with shared types."
+- **PR #169** — first PR to land this triple-sync pattern; closed issue #155.
+- **Issue #170** — follow-up for the heartbeat error envelope (separate pattern: error-envelope per-surface, not response-shape mirror).
+- `docs/solutions/conventions/form-submit-payload-null-checks-2026-05-19.md` — sibling convention on explicit checks across the wire boundary.

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -53,7 +53,7 @@ app.use(
 // Public, unauthenticated endpoint used by load balancers. Delegates to
 // the centralized health service (issue #109) but keeps the legacy
 // envelope shape so older probes that read services.{database,redis,
-// minio}.status keep working. HTTP 503 fires only when the system is
+// object_store}.status keep working. HTTP 503 fires only when the system is
 // unhealthy; degraded queues stay 200 so we don't flap LB rotation on
 // transient warnings.
 

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -51,9 +51,14 @@ app.use(
 // ─── Health Check ───────────────────────────────────────────────────
 //
 // Public, unauthenticated endpoint used by load balancers. Delegates to
-// the centralized health service (issue #109) but keeps the legacy
-// envelope shape so older probes that read services.{database,redis,
-// object_store}.status keep working. HTTP 503 fires only when the system is
+// the centralized health service (issue #109) and keeps the legacy
+// envelope shape (`status: ok | degraded`, `services` map, additive
+// `aggregateStatus`) for LB probes that read services.{database,redis,
+// object_store,queues}.status. Issue #156 renamed the object-store
+// component from `minio` to `object_store` and bumped `HEALTH_VERSION`
+// to 2.0.0; pre-2.0.0 probes keyed on `services.minio` will see
+// `undefined` after this change (pre-prod posture — no external
+// automation consumers known). HTTP 503 fires only when the system is
 // unhealthy; degraded queues stay 200 so we don't flap LB rotation on
 // transient warnings.
 

--- a/packages/backend/src/queue/workers/health-monitor.ts
+++ b/packages/backend/src/queue/workers/health-monitor.ts
@@ -42,7 +42,7 @@ import {
 } from '../../services/health.js'
 import { attachWorkerMetrics } from './metrics.js'
 
-const COMPONENTS: ComponentName[] = ['database', 'redis', 'minio', 'queues']
+const COMPONENTS: ComponentName[] = ['database', 'redis', 'object_store', 'queues']
 const REDIS_KEY_PREFIX = 'health:last-status:'
 const REDIS_KEY_TTL_SEC = 24 * 60 * 60
 

--- a/packages/backend/src/services/crackers.ts
+++ b/packages/backend/src/services/crackers.ts
@@ -1,7 +1,7 @@
 import { crackerBinaries, KNOWN_ENGINES, type KnownEngineName } from '@hashhive/shared'
 import { and, desc, eq, sql } from 'drizzle-orm'
 /**
- * Cracker binary registry — engine-aware, MinIO-backed, admin-managed.
+ * Cracker binary registry — engine-aware, object-store-backed, admin-managed.
  *
  * Hashcat is the default engine throughout: any caller that omits `engine`
  * resolves to `'hashcat'`. Engine values are stored lowercased so that a
@@ -256,7 +256,7 @@ export async function deleteCrackerBinary(
   const fileRef = readFileRef(row.fileRef)
 
   // Branch on lifecycle state. An in-progress multipart upload needs
-  // `abortMultipartUpload` to free MinIO's stored parts; calling
+  // `abortMultipartUpload` to free the object store's stored parts; calling
   // `deleteFile` on the key would leave orphaned parts behind because
   // the assembled object doesn't exist yet.
   if (fileRef.state === 'uploading') {
@@ -421,7 +421,7 @@ export async function getLatestCracker(opts: { engine?: string | undefined; plat
 
 /**
  * Generate a presigned download URL for a cracker binary. Used by agents
- * to stream the binary directly from MinIO without proxying through the
+ * to stream the binary directly from the object store without proxying through the
  * API (avoids tying up an API process for the duration of a multi-MB
  * download).
  *

--- a/packages/backend/src/services/health.ts
+++ b/packages/backend/src/services/health.ts
@@ -27,13 +27,12 @@ export type ComponentStatus = 'healthy' | 'degraded' | 'unhealthy'
 /**
  * Component names exposed on the wire (`components.<name>` on
  * `/api/v1/dashboard/health`, `services.<name>` on the legacy `/health` envelope).
- * `'minio'` is preserved as the wire identifier across the SeaweedFS swap
- * so frontend consumers (see `packages/frontend/src/hooks/use-system-health.ts`)
- * keep working without a coupled release. Internal symbols are migrated
- * to neutral terminology (`checkObjectStoreHealth`) where doing so does
- * not touch the wire.
+ * `'object_store'` is the neutral wire identifier — vendor-agnostic across
+ * the SeaweedFS swap (and any future hosted AWS S3 deploy). The previous
+ * `'minio'` placeholder was dropped on the pre-prod boundary; see issue
+ * #156 AC 4.3.
  */
-export type ComponentName = 'database' | 'redis' | 'minio' | 'queues'
+export type ComponentName = 'database' | 'redis' | 'object_store' | 'queues'
 
 /**
  * Probe result shape without a `durationMs` field — that field is
@@ -320,7 +319,7 @@ export function __resetMaxConnectionsCache(): void {
 function buildDefaultProbes(): {
   database: DatabaseProbeDeps
   redis: RedisProbeDeps
-  minio: ObjectStoreProbeDeps
+  object_store: ObjectStoreProbeDeps
   queues: QueuesProbeDeps
 } {
   const qm = getQueueManager()
@@ -336,7 +335,7 @@ function buildDefaultProbes(): {
       // qm.getHealth().
       status: () => qm?.getRedisStatus() ?? 'disconnected',
     },
-    minio: { check: checkObjectStoreHealth },
+    object_store: { check: checkObjectStoreHealth },
     queues: {
       health: async () => {
         if (!qm) {
@@ -355,7 +354,7 @@ export interface SystemHealthOptions {
   probes?: {
     database?: DatabaseProbeDeps
     redis?: RedisProbeDeps
-    minio?: ObjectStoreProbeDeps
+    object_store?: ObjectStoreProbeDeps
     queues?: QueuesProbeDeps
   }
   /** Override thresholds for testing. */
@@ -372,7 +371,7 @@ async function executeProbes(opts: SystemHealthOptions): Promise<SystemHealth> {
   const probes = {
     database: opts.probes?.database ?? defaults.database,
     redis: opts.probes?.redis ?? defaults.redis,
-    minio: opts.probes?.minio ?? defaults.minio,
+    object_store: opts.probes?.object_store ?? defaults.object_store,
     queues: opts.probes?.queues ?? defaults.queues,
   }
   const thresholds = {
@@ -382,7 +381,7 @@ async function executeProbes(opts: SystemHealthOptions): Promise<SystemHealth> {
     dbConnectionWarnPct: opts.thresholds?.dbConnectionWarnPct ?? env.HEALTH_DB_CONNECTION_WARN_PCT,
   }
 
-  const [database, redis, minio, queues] = await Promise.all([
+  const [database, redis, object_store, queues] = await Promise.all([
     // probeFn signatures all accept (signal: AbortSignal) so runProbe
     // can abort the underlying driver call on timeout. probes that
     // don't need it (sync redis status check, queue stat fan-out)
@@ -394,8 +393,8 @@ async function executeProbes(opts: SystemHealthOptions): Promise<SystemHealth> {
     ),
     runProbe('redis', () => probeRedis(probes.redis), thresholds.probeTimeoutMs),
     runProbe(
-      'minio',
-      (signal) => probeObjectStore(probes.minio, signal),
+      'object_store',
+      (signal) => probeObjectStore(probes.object_store, signal),
       thresholds.probeTimeoutMs
     ),
     runProbe(
@@ -405,7 +404,12 @@ async function executeProbes(opts: SystemHealthOptions): Promise<SystemHealth> {
     ),
   ])
 
-  const components: Record<ComponentName, ComponentHealth> = { database, redis, minio, queues }
+  const components: Record<ComponentName, ComponentHealth> = {
+    database,
+    redis,
+    object_store,
+    queues,
+  }
   return {
     status: aggregateStatus(components),
     timestamp: new Date().toISOString(),
@@ -417,7 +421,7 @@ async function executeProbes(opts: SystemHealthOptions): Promise<SystemHealth> {
 // ─── Caching layer ──────────────────────────────────────────────────
 //
 // Each call fans out probes that hit Postgres (3 queries), Redis (status
-// + per-queue counts × 7 queues = ~21 calls), MinIO (HeadBucket), and
+// + per-queue counts × 7 queues = ~21 calls), object store (HeadBucket), and
 // usually completes in tens of ms. Without caching, three surfaces
 // (/health, /api/v1/control/health, /api/v1/dashboard/health) plus the
 // 30s scheduled monitor plus a polling dashboard could pile probes
@@ -475,12 +479,12 @@ export async function getSystemHealth(opts: SystemHealthOptions = {}): Promise<S
  * - `status: 'ok' | 'degraded'` — coarse two-tier signal kept for older
  *   monitors. The HTTP status code (503 on unhealthy) is the additional
  *   signal those monitors can opt into.
- * - `services.{database,redis,minio,queues}.status: 'connected' |
+ * - `services.{database,redis,object_store,queues}.status: 'connected' |
  *   'disconnected'` — coarse connectivity. A "degraded" component
  *   (queue depth above warn threshold, DB pool >= warn percent) is still
  *   `connected` since it's reachable; only `unhealthy` collapses to
  *   `disconnected`.
- * - `services.minio.bucket` — preserved.
+ * - `services.object_store.bucket` — current bucket name from `env.S3_BUCKET`.
  * - `services.queues.queues` — a flat `{ queueName: { waiting, active,
  *   failed } }` map matching what `qm.getHealth()` previously returned
  *   in the inline /health handler. Preserved so anonymous probes that
@@ -501,8 +505,8 @@ export async function getSystemHealth(opts: SystemHealthOptions = {}): Promise<S
  * Anti-leak guard fields on every legacy-envelope service entry: a
  * future PR adding `message` or `detail` here would silently leak
  * probe internals to anonymous callers, so we make it a compile error
- * instead. New per-service fields (like `bucket` on minio or `queues`
- * on queues) are added by intersection on the specific entry below.
+ * instead. New per-service fields (like `bucket` on `object_store` or
+ * `queues` on `queues`) are added by intersection on the specific entry below.
  */
 type LegacyServiceGuards = {
   message?: never
@@ -518,7 +522,7 @@ export interface LegacyHealthEnvelope {
   services: {
     database: LegacyServiceGuards & { status: 'connected' | 'disconnected' }
     redis: LegacyServiceGuards & { status: 'connected' | 'disconnected' }
-    minio: LegacyServiceGuards & {
+    object_store: LegacyServiceGuards & {
       status: 'connected' | 'disconnected'
       bucket: string
     }
@@ -542,11 +546,11 @@ function extractQueueStats(
 }
 
 export function legacyPublicEnvelope(health: SystemHealth): LegacyHealthEnvelope {
-  // Preserve the pre-#109 `services.minio.bucket` contract even when the
-  // probe timed out before setting `detail` — fall back to env.S3_BUCKET so
-  // monitors that read `body.services.minio.bucket.length` keep working.
-  const minioBucket =
-    (health.components.minio.detail?.['bucket'] as string | undefined) ?? env.S3_BUCKET
+  // Always populate `services.object_store.bucket` from `env.S3_BUCKET` when
+  // the probe timed out before setting `detail`, so anonymous monitors that
+  // read the bucket name get a stable value regardless of probe outcome.
+  const objectStoreBucket =
+    (health.components.object_store.detail?.['bucket'] as string | undefined) ?? env.S3_BUCKET
   return {
     status: health.status === 'healthy' ? 'ok' : 'degraded',
     aggregateStatus: health.status,
@@ -555,9 +559,9 @@ export function legacyPublicEnvelope(health: SystemHealth): LegacyHealthEnvelope
     services: {
       database: { status: legacyServiceStatus(health.components.database.status) },
       redis: { status: legacyServiceStatus(health.components.redis.status) },
-      minio: {
-        status: legacyServiceStatus(health.components.minio.status),
-        bucket: minioBucket,
+      object_store: {
+        status: legacyServiceStatus(health.components.object_store.status),
+        bucket: objectStoreBucket,
       },
       queues: {
         status: legacyServiceStatus(health.components.queues.status),

--- a/packages/backend/src/services/health.ts
+++ b/packages/backend/src/services/health.ts
@@ -14,6 +14,8 @@
  * from getSystemHealth().
  */
 
+import type { ComponentName, ComponentStatus } from '@hashhive/shared'
+
 import { sql } from 'drizzle-orm'
 
 import { env } from '../config/env.js'
@@ -22,17 +24,12 @@ import { checkObjectStoreHealth } from '../config/storage.js'
 import { db } from '../db/index.js'
 import { getQueueManager } from '../queue/context.js'
 
-export type ComponentStatus = 'healthy' | 'degraded' | 'unhealthy'
-
-/**
- * Component names exposed on the wire (`components.<name>` on
- * `/api/v1/dashboard/health`, `services.<name>` on the legacy `/health` envelope).
- * `'object_store'` is the neutral wire identifier — vendor-agnostic across
- * the SeaweedFS swap (and any future hosted AWS S3 deploy). The previous
- * `'minio'` placeholder was dropped on the pre-prod boundary; see issue
- * #156 AC 4.3.
- */
-export type ComponentName = 'database' | 'redis' | 'object_store' | 'queues'
+// Re-export so existing callers (`import { ComponentName } from
+// '../services/health.js'`) continue to work without churn. The
+// canonical declaration lives in `@hashhive/shared` per AGENTS.md's
+// wire-shape rule. See `componentNameSchema` /
+// `componentStatusSchema` there.
+export type { ComponentName, ComponentStatus }
 
 /**
  * Probe result shape without a `durationMs` field — that field is
@@ -65,8 +62,15 @@ export interface SystemHealth {
  * since the health surface evolves on its own cadence; see the
  * Control API spec at packages/openapi/control-api.yaml for the
  * matching `info.version` it documents.
+ *
+ * 2.0.0 (issue #156) — `components.minio` renamed to `components.object_store`
+ *   across both the rich envelope and the legacy public envelope. No
+ *   back-compat alias; pre-2.0.0 probes keyed on the old name will see
+ *   the field absent.
+ * 1.1.0 (issue #109) — three-tier status, `components` map, per-component
+ *   `message`/`detail`/`durationMs`.
  */
-export const HEALTH_VERSION = '1.1.0'
+export const HEALTH_VERSION = '2.0.0'
 
 // Threshold semantics for the entire module: warn comparisons use `>=`
 // (inclusive boundary). "Warn at 10000" means 10000 is already the warn

--- a/packages/backend/src/services/health.ts
+++ b/packages/backend/src/services/health.ts
@@ -546,9 +546,12 @@ function extractQueueStats(
 }
 
 export function legacyPublicEnvelope(health: SystemHealth): LegacyHealthEnvelope {
-  // Always populate `services.object_store.bucket` from `env.S3_BUCKET` when
-  // the probe timed out before setting `detail`, so anonymous monitors that
-  // read the bucket name get a stable value regardless of probe outcome.
+  // On a healthy probe, `detail.bucket` carries the authoritative bucket
+  // name (which may differ from `env.S3_BUCKET` in unusual deploys). When
+  // the probe finished without populating `detail.bucket` (timeout,
+  // programming error, future probe variant), fall back to
+  // `env.S3_BUCKET` so anonymous monitors that read this field
+  // unconditionally do not break on a degraded probe outcome.
   const objectStoreBucket =
     (health.components.object_store.detail?.['bucket'] as string | undefined) ?? env.S3_BUCKET
   return {

--- a/packages/backend/tests/integration/control-health.test.ts
+++ b/packages/backend/tests/integration/control-health.test.ts
@@ -133,7 +133,7 @@ describe('GET /api/v1/control/health', () => {
       // it).
       expect(body.components['database']).toBeDefined()
       expect(body.components['redis']).toBeDefined()
-      expect(body.components['minio']).toBeDefined()
+      expect(body.components['object_store']).toBeDefined()
       expect(body.components['queues']).toBeDefined()
       // Per-component status uses the three-tier enum
       for (const c of Object.values(body.components)) {

--- a/packages/backend/tests/integration/control-health.test.ts
+++ b/packages/backend/tests/integration/control-health.test.ts
@@ -135,6 +135,10 @@ describe('GET /api/v1/control/health', () => {
       expect(body.components['redis']).toBeDefined()
       expect(body.components['object_store']).toBeDefined()
       expect(body.components['queues']).toBeDefined()
+      // Regression guard for issue #156 AC 4.3: the legacy `minio` key
+      // must not reappear on the rich envelope. Symmetric with the
+      // legacy /health absence assertion in tests/unit/health.test.ts.
+      expect(body.components['minio']).toBeUndefined()
       // Per-component status uses the three-tier enum
       for (const c of Object.values(body.components)) {
         expect(['healthy', 'degraded', 'unhealthy']).toContain(c.status)

--- a/packages/backend/tests/integration/control-health.test.ts
+++ b/packages/backend/tests/integration/control-health.test.ts
@@ -125,7 +125,7 @@ describe('GET /api/v1/control/health', () => {
         components: Record<string, { status: string; durationMs: number }>
       }
       expect(['healthy', 'degraded', 'unhealthy']).toContain(body.status)
-      expect(body.version).toBe('1.1.0')
+      expect(body.version).toBe('2.0.0')
       expect(typeof body.timestamp).toBe('string')
       // All four components present — same shape as the dashboard surface,
       // unlike the public /health envelope. Bracket notation per

--- a/packages/backend/tests/integration/dashboard-health.test.ts
+++ b/packages/backend/tests/integration/dashboard-health.test.ts
@@ -7,7 +7,7 @@
  *     when authenticated
  *
  * Mocks BetterAuth and storage so the test does not depend on real
- * Postgres / Redis / MinIO availability.
+ * Postgres / Redis / object-store availability.
  */
 import { beforeEach, describe, expect, it, mock } from 'bun:test'
 
@@ -114,6 +114,10 @@ describe('GET /api/v1/dashboard/health', () => {
     expect(body.components['redis']).toBeDefined()
     expect(body.components['object_store']).toBeDefined()
     expect(body.components['queues']).toBeDefined()
+    // Regression guard for issue #156 AC 4.3: the legacy `minio` key
+    // must not reappear on the rich envelope. Symmetric with the
+    // legacy /health absence assertion in tests/unit/health.test.ts.
+    expect(body.components['minio']).toBeUndefined()
 
     // Per-component status uses the new three-tier enum
     for (const c of Object.values(body.components)) {
@@ -130,7 +134,7 @@ describe('GET /api/v1/dashboard/health', () => {
     const body = (await res.json()) as {
       components: Record<string, { detail?: Record<string, unknown> }>
     }
-    // MinIO probe is mocked to connected, so detail should include the bucket name
+    // Object-store probe is mocked to connected, so detail should include the bucket name
     expect(body.components['object_store']?.detail?.['bucket']).toBe('hashhive-test')
   })
 

--- a/packages/backend/tests/integration/dashboard-health.test.ts
+++ b/packages/backend/tests/integration/dashboard-health.test.ts
@@ -106,7 +106,7 @@ describe('GET /api/v1/dashboard/health', () => {
     // Top-level envelope
     expect(['healthy', 'degraded', 'unhealthy']).toContain(body.status)
     expect(typeof body.timestamp).toBe('string')
-    expect(body.version).toBe('1.1.0')
+    expect(body.version).toBe('2.0.0')
 
     // All four components present. Bracket notation per
     // `noPropertyAccessFromIndexSignature` (Record<string, …>).

--- a/packages/backend/tests/integration/dashboard-health.test.ts
+++ b/packages/backend/tests/integration/dashboard-health.test.ts
@@ -112,7 +112,7 @@ describe('GET /api/v1/dashboard/health', () => {
     // `noPropertyAccessFromIndexSignature` (Record<string, …>).
     expect(body.components['database']).toBeDefined()
     expect(body.components['redis']).toBeDefined()
-    expect(body.components['minio']).toBeDefined()
+    expect(body.components['object_store']).toBeDefined()
     expect(body.components['queues']).toBeDefined()
 
     // Per-component status uses the new three-tier enum
@@ -131,7 +131,7 @@ describe('GET /api/v1/dashboard/health', () => {
       components: Record<string, { detail?: Record<string, unknown> }>
     }
     // MinIO probe is mocked to connected, so detail should include the bucket name
-    expect(body.components['minio']?.detail?.['bucket']).toBe('hashhive-test')
+    expect(body.components['object_store']?.detail?.['bucket']).toBe('hashhive-test')
   })
 
   // PR review I-1: the dashboard surface intentionally exposes the rich
@@ -166,10 +166,10 @@ describe('GET /api/v1/dashboard/health', () => {
 
     // The contract under test: every non-healthy component carries a
     // `message` (required by the ComponentHealth discriminated union).
-    // `detail` is optional per probe — redis omits it, queues+minio
+    // `detail` is optional per probe — redis omits it, queues+object_store
     // include it — so we only assert message presence on the
     // first-non-healthy. Detail is asserted on the queues path (which
-    // always carries `{ queues: {} }`) and the minio path (which always
+    // always carries `{ queues: {} }`) and the object_store path (which always
     // carries `{ bucket }`) below.
     const nonHealthy = Object.values(body.components).find((c) => c.status !== 'healthy')
     expect(nonHealthy).toBeDefined()
@@ -186,9 +186,9 @@ describe('GET /api/v1/dashboard/health', () => {
     if (queues && queues.status !== 'healthy') {
       expect(queues.detail).toBeDefined()
     }
-    // minio probe is stubbed, so its detail.bucket is reliably present
+    // object_store probe is stubbed, so its detail.bucket is reliably present
     // — proves the dashboard surface keeps the field that the public
     // envelope is allowed to strip.
-    expect(body.components['minio']?.detail?.['bucket']).toBe('hashhive-test')
+    expect(body.components['object_store']?.detail?.['bucket']).toBe('hashhive-test')
   })
 })

--- a/packages/backend/tests/integration/health-deterministic.test.ts
+++ b/packages/backend/tests/integration/health-deterministic.test.ts
@@ -50,7 +50,7 @@ function buildSystemHealth(): SystemHealth {
   return {
     status: mockedAggregateStatus,
     timestamp: '2026-05-07T00:00:00.000Z',
-    version: '1.1.0',
+    version: '2.0.0',
     components: {
       database: buildComponent(mockedAggregateStatus === 'unhealthy' ? 'unhealthy' : 'healthy'),
       redis: buildComponent('healthy'),

--- a/packages/backend/tests/integration/health-deterministic.test.ts
+++ b/packages/backend/tests/integration/health-deterministic.test.ts
@@ -54,7 +54,7 @@ function buildSystemHealth(): SystemHealth {
     components: {
       database: buildComponent(mockedAggregateStatus === 'unhealthy' ? 'unhealthy' : 'healthy'),
       redis: buildComponent('healthy'),
-      minio: buildComponent('healthy'),
+      object_store: buildComponent('healthy'),
       queues: buildComponent(mockedAggregateStatus === 'degraded' ? 'degraded' : 'healthy'),
     },
   }

--- a/packages/backend/tests/integration/smoke.test.ts
+++ b/packages/backend/tests/integration/smoke.test.ts
@@ -31,7 +31,7 @@ describe('Integration: Health check', () => {
 
     const body = await res.json()
     expect(['ok', 'degraded']).toContain(body['status'])
-    expect(body['version']).toBe('1.1.0')
+    expect(body['version']).toBe('2.0.0')
     expect(typeof body['timestamp']).toBe('string')
 
     // Validate ISO 8601 timestamp

--- a/packages/backend/tests/unit/events.test.ts
+++ b/packages/backend/tests/unit/events.test.ts
@@ -141,7 +141,7 @@ describe('broadcastSystemEvent', () => {
     const id = trackedRegister(closedWs, [1])
     const before = getClientCount()
 
-    broadcastSystemEvent('system_health', { component: 'minio', status: 'unhealthy' })
+    broadcastSystemEvent('system_health', { component: 'object_store', status: 'unhealthy' })
 
     expect(closedWs.sent).toHaveLength(0)
     expect(getClientCount()).toBe(before - 1)

--- a/packages/backend/tests/unit/health-monitor.test.ts
+++ b/packages/backend/tests/unit/health-monitor.test.ts
@@ -44,20 +44,20 @@ function buildContext(
   const memory: Record<ComponentName, ComponentStatus | null> = {
     database: initial.memory?.database ?? null,
     redis: initial.memory?.redis ?? null,
-    minio: initial.memory?.minio ?? null,
+    object_store: initial.memory?.object_store ?? null,
     queues: initial.memory?.queues ?? null,
   }
   const redis: Record<ComponentName, ComponentStatus | null> = {
     database: initial.redis?.database ?? null,
     redis: initial.redis?.redis ?? null,
-    minio: initial.redis?.minio ?? null,
+    object_store: initial.redis?.object_store ?? null,
     queues: initial.redis?.queues ?? null,
   }
   const broadcasts: TestContext['broadcasts'] = []
   const components: Record<ComponentName, ComponentHealth> = {
     database: parseStatus(componentStatuses.database),
     redis: parseStatus(componentStatuses.redis),
-    minio: parseStatus(componentStatuses.minio),
+    object_store: parseStatus(componentStatuses.object_store),
     queues: parseStatus(componentStatuses.queues),
   }
 
@@ -90,13 +90,13 @@ describe('runHealthMonitorTick', () => {
   test('first run with no prior state seeds memory and emits zero broadcasts', async () => {
     const ctx = buildContext(
       {}, // no prior state in memory or Redis
-      { database: 'healthy', redis: 'healthy', minio: 'healthy', queues: 'healthy' }
+      { database: 'healthy', redis: 'healthy', object_store: 'healthy', queues: 'healthy' }
     )
 
     const result = await runHealthMonitorTick(ctx.deps)
 
     expect(result.transitioned).toEqual([])
-    expect(result.initialized.sort()).toEqual(['database', 'minio', 'queues', 'redis'])
+    expect(result.initialized.sort()).toEqual(['database', 'object_store', 'queues', 'redis'])
     expect(ctx.broadcasts).toHaveLength(0)
 
     // Both memory and Redis are seeded
@@ -112,42 +112,57 @@ describe('runHealthMonitorTick', () => {
     const ctx = buildContext(
       {
         memory: {}, // empty post-boot
-        redis: { database: 'healthy', redis: 'healthy', minio: 'healthy', queues: 'healthy' },
+        redis: {
+          database: 'healthy',
+          redis: 'healthy',
+          object_store: 'healthy',
+          queues: 'healthy',
+        },
       },
-      { database: 'healthy', redis: 'healthy', minio: 'healthy', queues: 'healthy' }
+      { database: 'healthy', redis: 'healthy', object_store: 'healthy', queues: 'healthy' }
     )
 
     const result = await runHealthMonitorTick(ctx.deps)
 
     expect(result.transitioned).toEqual([])
-    expect(result.unchanged.sort()).toEqual(['database', 'minio', 'queues', 'redis'])
+    expect(result.unchanged.sort()).toEqual(['database', 'object_store', 'queues', 'redis'])
     expect(ctx.broadcasts).toHaveLength(0)
   })
 
   test('second run with identical status emits zero broadcasts', async () => {
     const ctx = buildContext(
       {
-        memory: { database: 'healthy', redis: 'healthy', minio: 'healthy', queues: 'healthy' },
+        memory: {
+          database: 'healthy',
+          redis: 'healthy',
+          object_store: 'healthy',
+          queues: 'healthy',
+        },
       },
-      { database: 'healthy', redis: 'healthy', minio: 'healthy', queues: 'healthy' }
+      { database: 'healthy', redis: 'healthy', object_store: 'healthy', queues: 'healthy' }
     )
 
     const result = await runHealthMonitorTick(ctx.deps)
 
     expect(result.transitioned).toEqual([])
-    expect(result.unchanged.sort()).toEqual(['database', 'minio', 'queues', 'redis'])
+    expect(result.unchanged.sort()).toEqual(['database', 'object_store', 'queues', 'redis'])
     expect(ctx.broadcasts).toHaveLength(0)
   })
 
   test('one component flips from healthy to degraded — exactly one broadcast', async () => {
     const ctx = buildContext(
       {
-        memory: { database: 'healthy', redis: 'healthy', minio: 'healthy', queues: 'healthy' },
+        memory: {
+          database: 'healthy',
+          redis: 'healthy',
+          object_store: 'healthy',
+          queues: 'healthy',
+        },
       },
       {
         database: { status: 'degraded', message: 'pool 90% full' },
         redis: 'healthy',
-        minio: 'healthy',
+        object_store: 'healthy',
         queues: 'healthy',
       }
     )
@@ -169,12 +184,17 @@ describe('runHealthMonitorTick', () => {
   test('two components flip simultaneously — exactly two broadcasts', async () => {
     const ctx = buildContext(
       {
-        memory: { database: 'healthy', redis: 'healthy', minio: 'healthy', queues: 'healthy' },
+        memory: {
+          database: 'healthy',
+          redis: 'healthy',
+          object_store: 'healthy',
+          queues: 'healthy',
+        },
       },
       {
         database: 'degraded',
         redis: 'unhealthy',
-        minio: 'healthy',
+        object_store: 'healthy',
         queues: 'healthy',
       }
     )
@@ -190,28 +210,38 @@ describe('runHealthMonitorTick', () => {
   test('all four components flip simultaneously — four broadcasts (testing T-008 / U5)', async () => {
     const ctx = buildContext(
       {
-        memory: { database: 'healthy', redis: 'healthy', minio: 'healthy', queues: 'healthy' },
+        memory: {
+          database: 'healthy',
+          redis: 'healthy',
+          object_store: 'healthy',
+          queues: 'healthy',
+        },
       },
       {
         database: 'unhealthy',
         redis: 'unhealthy',
-        minio: 'unhealthy',
+        object_store: 'unhealthy',
         queues: 'unhealthy',
       }
     )
 
     const result = await runHealthMonitorTick(ctx.deps)
 
-    expect(result.transitioned.sort()).toEqual(['database', 'minio', 'queues', 'redis'])
+    expect(result.transitioned.sort()).toEqual(['database', 'object_store', 'queues', 'redis'])
     expect(ctx.broadcasts).toHaveLength(4)
   })
 
   test('component flips back from unhealthy to healthy — broadcast on recovery', async () => {
     const ctx = buildContext(
       {
-        memory: { database: 'healthy', redis: 'unhealthy', minio: 'healthy', queues: 'healthy' },
+        memory: {
+          database: 'healthy',
+          redis: 'unhealthy',
+          object_store: 'healthy',
+          queues: 'healthy',
+        },
       },
-      { database: 'healthy', redis: 'healthy', minio: 'healthy', queues: 'healthy' }
+      { database: 'healthy', redis: 'healthy', object_store: 'healthy', queues: 'healthy' }
     )
 
     const result = await runHealthMonitorTick(ctx.deps)
@@ -227,7 +257,7 @@ describe('runHealthMonitorTick', () => {
     const memory = new Map<ComponentName, ComponentStatus>([
       ['database', 'healthy'],
       ['redis', 'healthy'],
-      ['minio', 'healthy'],
+      ['object_store', 'healthy'],
       ['queues', 'healthy'],
     ])
     const broadcasts: TestContext['broadcasts'] = []
@@ -260,7 +290,7 @@ describe('runHealthMonitorTick', () => {
         {
           database: makeComponent('healthy'),
           redis: makeComponent('unhealthy', 'redis disconnected'),
-          minio: makeComponent('healthy'),
+          object_store: makeComponent('healthy'),
           queues: makeComponent('unhealthy', 'queue manager not connected to redis'),
         },
         true
@@ -272,7 +302,7 @@ describe('runHealthMonitorTick', () => {
         {
           database: makeComponent('healthy'),
           redis: makeComponent('unhealthy', 'redis disconnected'),
-          minio: makeComponent('healthy'),
+          object_store: makeComponent('healthy'),
           queues: makeComponent('unhealthy', 'queue manager not connected to redis'),
         },
         true
@@ -284,7 +314,7 @@ describe('runHealthMonitorTick', () => {
         {
           database: makeComponent('healthy'),
           redis: makeComponent('healthy'),
-          minio: makeComponent('healthy'),
+          object_store: makeComponent('healthy'),
           queues: makeComponent('healthy'),
         },
         false
@@ -317,7 +347,7 @@ describe('runHealthMonitorTick', () => {
         components: {
           database: makeComponent('healthy'),
           redis: makeComponent('unhealthy', 'connection refused'),
-          minio: makeComponent('healthy'),
+          object_store: makeComponent('healthy'),
           queues: makeComponent('healthy'),
         },
       }),
@@ -332,7 +362,7 @@ describe('runHealthMonitorTick', () => {
   test('Redis write failure is logged but does not crash the worker', async () => {
     const ctx = buildContext(
       { memory: { database: 'healthy' } },
-      { database: 'degraded', redis: 'healthy', minio: 'healthy', queues: 'healthy' }
+      { database: 'degraded', redis: 'healthy', object_store: 'healthy', queues: 'healthy' }
     )
     // Override writeRedisStatus to throw — memory write still succeeds
     const deps: HealthMonitorDeps = {
@@ -353,12 +383,17 @@ describe('runHealthMonitorTick', () => {
   test('broadcast throw on one component does not stop the loop (T-009)', async () => {
     const ctx = buildContext(
       {
-        memory: { database: 'healthy', redis: 'healthy', minio: 'healthy', queues: 'healthy' },
+        memory: {
+          database: 'healthy',
+          redis: 'healthy',
+          object_store: 'healthy',
+          queues: 'healthy',
+        },
       },
       {
         database: 'degraded',
         redis: 'degraded',
-        minio: 'healthy',
+        object_store: 'healthy',
         queues: 'healthy',
       }
     )
@@ -414,7 +449,7 @@ describe('runHealthMonitorTick', () => {
         queues: { status: 'degraded', message: 'tasks-high waiting=50000 > 10000' },
         database: 'healthy',
         redis: 'healthy',
-        minio: 'healthy',
+        object_store: 'healthy',
       }
     )
 

--- a/packages/backend/tests/unit/health-monitor.test.ts
+++ b/packages/backend/tests/unit/health-monitor.test.ts
@@ -96,7 +96,7 @@ describe('runHealthMonitorTick', () => {
     const result = await runHealthMonitorTick(ctx.deps)
 
     expect(result.transitioned).toEqual([])
-    expect(result.initialized.sort()).toEqual(['database', 'object_store', 'queues', 'redis'])
+    expect([...result.initialized].sort()).toEqual(['database', 'object_store', 'queues', 'redis'])
     expect(ctx.broadcasts).toHaveLength(0)
 
     // Both memory and Redis are seeded
@@ -125,7 +125,7 @@ describe('runHealthMonitorTick', () => {
     const result = await runHealthMonitorTick(ctx.deps)
 
     expect(result.transitioned).toEqual([])
-    expect(result.unchanged.sort()).toEqual(['database', 'object_store', 'queues', 'redis'])
+    expect([...result.unchanged].sort()).toEqual(['database', 'object_store', 'queues', 'redis'])
     expect(ctx.broadcasts).toHaveLength(0)
   })
 
@@ -145,7 +145,7 @@ describe('runHealthMonitorTick', () => {
     const result = await runHealthMonitorTick(ctx.deps)
 
     expect(result.transitioned).toEqual([])
-    expect(result.unchanged.sort()).toEqual(['database', 'object_store', 'queues', 'redis'])
+    expect([...result.unchanged].sort()).toEqual(['database', 'object_store', 'queues', 'redis'])
     expect(ctx.broadcasts).toHaveLength(0)
   })
 
@@ -201,7 +201,7 @@ describe('runHealthMonitorTick', () => {
 
     const result = await runHealthMonitorTick(ctx.deps)
 
-    expect(result.transitioned.sort()).toEqual(['database', 'redis'])
+    expect([...result.transitioned].sort()).toEqual(['database', 'redis'])
     expect(ctx.broadcasts).toHaveLength(2)
     const components = ctx.broadcasts.map((b) => b.component).sort()
     expect(components).toEqual(['database', 'redis'])
@@ -227,7 +227,7 @@ describe('runHealthMonitorTick', () => {
 
     const result = await runHealthMonitorTick(ctx.deps)
 
-    expect(result.transitioned.sort()).toEqual(['database', 'object_store', 'queues', 'redis'])
+    expect([...result.transitioned].sort()).toEqual(['database', 'object_store', 'queues', 'redis'])
     expect(ctx.broadcasts).toHaveLength(4)
   })
 
@@ -412,7 +412,7 @@ describe('runHealthMonitorTick', () => {
     const result = await runHealthMonitorTick(deps)
 
     // Both components still appear in transitioned (loop continued)
-    expect(result.transitioned.sort()).toEqual(['database', 'redis'])
+    expect([...result.transitioned].sort()).toEqual(['database', 'redis'])
     // Memory was updated for both despite first broadcast throwing
     expect(ctx.memory.database).toBe('degraded')
     expect(ctx.memory.redis).toBe('degraded')

--- a/packages/backend/tests/unit/health-service.test.ts
+++ b/packages/backend/tests/unit/health-service.test.ts
@@ -364,7 +364,7 @@ describe('getSystemHealth', () => {
   test('returns SystemHealth shape with all four components and version', async () => {
     const result = await getSystemHealth({ probes: allHealthyProbes })
     expect(result.status).toBe('healthy')
-    expect(result.version).toBe('1.1.0')
+    expect(result.version).toBe('2.0.0')
     expect(result.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/)
     expect(result.components.database.status).toBe('healthy')
     expect(result.components.redis.status).toBe('healthy')
@@ -529,7 +529,7 @@ describe('legacyPublicEnvelope', () => {
     expect(env.services.object_store.status).toBe('connected')
     expect(env.services.object_store.bucket).toBe('hashhive-test')
     expect(env.services.queues.status).toBe('connected')
-    expect(env.version).toBe('1.1.0')
+    expect(env.version).toBe('2.0.0')
   })
 
   test('degraded maps to status="degraded" body, aggregateStatus="degraded", services stay "connected"', async () => {

--- a/packages/backend/tests/unit/health-service.test.ts
+++ b/packages/backend/tests/unit/health-service.test.ts
@@ -33,7 +33,7 @@ function makeComponents(
   return {
     database: makeComponent(overrides.database ?? 'healthy'),
     redis: makeComponent(overrides.redis ?? 'healthy'),
-    minio: makeComponent(overrides.minio ?? 'healthy'),
+    object_store: makeComponent(overrides.object_store ?? 'healthy'),
     queues: makeComponent(overrides.queues ?? 'healthy'),
   }
 }
@@ -48,7 +48,7 @@ describe('aggregateStatus', () => {
   })
 
   test('returns unhealthy when any component is unhealthy regardless of degraded', () => {
-    expect(aggregateStatus(makeComponents({ minio: 'unhealthy', queues: 'degraded' }))).toBe(
+    expect(aggregateStatus(makeComponents({ object_store: 'unhealthy', queues: 'degraded' }))).toBe(
       'unhealthy'
     )
   })
@@ -59,7 +59,7 @@ describe('aggregateStatus', () => {
         makeComponents({
           database: 'unhealthy',
           redis: 'unhealthy',
-          minio: 'unhealthy',
+          object_store: 'unhealthy',
           queues: 'unhealthy',
         })
       )
@@ -350,7 +350,7 @@ describe('getSystemHealth', () => {
     redis: {
       status: () => 'connected' as const,
     },
-    minio: {
+    object_store: {
       check: async () => ({ status: 'connected' as const, bucket: 'test' }),
     },
     queues: {
@@ -368,7 +368,7 @@ describe('getSystemHealth', () => {
     expect(result.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/)
     expect(result.components.database.status).toBe('healthy')
     expect(result.components.redis.status).toBe('healthy')
-    expect(result.components.minio.status).toBe('healthy')
+    expect(result.components.object_store.status).toBe('healthy')
     expect(result.components.queues.status).toBe('healthy')
   })
 
@@ -393,16 +393,16 @@ describe('getSystemHealth', () => {
     const result = await getSystemHealth({
       probes: {
         ...allHealthyProbes,
-        minio: {
+        object_store: {
           check: async () => {
-            throw new Error('minio down')
+            throw new Error('object_store down')
           },
         },
       },
     })
     expect(result.status).toBe('unhealthy')
-    expect(result.components.minio.status).toBe('unhealthy')
-    expect(result.components.minio.message).toBe('minio down')
+    expect(result.components.object_store.status).toBe('unhealthy')
+    expect(result.components.object_store.message).toBe('object_store down')
     // Other components still healthy — parallel probes did not short-circuit
     expect(result.components.database.status).toBe('healthy')
     expect(result.components.redis.status).toBe('healthy')
@@ -412,7 +412,7 @@ describe('getSystemHealth', () => {
   test('three async probes hanging simultaneously do not serialize wall-clock (parallelism proof, T-008)', async () => {
     // The redis probe's status() is synchronous so it can't hang on a
     // timeout — instead it reports unhealthy immediately. The three
-    // async probes (database, minio, queues) all hang and must time
+    // async probes (database, object_store, queues) all hang and must time
     // out in parallel, not one-after-another.
     const hangingProbe = () => new Promise<never>(() => {})
     const start = Date.now()
@@ -423,7 +423,7 @@ describe('getSystemHealth', () => {
           poolStats: async () => ({ used: 0, max: 100 }),
         },
         redis: { status: () => 'disconnected' },
-        minio: { check: hangingProbe },
+        object_store: { check: hangingProbe },
         queues: { health: hangingProbe },
       },
       thresholds: { probeTimeoutMs: 50 },
@@ -431,7 +431,7 @@ describe('getSystemHealth', () => {
     const elapsed = Date.now() - start
     expect(result.status).toBe('unhealthy')
     expect(result.components.database.message).toContain('timed out')
-    expect(result.components.minio.message).toContain('timed out')
+    expect(result.components.object_store.message).toContain('timed out')
     expect(result.components.queues.message).toContain('timed out')
     // Parallel execution: total wall-clock should be roughly one probe's
     // timeout, not three times it. Allow generous margin for CI.
@@ -483,7 +483,7 @@ describe('legacyPublicEnvelope', () => {
     overrides: Partial<{
       db: ComponentHealth['status']
       redis: ComponentHealth['status']
-      minio: ComponentHealth['status']
+      object_store: ComponentHealth['status']
       queues: ComponentHealth['status']
     }> = {}
   ): Promise<ReturnType<typeof getSystemHealth> extends Promise<infer T> ? T : never> {
@@ -501,9 +501,9 @@ describe('legacyPublicEnvelope', () => {
         redis: {
           status: () => (overrides.redis === 'unhealthy' ? 'disconnected' : 'connected'),
         },
-        minio: {
+        object_store: {
           check: async () => ({
-            status: overrides.minio === 'unhealthy' ? 'disconnected' : 'connected',
+            status: overrides.object_store === 'unhealthy' ? 'disconnected' : 'connected',
             bucket: 'hashhive-test',
           }),
         },
@@ -526,8 +526,8 @@ describe('legacyPublicEnvelope', () => {
     expect(env.aggregateStatus).toBe('healthy')
     expect(env.services.database.status).toBe('connected')
     expect(env.services.redis.status).toBe('connected')
-    expect(env.services.minio.status).toBe('connected')
-    expect(env.services.minio.bucket).toBe('hashhive-test')
+    expect(env.services.object_store.status).toBe('connected')
+    expect(env.services.object_store.bucket).toBe('hashhive-test')
     expect(env.services.queues.status).toBe('connected')
     expect(env.version).toBe('1.1.0')
   })
@@ -546,10 +546,10 @@ describe('legacyPublicEnvelope', () => {
     // The body's coarse `status` collapses to 'degraded' for backward compat,
     // but the new `aggregateStatus` field carries the full three-tier value
     // so JSON-only monitors can distinguish degraded from unhealthy.
-    const env = legacyPublicEnvelope(await makeHealth({ minio: 'unhealthy' }))
+    const env = legacyPublicEnvelope(await makeHealth({ object_store: 'unhealthy' }))
     expect(env.status).toBe('degraded')
     expect(env.aggregateStatus).toBe('unhealthy')
-    expect(env.services.minio.status).toBe('disconnected')
+    expect(env.services.object_store.status).toBe('disconnected')
   })
 
   test('exposes services.queues.queues map with per-queue stats (api-contract-3)', async () => {

--- a/packages/backend/tests/unit/health.test.ts
+++ b/packages/backend/tests/unit/health.test.ts
@@ -58,6 +58,12 @@ describe('GET /health', () => {
 
     const body = await res.json()
     expect(body['services']['minio']).toBeUndefined()
+    // Positive assertion: the new `object_store` field carries the shape
+    // the old `minio` field used to (status + bucket). This pairs with the
+    // absence assertion above so the rename is enforced from both sides.
+    expect(['connected', 'disconnected']).toContain(body['services']['object_store']['status'])
+    expect(typeof body['services']['object_store']['bucket']).toBe('string')
+    expect(body['services']['object_store']['bucket'].length).toBeGreaterThan(0)
   })
 
   it('should expose services.queues.queues map (api-contract-3)', async () => {

--- a/packages/backend/tests/unit/health.test.ts
+++ b/packages/backend/tests/unit/health.test.ts
@@ -30,7 +30,7 @@ describe('GET /health', () => {
     const body = await res.json()
     expect(['ok', 'degraded']).toContain(body['status'])
     expect(['healthy', 'degraded', 'unhealthy']).toContain(body['aggregateStatus'])
-    expect(body['version']).toBe('1.1.0')
+    expect(body['version']).toBe('2.0.0')
     expect(body['timestamp']).toBeDefined()
     expect(body['services']['database']).toBeDefined()
     expect(['connected', 'disconnected']).toContain(body['services']['database']['status'])

--- a/packages/backend/tests/unit/health.test.ts
+++ b/packages/backend/tests/unit/health.test.ts
@@ -36,18 +36,28 @@ describe('GET /health', () => {
     expect(['connected', 'disconnected']).toContain(body['services']['database']['status'])
   })
 
-  it('should include object-store health status under the legacy `minio` wire key', async () => {
-    // The wire key stays `minio` across the SeaweedFS swap so the dashboard
-    // and any external probe consumers do not need a coupled release.
+  it('should include object-store health status under `services.object_store`', async () => {
+    // The wire key is `object_store` (vendor-neutral). The pre-prod `minio`
+    // placeholder was dropped in this PR; see issue #156 AC 4.3.
     const res = await app.request('/health')
     expect(VALID_HTTP_STATUSES).toContain(res.status)
 
     const body = await res.json()
-    const objectStore = body['services']['minio']
+    const objectStore = body['services']['object_store']
     expect(objectStore).toBeDefined()
     expect(objectStore['status']).toBe('connected')
     expect(typeof objectStore['bucket']).toBe('string')
     expect(objectStore['bucket'].length).toBeGreaterThan(0)
+  })
+
+  it('should not expose the legacy `services.minio` wire key', async () => {
+    // Regression guard: AC 4.3 of issue #156 requires neutral naming.
+    // Reintroducing the `minio` field would silently re-violate the AC.
+    const res = await app.request('/health')
+    expect(VALID_HTTP_STATUSES).toContain(res.status)
+
+    const body = await res.json()
+    expect(body['services']['minio']).toBeUndefined()
   })
 
   it('should expose services.queues.queues map (api-contract-3)', async () => {
@@ -89,13 +99,13 @@ describe('404 handler', () => {
   })
 })
 
-// ─── Object-store probe + legacy-wire contract regression tests ────────
+// ─── Object-store probe + wire-contract regression tests ────────
 //
-// These pin the post-SeaweedFS-swap behavior so renaming the internal
-// `ComponentName` value `'minio'` or dropping the legacy bucket fallback
-// becomes a test-time error instead of a frontend regression.
+// These pin the post-rename behavior so reintroducing the legacy `minio`
+// wire identifier or dropping the bucket fallback becomes a test-time
+// error instead of a frontend regression.
 
-describe('object-store probe + legacy wire contract', () => {
+describe('object-store probe + wire contract', () => {
   it('reports the documented error string when the object store is unreachable', async () => {
     const { probeObjectStore } = await import('../../src/services/health.js')
     const result = await probeObjectStore({
@@ -107,11 +117,11 @@ describe('object-store probe + legacy wire contract', () => {
     }
   })
 
-  it('preserves services.minio.bucket from env.S3_BUCKET even when probe detail is missing', async () => {
+  it('populates services.object_store.bucket from env.S3_BUCKET even when probe detail is missing', async () => {
     // Simulates the timeout/programming-error path where ComponentHealth
     // has no `detail` field. The legacy envelope must still surface
-    // `services.minio.bucket` so pre-#109 monitors that read it without
-    // optional-chaining keep working.
+    // `services.object_store.bucket` so anonymous monitors that read it
+    // without optional-chaining keep working.
     const { legacyPublicEnvelope } = await import('../../src/services/health.js')
     const envelope = legacyPublicEnvelope({
       status: 'unhealthy',
@@ -120,20 +130,21 @@ describe('object-store probe + legacy wire contract', () => {
       components: {
         database: { status: 'healthy', durationMs: 1 },
         redis: { status: 'healthy', durationMs: 1 },
-        minio: { status: 'unhealthy', message: 'probe timed out', durationMs: 1 },
+        object_store: { status: 'unhealthy', message: 'probe timed out', durationMs: 1 },
         queues: { status: 'healthy', durationMs: 1 },
       },
     })
-    expect(envelope.services.minio.status).toBe('disconnected')
-    expect(typeof envelope.services.minio.bucket).toBe('string')
-    expect(envelope.services.minio.bucket.length).toBeGreaterThan(0)
+    expect(envelope.services.object_store.status).toBe('disconnected')
+    expect(typeof envelope.services.object_store.bucket).toBe('string')
+    expect(envelope.services.object_store.bucket.length).toBeGreaterThan(0)
   })
 
-  it("pins ComponentName 'minio' as the wire identifier (regression: renaming breaks dashboard)", async () => {
+  it("pins ComponentName 'object_store' as the wire identifier (regression: renaming breaks dashboard)", async () => {
     // If the internal `ComponentName` union is ever renamed away from
-    // 'minio', the `components.minio` lookup below becomes a TypeScript
-    // error at compile time and this test stops building. The compile-time
-    // pin is the actual guard; the runtime assertion is the message.
+    // 'object_store', the `components.object_store` lookup below becomes a
+    // TypeScript error at compile time and this test stops building. The
+    // compile-time pin is the actual guard; the runtime assertion is the
+    // message.
     const { legacyPublicEnvelope } = await import('../../src/services/health.js')
     const envelope = legacyPublicEnvelope({
       status: 'healthy',
@@ -142,7 +153,7 @@ describe('object-store probe + legacy wire contract', () => {
       components: {
         database: { status: 'healthy', durationMs: 1 },
         redis: { status: 'healthy', durationMs: 1 },
-        minio: {
+        object_store: {
           status: 'healthy',
           detail: { bucket: 'pinned-bucket' },
           durationMs: 1,
@@ -150,6 +161,6 @@ describe('object-store probe + legacy wire contract', () => {
         queues: { status: 'healthy', durationMs: 1 },
       },
     })
-    expect(envelope.services.minio.bucket).toBe('pinned-bucket')
+    expect(envelope.services.object_store.bucket).toBe('pinned-bucket')
   })
 })

--- a/packages/backend/tests/unit/workers/metrics.test.ts
+++ b/packages/backend/tests/unit/workers/metrics.test.ts
@@ -85,7 +85,7 @@ if (IS_ISOLATED) {
         components: {
           database: { status: 'healthy' },
           redis: { status: 'healthy' },
-          minio: { status: 'healthy' },
+          object_store: { status: 'healthy' },
           queues: { status: 'healthy' },
         },
       })

--- a/packages/frontend/src/components/features/system-health-card.tsx
+++ b/packages/frontend/src/components/features/system-health-card.tsx
@@ -1,7 +1,7 @@
 /**
  * System health card (issue #109).
  *
- * Renders the four-component health snapshot (database, redis, minio,
+ * Renders the four-component health snapshot (database, redis, object_store,
  * queues) with status dots and per-component messages on degraded /
  * unhealthy. Click a row to expand its raw `detail` payload.
  *
@@ -24,11 +24,11 @@ import { cn } from '../../lib/utils'
 const COMPONENT_LABELS: Record<ComponentName, string> = {
   database: 'Database',
   redis: 'Redis',
-  minio: 'Object Storage',
+  object_store: 'Object Storage',
   queues: 'Job Queues',
 }
 
-const COMPONENT_ORDER: ComponentName[] = ['database', 'redis', 'minio', 'queues']
+const COMPONENT_ORDER: ComponentName[] = ['database', 'redis', 'object_store', 'queues']
 
 const STATUS_DOT: Record<ComponentStatus, string> = {
   healthy: 'bg-success',

--- a/packages/frontend/src/hooks/use-system-health.ts
+++ b/packages/frontend/src/hooks/use-system-health.ts
@@ -1,3 +1,5 @@
+import type { ComponentName, ComponentStatus } from '@hashhive/shared'
+
 /**
  * System health query hook (issue #109).
  *
@@ -9,13 +11,11 @@ import { keepPreviousData, useQuery } from '@tanstack/react-query'
 
 import { api } from '../lib/api'
 
-export type ComponentStatus = 'healthy' | 'degraded' | 'unhealthy'
-
-// `'object_store'` is the neutral wire identifier — vendor-agnostic across
-// SeaweedFS today and any future hosted AWS S3 deploy. See
-// `packages/backend/src/services/health.ts` (ComponentName) for the
-// corresponding backend type.
-export type ComponentName = 'database' | 'redis' | 'object_store' | 'queues'
+// Re-export so component files keep `import { ComponentName } from
+// '../hooks/use-system-health'` working. Canonical schemas
+// (`componentNameSchema`, `componentStatusSchema`) live in
+// `@hashhive/shared` per AGENTS.md's wire-shape rule.
+export type { ComponentName, ComponentStatus }
 
 export interface ComponentHealth {
   status: ComponentStatus

--- a/packages/frontend/src/hooks/use-system-health.ts
+++ b/packages/frontend/src/hooks/use-system-health.ts
@@ -11,11 +11,11 @@ import { api } from '../lib/api'
 
 export type ComponentStatus = 'healthy' | 'degraded' | 'unhealthy'
 
-// `'minio'` is preserved as the wire identifier across the SeaweedFS swap
-// so the backend can swap its object-store implementation without a
-// coupled frontend release. See `packages/backend/src/services/health.ts`
-// (ComponentName) for the corresponding backend type.
-export type ComponentName = 'database' | 'redis' | 'minio' | 'queues'
+// `'object_store'` is the neutral wire identifier — vendor-agnostic across
+// SeaweedFS today and any future hosted AWS S3 deploy. See
+// `packages/backend/src/services/health.ts` (ComponentName) for the
+// corresponding backend type.
+export type ComponentName = 'database' | 'redis' | 'object_store' | 'queues'
 
 export interface ComponentHealth {
   status: ComponentStatus

--- a/packages/frontend/tests/components/campaign-dag-view.test.tsx
+++ b/packages/frontend/tests/components/campaign-dag-view.test.tsx
@@ -44,7 +44,7 @@ mock.module('reactflow', () => {
       <div data-testid="react-flow-stub">
         <ul data-testid="dag-nodes">
           {nodes.map((n) => (
-            <li key={n.id} data-node-id={n.id} data-node-bg={String(n.style?.['background'] ?? '')}>
+            <li key={n.id} data-node-id={n.id} data-node-bg={n.style?.['background'] ?? ''}>
               {n.data.label}
             </li>
           ))}

--- a/packages/frontend/tests/components/system-health-card.test.tsx
+++ b/packages/frontend/tests/components/system-health-card.test.tsx
@@ -28,7 +28,7 @@ function buildHealth(overrides: Partial<SystemHealth> = {}): SystemHealth {
     components: {
       database: { status: 'healthy', durationMs: 4 },
       redis: { status: 'healthy', durationMs: 2 },
-      minio: { status: 'healthy', durationMs: 8, detail: { bucket: 'hashhive' } },
+      object_store: { status: 'healthy', durationMs: 8, detail: { bucket: 'hashhive' } },
       queues: {
         status: 'healthy',
         durationMs: 12,
@@ -79,7 +79,7 @@ describe('SystemHealthCard', () => {
               durationMs: 4,
             },
             redis: { status: 'healthy', durationMs: 2 },
-            minio: { status: 'healthy', durationMs: 8, detail: { bucket: 'hashhive' } },
+            object_store: { status: 'healthy', durationMs: 8, detail: { bucket: 'hashhive' } },
             queues: { status: 'healthy', durationMs: 12 },
           },
         }),
@@ -102,7 +102,7 @@ describe('SystemHealthCard', () => {
           components: {
             database: { status: 'healthy', durationMs: 4 },
             redis: { status: 'unhealthy', message: 'connection refused', durationMs: 2 },
-            minio: { status: 'healthy', durationMs: 8, detail: { bucket: 'hashhive' } },
+            object_store: { status: 'healthy', durationMs: 8, detail: { bucket: 'hashhive' } },
             queues: { status: 'healthy', durationMs: 12 },
           },
         }),
@@ -146,7 +146,7 @@ describe('SystemHealthCard', () => {
               durationMs: 2,
               detail: { latencyMs: 800 },
             },
-            minio: { status: 'healthy', durationMs: 8, detail: { bucket: 'hashhive' } },
+            object_store: { status: 'healthy', durationMs: 8, detail: { bucket: 'hashhive' } },
             queues: {
               status: 'healthy',
               durationMs: 12,
@@ -177,10 +177,10 @@ describe('SystemHealthCard', () => {
       .find((b) => b.getAttribute('aria-label')?.startsWith('Redis status:'))
     expect(redisRow?.getAttribute('aria-label')).toContain('degraded')
 
-    const minioRow = screen
+    const objectStoreRow = screen
       .getAllByRole('button')
       .find((b) => b.getAttribute('aria-label')?.startsWith('Object Storage status:'))
-    expect(minioRow?.getAttribute('aria-label')).toContain('healthy')
+    expect(objectStoreRow?.getAttribute('aria-label')).toContain('healthy')
 
     // Per-component messages render adjacent to their row.
     expect(screen.getByText('pool exhausted')).toBeDefined()
@@ -195,7 +195,7 @@ describe('SystemHealthCard', () => {
           components: {
             database: { status: 'healthy', durationMs: 4 },
             redis: { status: 'healthy', durationMs: 2 },
-            minio: { status: 'healthy', durationMs: 8, detail: { bucket: 'hashhive' } },
+            object_store: { status: 'healthy', durationMs: 8, detail: { bucket: 'hashhive' } },
             queues: {
               status: 'healthy',
               durationMs: 12,
@@ -257,7 +257,7 @@ describe('SystemHealthCard', () => {
           components: {
             database: { status: 'healthy', durationMs: 4 },
             redis: { status: 'healthy', durationMs: 2 },
-            minio: { status: 'healthy', durationMs: 8, detail: { bucket: 'hashhive' } },
+            object_store: { status: 'healthy', durationMs: 8, detail: { bucket: 'hashhive' } },
             queues: {
               status: 'healthy',
               durationMs: 12,

--- a/packages/frontend/tests/components/system-health-card.test.tsx
+++ b/packages/frontend/tests/components/system-health-card.test.tsx
@@ -24,7 +24,7 @@ function buildHealth(overrides: Partial<SystemHealth> = {}): SystemHealth {
   return {
     status: 'healthy',
     timestamp: '2026-05-06T12:00:00.000Z',
-    version: '1.1.0',
+    version: '2.0.0',
     components: {
       database: { status: 'healthy', durationMs: 4 },
       redis: { status: 'healthy', durationMs: 2 },

--- a/packages/openapi/control-api.yaml
+++ b/packages/openapi/control-api.yaml
@@ -9,6 +9,23 @@ info:
 
     ## Changelog
 
+    ### 2.0.0 (issue #156)
+
+    Breaking rename in the `SystemHealth.components` map (and the legacy
+    public `/health` `services` map):
+    - `minio` → `object_store`. The previous key was a SeaweedFS-era
+      placeholder; the neutral name is vendor-agnostic across SeaweedFS
+      and any future hosted AWS S3 deploy.
+    - `services.minio` is **removed** from the legacy `/health` envelope —
+      no dual-write, no alias. Probes built against `services.minio.status`
+      will see `undefined` after this change.
+    - `HEALTH_VERSION` constant in `services/health.ts` bumps to `2.0.0`
+      in lock-step.
+
+    Pre-prod posture: HashHive has no external automation consumers of
+    this surface at this time. Internal frontend and CLI consumers are
+    updated in the same PR.
+
     ### 1.1.0 (issue #109)
 
     Breaking change to `GET /health`:
@@ -22,7 +39,7 @@ info:
     Consumers that pinned the old envelope must update before upgrading.
     No deprecation window: this surface was introduced in 1.0.0 and has
     no known external automation consumers yet.
-  version: 1.1.0
+  version: 2.0.0
 
 servers:
   - url: /api/v1/control
@@ -42,12 +59,16 @@ paths:
           `/api/v1/dashboard/health` return the rich `SystemHealth`
           shape — three-tier `status`, `components` map, per-component
           `message`, `detail`, and `durationMs`.
-        - The public `/health` returns a backward-compatible legacy
-          envelope: two-tier `status: ok | degraded`, a `services` map,
-          and an additive `aggregateStatus` field carrying the full
-          three-tier signal. This shape exists so older load-balancer
-          probes that read `services.{database,redis,object_store}.status`
-          keep working.
+        - The public `/health` returns a legacy envelope: two-tier
+          `status: ok | degraded`, a `services` map, and an additive
+          `aggregateStatus` field carrying the full three-tier signal.
+          The envelope shape pre-dates issue #109; LB probes that read
+          `services.{database,redis,object_store,queues}.status` use it.
+          **Note:** this is not back-compat in the strict sense — the
+          rich-vs-legacy split is preserved, but issue #156 renamed the
+          object-store component from `minio` to `object_store` and
+          bumped the schema version to 2.0.0; pre-2.0.0 probes keyed on
+          `services.minio` will see `undefined`.
 
         Authenticated control consumers receive the full shape including
         connection counts, queue depths, and probe durations.

--- a/packages/openapi/control-api.yaml
+++ b/packages/openapi/control-api.yaml
@@ -46,7 +46,7 @@ paths:
           envelope: two-tier `status: ok | degraded`, a `services` map,
           and an additive `aggregateStatus` field carrying the full
           three-tier signal. This shape exists so older load-balancer
-          probes that read `services.{database,redis,minio}.status`
+          probes that read `services.{database,redis,object_store}.status`
           keep working.
 
         Authenticated control consumers receive the full shape including
@@ -770,13 +770,13 @@ components:
           type: string
         components:
           type: object
-          required: [database, redis, minio, queues]
+          required: [database, redis, object_store, queues]
           properties:
             database:
               $ref: '#/components/schemas/ComponentHealth'
             redis:
               $ref: '#/components/schemas/ComponentHealth'
-            minio:
+            object_store:
               $ref: '#/components/schemas/ComponentHealth'
             queues:
               $ref: '#/components/schemas/ComponentHealth'

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -536,6 +536,25 @@ export const agentHeartbeatResponseSchema = z
   })
   .strict()
 
+// ─── System Health API ─────────────────────────────────────────────
+
+/**
+ * Wire identifiers for the four health components surfaced on
+ * `/api/v1/control/health`, `/api/v1/dashboard/health`, and the legacy
+ * public `/health` envelope. Renamed in issue #156 (HEALTH_VERSION 2.0.0):
+ * the prior `'minio'` placeholder was dropped in favor of the neutral
+ * `'object_store'` so the wire shape stays vendor-agnostic across
+ * SeaweedFS and any future hosted AWS S3 deploy.
+ *
+ * Single source of truth — backend `services/health.ts`, frontend
+ * `hooks/use-system-health.ts`, and the OpenAPI control spec all
+ * consume this schema (per AGENTS.md "Wire shapes live in @hashhive/shared").
+ */
+export const componentNameSchema = z.enum(['database', 'redis', 'object_store', 'queues'])
+
+/** Three-tier component status used on the rich SystemHealth envelope. */
+export const componentStatusSchema = z.enum(['healthy', 'degraded', 'unhealthy'])
+
 // ─── Cracker Check-Update API ───────────────────────────────────────
 
 /**

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -7,6 +7,8 @@ import type {
   agentHeartbeatErrorSchema,
   agentHeartbeatResponseSchema,
   agentHeartbeatSchema,
+  componentNameSchema,
+  componentStatusSchema,
   agentStatusSchema,
   agentTaskSummarySchema,
   agentWorstSeveritySchema,
@@ -231,6 +233,8 @@ export type AgentHeartbeat = z.infer<typeof agentHeartbeatSchema>
 export type AgentHeartbeatError = z.infer<typeof agentHeartbeatErrorSchema>
 export type AgentHeartbeatCurrentTask = z.infer<typeof agentHeartbeatCurrentTaskSchema>
 export type AgentHeartbeatResponse = z.infer<typeof agentHeartbeatResponseSchema>
+export type ComponentName = z.infer<typeof componentNameSchema>
+export type ComponentStatus = z.infer<typeof componentStatusSchema>
 export type AgentHardwareProfile = z.infer<typeof agentHardwareProfileSchema>
 export type BenchmarkSubmission = z.infer<typeof benchmarkSubmissionSchema>
 export type CreateAttackTemplateRequest = z.infer<typeof createAttackTemplateRequestSchema>


### PR DESCRIPTION
Closes #156.

## Summary

Issue #156 covers the Resource Pipeline foundation: S3-compatible object store (now SeaweedFS), env-driven buckets, presigned URLs, object-store health checks, 12-factor config, and the local-stack migration. **PR #153 already landed the SeaweedFS infrastructure swap with `minio` preserved as the wire identifier defensively.** This PR is the verification sweep — close the remaining acceptance criteria, ship the AC traceability matrix, and **drop `minio` outright** as the wire identifier per AC 4.3's neutral-naming requirement.

| Metric | Value |
| ------ | ----- |
| Files changed | 23 (3 new, 20 modified) |
| Net change | +730 / -162 |
| Schema version | `1.1.0` → `2.0.0` (breaking) |
| Risk | 🟡 Medium — destructive wire-contract change on the public `/health` endpoint |
| Type | `refactor` + `feat` (rename + contract artifacts + docs) |
| Test delta | Backend 469 pass / 0 fail · Frontend 319 pass / 0 fail · E2E 3 pass |

## What changed

### 🔧 Source / wire contract

| Status | File | Notes |
| ------ | ---- | ----- |
| M | `packages/backend/src/services/health.ts` | `ComponentName` enum literal `'minio'` → `'object_store'`; `ObjectStoreProbeDeps` keys + probe wiring + `executeProbes` destructure + `LegacyHealthEnvelope.services.minio` → `services.object_store`; `HEALTH_VERSION` bumped to `2.0.0` with inline changelog block. Now imports `ComponentName`/`ComponentStatus` from `@hashhive/shared` and re-exports for callers. |
| M | `packages/backend/src/queue/workers/health-monitor.ts` | `COMPONENTS` array literal updated. |
| M | `packages/backend/src/services/crackers.ts` | 3 current-code comment updates (`MinIO-backed` → `object-store-backed`, etc.). |
| M | `packages/backend/src/index.ts` | `/health` route docstring rewritten to explicitly call out the breaking rename and `HEALTH_VERSION` bump instead of implying back-compat. |
| M | `packages/openapi/control-api.yaml` | `SystemHealth.components.required` + `properties` renamed; description block updated; new `2.0.0 (issue #156)` changelog entry; `info.version` bumped to `2.0.0`. |
| M | `packages/frontend/src/hooks/use-system-health.ts` | `ComponentName`/`ComponentStatus` now imported from `@hashhive/shared` and re-exported (no more local type declaration crossing the API boundary per AGENTS.md). |
| M | `packages/frontend/src/components/features/system-health-card.tsx` | `COMPONENT_LABELS` map + `COMPONENT_ORDER` array updated. |
| M | `packages/shared/src/schemas/index.ts` | New `componentNameSchema` and `componentStatusSchema` (Zod enums). |
| M | `packages/shared/src/types/index.ts` | New `ComponentName` and `ComponentStatus` types exported as `z.infer<typeof …>`. |

### ✅ Tests

| Status | File | Notes |
| ------ | ---- | ----- |
| M | `tests/unit/health.test.ts` | Renames assertions; symmetric regression guard (`services.minio` absent **and** `services.object_store` positive shape). Version assertion bumped. |
| M | `tests/unit/health-service.test.ts` | Property-key renames in mocks/assertions; version assertion bumped. |
| M | `tests/unit/health-monitor.test.ts` | Component-set assertions; 6 `.sort()` → `[...arr].sort()` to avoid in-place mutation. |
| M | `tests/unit/events.test.ts` | One log-event component-name assertion. |
| M | `tests/unit/workers/metrics.test.ts` | One mock fixture. |
| M | `tests/integration/control-health.test.ts` | Renames; added `components['minio']` absence guard symmetric with legacy `/health`. Version assertion bumped. |
| M | `tests/integration/dashboard-health.test.ts` | Same rename + absence-guard pattern. |
| M | `tests/integration/health-deterministic.test.ts` | Mock builder fields renamed. |
| M | `tests/integration/smoke.test.ts` | Version assertion bumped. |
| M | `tests/components/system-health-card.test.tsx` | Frontend fixtures renamed; version assertion bumped. |
| M | `tests/components/campaign-dag-view.test.tsx` | Pre-existing oxlint error fixed inline (unnecessary `String(...)` wrapper). |

### 📝 Documentation

| Status | File | Notes |
| ------ | ---- | ----- |
| A | `docs/issues/156-object-storage-file-management-spec.md` | Technical spec with verification sweep and the rename decision. |
| A | `docs/issues/156-ac-traceability-matrix.md` | AC↔code↔test mapping for all 20 acceptance checkboxes; documents the stale "hardcoded bucket" ticket warning, the 6h `getAgentDownloadUrl` deviation from AC 3.1, and the kept `minioadmin/minioadmin` seeded credentials per AC 6.2. |
| A | `docs/solutions/conventions/shared-zod-openapi-wire-contract-mirror-2026-05-25.md` | New convention doc capturing the Zod ↔ OpenAPI ↔ route ↔ contract-test triple-sync pattern (companion to issue #155's learning). |

## Why this change

AC 4.3 of issue #156: "log messages and field names use neutral terms (e.g., `object_store`, not `minio`)." PR #153 defensively preserved `minio` as the wire identifier to avoid breaking external monitors. **HashHive is pre-prod** — no in-repo consumer reads `services.minio.*` (audited via `rg`), so the placeholder is dropped outright rather than carrying the legacy vendor name forward into post-prod.

The rename is treated as a wire-contract change per [the shared Zod/OpenAPI mirror convention](docs/solutions/conventions/shared-zod-openapi-wire-contract-mirror-2026-05-25.md): the rename propagates atomically across `@hashhive/shared` (new Zod enums), `packages/openapi/control-api.yaml`, the backend route handler, and the frontend hook + card.

Three intentional `minio` references survive as documentation:

- `services/health.ts:32` — JSDoc explaining why the placeholder was dropped.
- `tests/unit/health.test.ts` — regression-guard tests that explicitly assert `services.minio` is absent from the response shape.

## AC matrix highlights

All 20 acceptance checkboxes pass. The matrix at [`docs/issues/156-ac-traceability-matrix.md`](docs/issues/156-ac-traceability-matrix.md) records three documented decisions:

1. **AC 2.3 "no hardcoded `'hashhive'` bucket"** — Stale ticket warning. The literal was already removed (likely #122/#153); `rg "'hashhive'" packages/backend/src/` returns one hit at `config/env.ts:31` (the Zod default — fine).
2. **AC 3.1 "1-hour expiration"** — `getAgentDownloadUrl` deliberately uses 6h for large-file agent downloads. Documented deviation; behavior preserved.
3. **AC 6.2 "matching prior MinIO defaults"** — Seeded credentials remain `minioadmin/minioadmin`. AC 6.2 explicitly mandates matching the prior defaults so `just db-seed` and integration tests don't need new env wiring.

## Risk assessment

| Factor | Score | Reasoning |
| ------ | ----- | --------- |
| Size | 🟢 3/10 | 23 files, mostly mechanical rename + doc artifacts |
| Wire compatibility | 🟡 6/10 | Destructive change on `/health` — no `services.minio` alias retained. Mitigated by pre-prod posture and `HEALTH_VERSION` bump to 2.0.0 so consumers can gate on the change. |
| Test coverage | 🟢 2/10 | Existing tests renamed; positive + absence assertions added across all three health surfaces (`/health`, `/api/v1/control/health`, `/api/v1/dashboard/health`) |
| Security | 🟢 0/10 | No auth/permission changes |
| Operational | 🟡 4/10 | Anonymous LB probes keyed on `services.minio.status` will see `undefined`. Pre-prod; no external monitors known. Changelog entry in `control-api.yaml` documents the break for any future SDK regeneration. |

### No-regression argument

- **Agent API** — untouched.
- **Frontend** — `ComponentName` type now sources from `@hashhive/shared`; both the hook and the health card consume it transparently.
- **OpenAPI consumers** — `control-api.yaml` `SystemHealth.components` schema renamed atomically (both `required` array and `properties` map); `info.version` bumped to `2.0.0` with explicit changelog entry.
- **Shared package** — `componentNameSchema` and `componentStatusSchema` introduced as the single source of truth per AGENTS.md "wire shapes live in `@hashhive/shared`."

## Test plan

- [x] `just check` green (format + lint + type-check + build).
- [x] `just ci-check` green — **469 backend / 0 fail**, **319 frontend / 0 fail**, **3 e2e pass**.
- [x] Regression guards on all three health surfaces: `services.minio` absent, `services.object_store` positive shape.
- [x] Version assertion contracts pinned at `2.0.0` across 7 test files.
- [x] PR review feedback: **11 threads resolved** (5 from copilot, 6 from coderabbit), all autonomous fixes applied in `22e0192`.
- [ ] CI green on the latest push.

## Follow-up (out of scope)

- `dashboard-api.yaml` has no `/health` path documented — pre-existing tech-debt surfaced during the API-contract review. The dashboard route returns the raw `SystemHealth` object and is not contract-tested through an OpenAPI spec.
- WebSocket `system_health` broadcasts now carry `{ component: 'object_store' }` instead of `'minio'`. External WS subscribers keyed on the old name will silently stop seeing object-store transitions. Document this in deployment notes if any external integrations exist.
- Stale Redis `health:last-status:minio` keys auto-expire within 24h on first deploy — no cleanup action required.

## Commits

| SHA | Summary |
| --- | ------- |
| `b301abb` | `feat(storage)`: technical specification for object storage and file management with SeaweedFS |
| `044a071` | `feat(conventions)`: shared Zod/OpenAPI wire-contract mirror documentation |
| `f56f6d2` | `refactor(health)`: rename `minio` → `object_store` across the wire contract |
| `42ac10f` | `fix(review)`: positive `services.object_store` assertion on `/health` |
| `d8d7769` | `fix(ci)`: finish rename in frontend fixtures + close review gaps |
| `22e0192` | Address PR #171 review feedback (11 threads, 5 clusters) |
