### PR TITLE
docs(backlog): reconcile Resource_Management_API as complete (#157)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,26 +4,27 @@ Companion to [STRATEGY.md](./STRATEGY.md). Orders work by leverage on the strate
 
 Work is in two phases:
 
-- **Phase 1 — Foundation:** the 11 remaining tickets under `spec/tickets/`. These complete the original ticket pack and are prerequisite for most of Phase 2.
+- **Phase 1 — Foundation:** the 10 remaining tickets under `spec/tickets/`. These complete the original ticket pack and are prerequisite for most of Phase 2.
 - **Phase 2 — Backlog:** open GitHub issues (#97–#124) labeled P0/P1/P2 and grouped under epics #117–#121. Strategic-value ordering within tracks.
 
 ---
 
-## Phase 1 — Remaining spec/tickets (11)
+## Phase 1 — Remaining spec/tickets (10)
 
-### Completed (7, retrospective)
+### Completed (8)
 
-| Ticket                                          | Track                 |
-| ----------------------------------------------- | --------------------- |
-| `Agent_Authentication_&_Authorization`          | 2 — Agent Protocol    |
-| `Agent_Heartbeat_&_Error_Handling`              | 2 — Agent Protocol    |
-| `Agent_List_&_Detail_UI`                        | 4 — Operator Console  |
-| `BullMQ_Queue_Architecture_&_Redis_Integration` | 1 — Scheduler (infra) |
-| `Campaign_Creation_Wizard_UI`                   | 4 — Operator Console  |
-| `Campaign_List_&_Detail_UI`                     | 4 — Operator Console  |
-| `Campaign_Orchestration_API`                    | 1 — Scheduler         |
+| Ticket                                          | Track                 | Landed                                                                       |
+| ----------------------------------------------- | --------------------- | ---------------------------------------------------------------------------- |
+| `Agent_Authentication_&_Authorization`          | 2 — Agent Protocol    | retrospective                                                                |
+| `Agent_Heartbeat_&_Error_Handling`              | 2 — Agent Protocol    | retrospective                                                                |
+| `Agent_List_&_Detail_UI`                        | 4 — Operator Console  | retrospective                                                                |
+| `BullMQ_Queue_Architecture_&_Redis_Integration` | 1 — Scheduler (infra) | retrospective                                                                |
+| `Campaign_Creation_Wizard_UI`                   | 4 — Operator Console  | retrospective                                                                |
+| `Campaign_List_&_Detail_UI`                     | 4 — Operator Console  | retrospective                                                                |
+| `Campaign_Orchestration_API`                    | 1 — Scheduler         | retrospective                                                                |
+| `Resource_Management_API`                       | 3 — Resource Pipeline | PRs #122 / #151 / #152 / #153 / #167 — AC walk complete (issue #157)         |
 
-### Recommended sequence for the remaining 11
+### Recommended sequence for the remaining 10
 
 Sequencing is strategy-driven, not alphabetical. The scheduler core comes first because it is the guiding choice of the product; resources come second because campaigns can't crack anything without wordlists; visibility and auth follow; results last.
 
@@ -31,21 +32,20 @@ Sequencing is strategy-driven, not alphabetical. The scheduler core comes first 
 | ---: | --------------------------------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 |    1 | `Task_Distribution_&_Assignment`              | 1 — Scheduler         | **The scheduler is half-done without this.** Strict capability matching, hybrid sync/async generation, reassignment job, retry logic, priority queuing — these *are* the rebalancing approach. Until this lands, campaigns don't actually distribute end-to-end. |
 |    2 | `Object_Storage_&_File_Management`            | 3 — Resource Pipeline | Resource API depends on it. Env-driven buckets, presigned URLs, object-store health checks. Now targets SeaweedFS instead of MinIO (Apache-2.0 + MinIO upstream archived). Some chunked-upload code exists from #122 but AC isn't met.                           |
-|    3 | `Resource_Management_API`                     | 3 — Resource Pipeline | Async hash-list parsing, bulk insert with dedup, resource CRUD with project scoping, hash-type detection endpoint. Required before resource UI is meaningful.                                                                                                    |
-|    4 | `Real-Time_Events_&_WebSocket_Infrastructure` | 4 — Operator Console  | WebSocket auth, polling fallback, project-scoped filtering, connection indicator. #150 shipped partial real-time updates; the full infra ticket has more AC items. Blocks live-update behavior in every Track 4 surface below.                                   |
-|    5 | `Project_Selection_&_User_Authentication_API` | 4 — Operator Console  | Project selector endpoint, RBAC enforcement, remember-last-project logic. BetterAuth migration (#127) covers login/logout but the project-scoping AC may still be open.                                                                                          |
-|    6 | `Login_&_Project_Selection_UI`                | 4 — Operator Console  | Depends on #5. Auto-select on single-project, remember-last-project, sidebar project switcher, protected route that requires a selected project.                                                                                                                 |
-|    7 | `Dashboard_Stats_API_Endpoint`                | 4 — Operator Console  | Backend feed for dashboard cards. `routes/dashboard/stats.ts` exists; verify AC: agent breakdown, campaign breakdown, task breakdown, cracked-hash totals, server-side project scoping.                                                                          |
-|    8 | `Dashboard_&_Real-Time_Monitoring_UI`         | 4 — Operator Console  | Depends on #4 + #7. Four stat cards with clickable nav, WebSocket-driven updates, polling fallback, connection indicator.                                                                                                                                        |
-|    9 | `Resource_Management_UI`                      | 3 — Resource Pipeline | Depends on #3. Tabbed resource page, drag-and-drop upload with progress, hash-type detection UI with confidence scores.                                                                                                                                          |
-|   10 | `Results_API_&_CSV_Export`                    | 4 — Operator Console  | Paginated/filterable results, CSV export, campaign→attack→hash-list attribution. `routes/dashboard/results.ts` exists; verify AC against ticket.                                                                                                                 |
-|   11 | `Results_Analysis_&_Export_UI`                | 4 — Operator Console  | Depends on #10. Global Results page with filters and search, CSV export trigger, campaign-specific results tab on campaign detail.                                                                                                                               |
+|    3 | `Real-Time_Events_&_WebSocket_Infrastructure` | 4 — Operator Console  | WebSocket auth, polling fallback, project-scoped filtering, connection indicator. #150 shipped partial real-time updates; the full infra ticket has more AC items. Blocks live-update behavior in every Track 4 surface below.                                   |
+|    4 | `Project_Selection_&_User_Authentication_API` | 4 — Operator Console  | Project selector endpoint, RBAC enforcement, remember-last-project logic. BetterAuth migration (#127) covers login/logout but the project-scoping AC may still be open.                                                                                          |
+|    5 | `Login_&_Project_Selection_UI`                | 4 — Operator Console  | Depends on #4. Auto-select on single-project, remember-last-project, sidebar project switcher, protected route that requires a selected project.                                                                                                                 |
+|    6 | `Dashboard_Stats_API_Endpoint`                | 4 — Operator Console  | Backend feed for dashboard cards. `routes/dashboard/stats.ts` exists; verify AC: agent breakdown, campaign breakdown, task breakdown, cracked-hash totals, server-side project scoping.                                                                          |
+|    7 | `Dashboard_&_Real-Time_Monitoring_UI`         | 4 — Operator Console  | Depends on #3 + #6. Four stat cards with clickable nav, WebSocket-driven updates, polling fallback, connection indicator.                                                                                                                                        |
+|    8 | `Resource_Management_UI`                      | 3 — Resource Pipeline | Backend API (`Resource_Management_API`) shipped — see Completed table. Tabbed resource page, drag-and-drop upload with progress, hash-type detection UI with confidence scores.                                                                                  |
+|    9 | `Results_API_&_CSV_Export`                    | 4 — Operator Console  | Paginated/filterable results, CSV export, campaign→attack→hash-list attribution. `routes/dashboard/results.ts` exists; verify AC against ticket.                                                                                                                 |
+|   10 | `Results_Analysis_&_Export_UI`                | 4 — Operator Console  | Depends on #9. Global Results page with filters and search, CSV export trigger, campaign-specific results tab on campaign detail.                                                                                                                                |
 
 ### Dependency notes
 
-- **#1 (Task Distribution) is on its own track and can be parallelized** against #2–#11 if you have the bandwidth. It blocks nothing in this list but is the highest-leverage item against STRATEGY.md.
-- **#4 (WebSocket infra) blocks live-update behavior** in #8, #9, and #11. Finishing it before those UI surfaces avoids re-wiring later.
-- **#5 → #6**, **#7 → #8**, **#3 → #9**, **#10 → #11** are hard dependencies. The rest is preference.
+- **#1 (Task Distribution) is on its own track and can be parallelized** against #2–#10 if you have the bandwidth. It blocks nothing in this list but is the highest-leverage item against STRATEGY.md.
+- **#3 (WebSocket infra) blocks live-update behavior** in #7, #8, and #10. Finishing it before those UI surfaces avoids re-wiring later.
+- **#4 → #5**, **#6 → #7**, **#9 → #10** are hard dependencies. The rest is preference. The `Resource_Management_API → Resource_Management_UI (#8)` dependency is now satisfied by the completed-table entry.
 
 ---
 

--- a/docs/solutions/conventions/pre-prod-wire-rename-and-schema-version-bump.md
+++ b/docs/solutions/conventions/pre-prod-wire-rename-and-schema-version-bump.md
@@ -1,0 +1,172 @@
+---
+module: packages/backend, packages/shared, packages/openapi, packages/frontend
+date: 2026-05-25
+problem_type: convention
+component: api-contract
+severity: medium
+tags:
+  - wire-contract
+  - rename
+  - schema-version
+  - pre-prod
+  - openapi
+  - back-compat
+  - health-endpoint
+applies_when:
+  - "An earlier PR defensively preserved a placeholder wire identifier (`minio`, `legacy_*`, vendor-specific name) instead of renaming it"
+  - "HashHive (or any project) is still pre-prod, with no documented external automation consumers of the affected surface"
+  - "The new field name is more accurate or vendor-neutral and would reduce future cognitive load for maintainers"
+  - "A subsequent PR can pay the rename cost once, atomically, with a schema-version bump"
+---
+
+# Drop placeholder wire identifiers cleanly while pre-prod, paired with a schema-version bump
+
+## Context
+
+PR #153 swapped HashHive's object store from MinIO to SeaweedFS but kept `minio` as the wire identifier in the `/health` envelope. The defensive preservation was explicit in the code: a comment said "`'minio'` is preserved as the wire identifier across the SeaweedFS swap so frontend consumers keep working without a coupled release." Three weeks later, issue #156 AC 4.3 mandated the neutral name (`object_store`). Two options surfaced:
+
+- **A. Add `services.object_store` alongside `services.minio`** — dual-write, deprecate the old name later.
+- **B. Rename outright, drop the legacy alias, bump the schema version.**
+
+The instinct on shipping wire-contract changes is to favor option A. Dual-write is what you do in production. But HashHive is pre-prod — no monitors, no load-balancer probes, no SDK consumers — so the defensive preservation had no live constraint to honor. Option A would carry placeholder vendor naming forward into post-prod indefinitely; option B costs one PR.
+
+The decision was option B. The rename landed in PR #171 alongside a `HEALTH_VERSION` bump from `1.1.0` to `2.0.0` and a matching `info.version` bump in the OpenAPI control spec, with a changelog entry documenting the break.
+
+## Guidance
+
+When an earlier PR's defensive back-compat preservation outlives its usefulness AND the project is genuinely pre-prod, drop it cleanly in one PR. Four moves make the change durable:
+
+### 1. Audit consumers before deciding (cheap, evidence-based)
+
+Run `rg "services\.minio|body\['minio'\]|body\.minio" packages/` (substitute your field name) across the repo. If the only consumers are the test files for the legacy field itself, the back-compat has no live constraint. If a frontend hook, CLI, or agent code reads the old name, the rename is still possible but must update those consumers in the same PR.
+
+Anything outside the repo is harder to audit. Pre-prod posture means "no production consumers exist yet" — note the assumption explicitly in the PR description so a reviewer can challenge it.
+
+### 2. Rename across the wire-shape mirror in one PR
+
+Per the [Zod ↔ OpenAPI ↔ route triple-sync convention](shared-zod-openapi-wire-contract-mirror-2026-05-25.md), the rename touches every corner of the contract atomically:
+
+- Backend service code (enum types, probe wiring, log fields, comments describing current behavior).
+- Backend tests (mocks, assertions, regression-guards).
+- Shared schemas (`packages/shared/src/schemas/`) — if the type didn't live there already, move it now per AGENTS.md "wire shapes live in shared."
+- OpenAPI spec (`packages/openapi/*.yaml`) — both `required` array and `properties` map.
+- Frontend hooks + components that consume the field.
+- Frontend tests with fixtures (the most common miss; the type-check covers backend but a `tsconfig.json` that only `includes` `src/**/*` won't catch frontend test fixtures).
+
+### 3. Bump the schema version with a changelog entry
+
+```typescript
+// packages/backend/src/services/health.ts
+/**
+ * 2.0.0 (issue #156) — `components.minio` renamed to `components.object_store`
+ *   across both the rich envelope and the legacy public envelope. No
+ *   back-compat alias; pre-2.0.0 probes keyed on the old name will see
+ *   the field absent.
+ * 1.1.0 (issue #109) — three-tier status, `components` map, per-component
+ *   `message`/`detail`/`durationMs`.
+ */
+export const HEALTH_VERSION = '2.0.0'
+```
+
+```yaml
+# packages/openapi/control-api.yaml
+info:
+  description: |
+    ## Changelog
+
+    ### 2.0.0 (issue #156)
+
+    Breaking rename in `SystemHealth.components`:
+    - `minio` → `object_store`. The previous key was a SeaweedFS-era
+      placeholder; the neutral name is vendor-agnostic.
+    - `services.minio` is removed from the legacy `/health` envelope —
+      no dual-write, no alias.
+    - `HEALTH_VERSION` constant bumps to `2.0.0` in lock-step.
+  version: 2.0.0
+```
+
+Bumping the version is the durable signal that lets a future consumer gate on the change. Without it, the only evidence of the rename is the git history.
+
+### 4. Add a regression guard, not just an assertion change
+
+Mechanical assertion renames (`expect(body.services.minio)` → `expect(body.services.object_store)`) prove the new field exists. Symmetric guards prove the old name is gone:
+
+```typescript
+// Asserts the new name is present AND the old name is absent —
+// reintroducing the legacy alias becomes a test failure, not a silent
+// re-violation of the AC.
+expect(body.services.object_store.status).toBe('connected')
+expect(body.services.minio).toBeUndefined()
+```
+
+Apply this pattern on every health surface (legacy `/health`, rich `/control/health`, rich `/dashboard/health`) — pinning only the least-used one is inconsistent.
+
+## Why This Matters
+
+- **Pre-prod is the right window.** Once external probes, generated SDKs, or third-party monitors exist, dropping a wire identifier requires a deprecation cycle (typically two minor versions with dual-write). Pre-prod has no such constraint — the cost is one atomic PR. Post-prod, the same rename is a quarter of work.
+- **Schema versions are the durable signal.** `HEALTH_VERSION` and OpenAPI `info.version` survive git-history archaeology. Consumers regenerating SDKs three months later see "2.0.0 — breaking rename" in the changelog without needing to read the diff.
+- **Symmetric absence guards prevent silent re-introduction.** A future PR that "helpfully" re-adds the old field as an alias would pass mechanical assertions on the new field; only the `toBeUndefined()` guard catches it. This is the same regression-guard discipline as the `services.minio.toBeUndefined()` test landed in this PR.
+- **Defensive preservation has a half-life.** PR #153's "preserve `minio` as wire identifier" comment was correct *at the time* and wrong three weeks later. Mark such preservations with their justification (PR #156's AC 4.3 cited the rename mandate) so the next maintainer can evaluate whether the constraint still holds.
+
+## When to Apply
+
+- A field, key, or wire identifier on a public-facing surface has placeholder vendor naming (`minio`, `aws_*`, `legacy_*`).
+- The repo is pre-prod and a `rg` audit confirms no in-repo consumer reads the old name.
+- The rename is part of a verification sweep or AC closure where the cleanup PR is already on the roadmap.
+- The new name reduces future cognitive load (a maintainer reading `object_store` shouldn't have to mentally translate to "actually SeaweedFS, or AWS S3 if hosted").
+
+Don't apply when:
+
+- Production consumers exist (operator scripts, generated SDKs, third-party monitors). Use additive-then-deprecate instead.
+- The "placeholder" is actually a load-bearing internal symbol — renaming would cascade through DB columns, queue names, log queries, or other infrastructure not in the same repo.
+- You can't audit the consumer space. Pre-prod posture is a claim about external state; if you can't verify it, treat the rename as a production-grade contract change with dual-write.
+
+## Examples
+
+### The audit that decided it
+
+```bash
+$ rg "services\.minio|body\['minio'\]|body\.minio" packages/
+packages/backend/src/services/health.ts: ...
+packages/backend/tests/unit/health.test.ts: ...
+packages/backend/tests/unit/health-service.test.ts: ...
+packages/frontend/src/hooks/use-system-health.ts: ...
+packages/frontend/src/components/features/system-health-card.tsx: ...
+packages/openapi/control-api.yaml: ...
+```
+
+All in-repo. No external grep target. Option B was safe.
+
+### The rename diff at a glance
+
+| Surface | Before | After |
+| ------- | ------ | ----- |
+| `ComponentName` enum | `'minio'` | `'object_store'` |
+| `LegacyHealthEnvelope.services.minio` | `{ status, bucket }` | (renamed to `object_store`) |
+| OpenAPI `required` array | `[database, redis, minio, queues]` | `[database, redis, object_store, queues]` |
+| `HEALTH_VERSION` | `'1.1.0'` | `'2.0.0'` |
+| OpenAPI `info.version` | `1.1.0` | `2.0.0` |
+| WS broadcast `component` field | `'minio'` | `'object_store'` |
+
+### What stayed
+
+```yaml
+# docker/seaweedfs/s3-iam.json — left untouched.
+# `minioadmin/minioadmin` is an opaque dev secret, not a wire identifier.
+# AC 6.2 explicitly mandates "matching the prior MinIO defaults so
+# `just db-seed` and integration tests do not need new env wiring."
+identities:
+  - name: hashhive-admin
+    credentials:
+      - accessKey: minioadmin
+        secretKey: minioadmin
+```
+
+Audit your "everything has the old name" intuition. Some literals — opaque credentials, third-party SDK class names, library version strings — survive a rename because they aren't wire identifiers in the AC-text sense.
+
+## Related
+
+- [`shared-zod-openapi-wire-contract-mirror-2026-05-25.md`](shared-zod-openapi-wire-contract-mirror-2026-05-25.md) — the triple-sync pattern this rename followed (Zod schema + OpenAPI spec + route handler + contract test).
+- **PR #153** — first half of the swap; preserved `minio` as wire identifier defensively.
+- **PR #171** — second half; dropped the placeholder, bumped `HEALTH_VERSION` to 2.0.0.
+- **AGENTS.md** — "Wire shapes live in `@hashhive/shared`" and "Keep the OpenAPI spec in sync with shared types."


### PR DESCRIPTION
## Summary

Two unrelated docs-only changes on this branch. Both are pure markdown; no source, schema, OpenAPI, or test changes. `just check` green.

**Commit 1 — `docs(backlog): reconcile Resource_Management_API as complete`** (BACKLOG.md, +25 / −25)

- Moves `Resource_Management_API` from the Phase 1 remaining-sequence table into Completed (8). The acceptance-criteria (AC) walk on `main` confirmed all 6 AC groups + Definition-of-Done (DoD) items are satisfied (issue #157).
- Renumbers the remaining sequence 11 → 10; refreshes dependency notes that referenced the old row numbers (`#4 → #3` for WebSocket infra; `#3 → #9` dep is now satisfied).
- Adds a "Landed" column to the Completed table so the new entry can cite the PRs that delivered it (#122 / #151 / #152 / #153 / #167) without rewriting prior retrospective rows.

**Commit 2 — `docs(conventions): add guidance for dropping placeholder wire identifiers in pre-prod`** (`docs/solutions/conventions/pre-prod-wire-rename-and-schema-version-bump.md`, +172)

- New lessons-learned writeup capturing the decision from PR #171 (`minio` → `object_store` rename + `HEALTH_VERSION` 1.1.0 → 2.0.0 bump). Explains why dropping defensive back-compat aliases cleanly is the right call pre-prod, and prescribes four moves: audit consumers, rename in one PR, bump the schema version, document the break.
- Filed under `docs/solutions/` with frontmatter (`module`, `tags`, `problem_type`) so future Resource API / health-envelope / OpenAPI work surfaces it.

## Why this PR

Issue #157 was left open because PR #167 didn't auto-close it (empty `closingIssuesReferences`). The AC walk in #157 confirms BACKLOG.md is stale, not the code. This is the smaller-and-safer half of the close-out — the issue close-comment is the other half (posted on #157). The conventions writeup landed on the same branch during the same working session and ships alongside it.

## Risk

Trivial. Both files are pure markdown. No code paths, no contract surfaces, no migrations. The only failure modes are mechanical:

- BACKLOG.md row-numbers / count-headers go out of sync (covered by the test plan below).
- The conventions doc's frontmatter `module:` or `tags:` are malformed (covered by `just check`'s YAML hook).

## Review focus (~3 min)

For the BACKLOG.md diff:
- Row numbers in dependency notes (`#1`, `#3`, `#4 → #5`, `#6 → #7`, `#9 → #10`) match the new row numbers in the renumbered table.
- Section headers `Phase 1 — Remaining spec/tickets (10)` and `Completed (8)` match the actual row counts in their tables.
- The "Landed" column is only populated for the new row; prior retrospective rows say `retrospective` rather than being rewritten.

For the conventions doc:
- Frontmatter `module`, `tags`, `problem_type` follow the convention used by neighboring files in `docs/solutions/`.
- The four prescriptions are concrete enough that a future maintainer can act on them without reading the source PRs.

## Test plan

- [x] `just check` green (format + lint + type-check + build).
- [x] Manual: BACKLOG.md row numbers in dep notes match new row numbers in the table.
- [x] Manual: BACKLOG.md total counts (Phase 1 header `(10)`, Completed header `(8)`) match table row counts.
- [x] Manual: conventions doc frontmatter parses; file path matches the `docs/solutions/conventions/` convention.