### PR TITLE
fix(agent-api): return Agent envelope on failure across all agent routes (#170)

### DIFF
--- a/packages/backend/src/routes/agent/index.ts
+++ b/packages/backend/src/routes/agent/index.ts
@@ -112,8 +112,7 @@ agentRoutes.post(
       // `app.onError` and return the dashboard envelope
       // (`{ error: { code: 'INTERNAL_SERVER_ERROR', timestamp, requestId } }`),
       // which violates the Agent API's `{ error: { code, message } }`
-      // contract documented in AGENTS.md. Mirrors the /benchmark handler
-      // below. See GitHub #170.
+      // contract documented in AGENTS.md.
       logger.error(
         { err, agentId, status: data.status, hasError: Boolean(data.error) },
         'Heartbeat processing failed'
@@ -130,8 +129,16 @@ agentRoutes.post(
 
 agentRoutes.post('/tasks/next', async (c) => {
   const { agentId } = c.get('agent')
-  const task = await assignNextTask(agentId)
-  return c.json({ task })
+  try {
+    const task = await assignNextTask(agentId)
+    return c.json({ task })
+  } catch (err: unknown) {
+    logger.error({ err, agentId }, 'Task assignment failed')
+    return c.json(
+      { error: { code: 'TASK_ASSIGN_ERROR', message: 'Failed to assign next task' } },
+      500
+    )
+  }
 })
 
 // ─── POST /tasks/:id/report — report task progress ─────────────────
@@ -184,39 +191,47 @@ agentRoutes.post(
 
     const data = c.req.valid('json')
 
-    // Log any errors reported by the agent
-    if (data.errors && data.errors.length > 0) {
-      for (const errorMessage of data.errors) {
-        await logAgentError({
-          agentId,
-          severity: 'error',
-          message: errorMessage,
+    try {
+      // Log any errors reported by the agent
+      if (data.errors && data.errors.length > 0) {
+        for (const errorMessage of data.errors) {
+          await logAgentError({
+            agentId,
+            severity: 'error',
+            message: errorMessage,
+            taskId,
+          })
+        }
+      }
+
+      // Handle failure with retry logic
+      if (data.status === 'failed') {
+        const failResult = await handleTaskFailure(
           taskId,
-        })
+          agentId,
+          data.errors?.[0] ?? 'Unknown failure'
+        )
+        if ('error' in failResult) {
+          return c.json({ error: { code: 'TASK_ERROR', message: failResult.error } }, 400)
+        }
+        return c.json({ acknowledged: true, retried: failResult.retried ?? false })
       }
-    }
 
-    // Handle failure with retry logic
-    if (data.status === 'failed') {
-      const failResult = await handleTaskFailure(
-        taskId,
-        agentId,
-        data.errors?.[0] ?? 'Unknown failure'
+      // Update task progress and insert cracked results
+      const result = await updateTaskProgress(taskId, agentId, data)
+
+      if ('error' in result) {
+        return c.json({ error: { code: 'TASK_ERROR', message: result.error } }, 400)
+      }
+
+      return c.json({ acknowledged: true })
+    } catch (err: unknown) {
+      logger.error({ err, agentId, taskId, status: data.status }, 'Task report processing failed')
+      return c.json(
+        { error: { code: 'TASK_REPORT_ERROR', message: 'Failed to process task report' } },
+        500
       )
-      if ('error' in failResult) {
-        return c.json({ error: { code: 'TASK_ERROR', message: failResult.error } }, 400)
-      }
-      return c.json({ acknowledged: true, retried: failResult.retried ?? false })
     }
-
-    // Update task progress and insert cracked results
-    const result = await updateTaskProgress(taskId, agentId, data)
-
-    if ('error' in result) {
-      return c.json({ error: { code: 'TASK_ERROR', message: result.error } }, 400)
-    }
-
-    return c.json({ acknowledged: true })
   }
 )
 
@@ -242,13 +257,21 @@ agentRoutes.get(
     }
 
     const { since, limit } = c.req.valid('query')
-    const result = await getZapsForTask(taskId, agentId, projectId, { since, limit })
+    try {
+      const result = await getZapsForTask(taskId, agentId, projectId, { since, limit })
 
-    if ('error' in result) {
-      return c.json({ error: { code: 'TASK_NOT_FOUND', message: result.error } }, 404)
+      if ('error' in result) {
+        return c.json({ error: { code: 'TASK_NOT_FOUND', message: result.error } }, 404)
+      }
+
+      return c.json(result)
+    } catch (err: unknown) {
+      logger.error({ err, agentId, taskId }, 'Task zap lookup failed')
+      return c.json(
+        { error: { code: 'TASK_ZAP_ERROR', message: 'Failed to retrieve cracked hashes' } },
+        500
+      )
     }
-
-    return c.json(result)
   }
 )
 
@@ -280,8 +303,16 @@ agentRoutes.post(
   async (c) => {
     const { agentId } = c.get('agent')
     const data = c.req.valid('json')
-    await logAgentError({ ...data, agentId })
-    return c.json({ acknowledged: true })
+    try {
+      await logAgentError({ ...data, agentId })
+      return c.json({ acknowledged: true })
+    } catch (err: unknown) {
+      logger.error({ err, agentId, severity: data.severity }, 'Agent error log ingestion failed')
+      return c.json(
+        { error: { code: 'ERROR_INGEST_ERROR', message: 'Failed to record agent error' } },
+        500
+      )
+    }
   }
 )
 
@@ -309,7 +340,7 @@ agentRoutes.post(
 // ─── GET /resources/:type/:id/download-url — presigned download ─────
 
 agentRoutes.get('/resources/:type/:id/download-url', async (c) => {
-  const { projectId } = c.get('agent')
+  const { agentId, projectId } = c.get('agent')
   const resourceType = c.req.param('type')
   const resourceId = Number(c.req.param('id'))
 
@@ -320,16 +351,29 @@ agentRoutes.get('/resources/:type/:id/download-url', async (c) => {
     )
   }
 
-  const result = await getAgentDownloadUrl(resourceType, resourceId, projectId)
+  try {
+    const result = await getAgentDownloadUrl(resourceType, resourceId, projectId)
 
-  if (!result) {
+    if (!result) {
+      return c.json(
+        { error: { code: 'RESOURCE_NOT_FOUND', message: 'Resource not found or has no file' } },
+        404
+      )
+    }
+
+    return c.json(result)
+  } catch (err: unknown) {
+    logger.error(
+      { err, agentId, resourceType, resourceId },
+      'Resource download URL generation failed'
+    )
     return c.json(
-      { error: { code: 'RESOURCE_NOT_FOUND', message: 'Resource not found or has no file' } },
-      404
+      {
+        error: { code: 'RESOURCE_URL_ERROR', message: 'Failed to generate resource download URL' },
+      },
+      500
     )
   }
-
-  return c.json(result)
 })
 
 // ─── POST /cracker/check-update — agent cracker auto-update ─────────
@@ -347,6 +391,7 @@ agentRoutes.post(
   '/cracker/check-update',
   zValidator('json', crackerCheckUpdateRequestSchema, agentValidationHook),
   async (c) => {
+    const { agentId } = c.get('agent')
     const data = c.req.valid('json')
     const engine = normalizeEngineName(data.engine)
     // Trim version + platform so an agent sending `'6.2.7 '` (trailing
@@ -369,31 +414,39 @@ agentRoutes.post(
       return c.json({ updateAvailable: false, engine })
     }
 
-    const latest = await getLatestCracker({ engine, platform })
+    try {
+      const latest = await getLatestCracker({ engine, platform })
 
-    if (!latest || compareCrackerVersions(latest.version, version) <= 0) {
-      return c.json({ updateAvailable: false, engine })
-    }
+      if (!latest || compareCrackerVersions(latest.version, version) <= 0) {
+        return c.json({ updateAvailable: false, engine })
+      }
 
-    const downloadInfo = await getCrackerDownloadUrl(latest.id)
-    if (!downloadInfo) {
-      // Latest record exists but lacks an uploaded file — treat as no update
-      // available rather than failing the agent's poll. Logged at warn so
-      // an admin can find rows that were created but never uploaded.
-      logger.warn(
-        { crackerBinaryId: latest.id, engine, platform: data.platform },
-        'Latest cracker binary has no completed file; agent will not see this version'
+      const downloadInfo = await getCrackerDownloadUrl(latest.id)
+      if (!downloadInfo) {
+        // Latest record exists but lacks an uploaded file — treat as no update
+        // available rather than failing the agent's poll. Logged at warn so
+        // an admin can find rows that were created but never uploaded.
+        logger.warn(
+          { crackerBinaryId: latest.id, engine, platform: data.platform },
+          'Latest cracker binary has no completed file; agent will not see this version'
+        )
+        return c.json({ updateAvailable: false, engine })
+      }
+
+      return c.json({
+        updateAvailable: true,
+        engine,
+        latestVersion: latest.version,
+        downloadUrl: downloadInfo.url,
+        expiresIn: downloadInfo.expiresIn,
+      })
+    } catch (err: unknown) {
+      logger.error({ err, agentId, engine, platform }, 'Cracker update check failed')
+      return c.json(
+        { error: { code: 'CRACKER_UPDATE_ERROR', message: 'Failed to check for cracker update' } },
+        500
       )
-      return c.json({ updateAvailable: false, engine })
     }
-
-    return c.json({
-      updateAvailable: true,
-      engine,
-      latestVersion: latest.version,
-      downloadUrl: downloadInfo.url,
-      expiresIn: downloadInfo.expiresIn,
-    })
   }
 )
 

--- a/packages/backend/src/routes/agent/index.ts
+++ b/packages/backend/src/routes/agent/index.ts
@@ -99,12 +99,30 @@ agentRoutes.post(
   async (c) => {
     const { agentId } = c.get('agent')
     const data = c.req.valid('json')
-    const result = await processHeartbeat(agentId, data)
-    const body: AgentHeartbeatResponse = {
-      acknowledged: true,
-      ...(result.hasHighPriorityTasks ? { hasHighPriorityTasks: true } : {}),
+    try {
+      const result = await processHeartbeat(agentId, data)
+      const body: AgentHeartbeatResponse = {
+        acknowledged: true,
+        ...(result.hasHighPriorityTasks ? { hasHighPriorityTasks: true } : {}),
+      }
+      return c.json(body)
+    } catch (err: unknown) {
+      // Heartbeat is the agent's hot-path liveness primitive. Without
+      // this try/catch the throw would fall through to the global
+      // `app.onError` and return the dashboard envelope
+      // (`{ error: { code: 'INTERNAL_SERVER_ERROR', timestamp, requestId } }`),
+      // which violates the Agent API's `{ error: { code, message } }`
+      // contract documented in AGENTS.md. Mirrors the /benchmark handler
+      // below. See GitHub #170.
+      logger.error(
+        { err, agentId, status: data.status, hasError: Boolean(data.error) },
+        'Heartbeat processing failed'
+      )
+      return c.json(
+        { error: { code: 'HEARTBEAT_ERROR', message: 'Failed to process heartbeat' } },
+        500
+      )
     }
-    return c.json(body)
   }
 )
 

--- a/packages/backend/src/services/agents.ts
+++ b/packages/backend/src/services/agents.ts
@@ -655,21 +655,36 @@ export async function processHeartbeat(agentId: number, data: AgentHeartbeat) {
   const { updated, transition } = txResult
 
   // Post-commit emits + audit log. If the transaction rolled back,
-  // none of these fire and SSE listeners stay consistent.
+  // none of these fire and SSE listeners stay consistent. We swallow
+  // failures here (log without rethrow) so a flaky SSE bus or audit
+  // sink cannot cause the route to return HEARTBEAT_ERROR 500 *after*
+  // the agent row was already committed — that would mislead operators
+  // into thinking the heartbeat failed when DB state was actually
+  // persisted. The agent will re-heartbeat and SSE listeners will
+  // catch up on the next cycle. See GitHub #170 and the post-commit
+  // hardening delta in
+  // docs/plans/2026-05-26-002-fix-agent-heartbeat-envelope-plan.md.
   if (updated) {
-    if (data.error) {
-      emitAgentError(updated.projectId, updated.id, data.error.severity)
-    }
-    emitAgentStatus(updated.projectId, updated.id, transition.effectiveStatus)
+    try {
+      if (data.error) {
+        emitAgentError(updated.projectId, updated.id, data.error.severity)
+      }
+      emitAgentStatus(updated.projectId, updated.id, transition.effectiveStatus)
 
-    if (transition.kind === 'transition') {
-      logStatusTransition({
-        agentId: updated.id,
-        projectId: updated.projectId,
-        fromStatus: transition.fromStatus,
-        toStatus: transition.effectiveStatus,
-        reason: transition.reason,
-      })
+      if (transition.kind === 'transition') {
+        logStatusTransition({
+          agentId: updated.id,
+          projectId: updated.projectId,
+          fromStatus: transition.fromStatus,
+          toStatus: transition.effectiveStatus,
+          reason: transition.reason,
+        })
+      }
+    } catch (postCommitErr: unknown) {
+      logger.error(
+        { err: postCommitErr, agentId: updated.id, projectId: updated.projectId },
+        'Post-commit heartbeat emit/audit failed; agent state was already committed'
+      )
     }
   } else {
     // Auth middleware verified the agent's bearer token, so the row was

--- a/packages/backend/src/services/agents.ts
+++ b/packages/backend/src/services/agents.ts
@@ -655,15 +655,19 @@ export async function processHeartbeat(agentId: number, data: AgentHeartbeat) {
   const { updated, transition } = txResult
 
   // Post-commit emits + audit log. If the transaction rolled back,
-  // none of these fire and SSE listeners stay consistent. We swallow
-  // failures here (log without rethrow) so a flaky SSE bus or audit
-  // sink cannot cause the route to return HEARTBEAT_ERROR 500 *after*
+  // none of these fire and SSE listeners stay consistent. The try/catch
+  // around the block swallows failures (log without rethrow) so a flaky
+  // SSE bus or audit sink cannot cause the route to return 500 *after*
   // the agent row was already committed — that would mislead operators
   // into thinking the heartbeat failed when DB state was actually
-  // persisted. The agent will re-heartbeat and SSE listeners will
-  // catch up on the next cycle. See GitHub #170 and the post-commit
-  // hardening delta in
-  // docs/plans/2026-05-26-002-fix-agent-heartbeat-envelope-plan.md.
+  // persisted. The agent re-heartbeats and SSE listeners catch up on
+  // the next cycle.
+  //
+  // The catch is block-level on purpose: if any single emit throws, the
+  // remaining emits and the audit log are skipped. The three emits share
+  // an SSE bus so a failure in one is a strong signal the next would
+  // also fail, and the audit miss is intentional rather than logged
+  // twice — the next heartbeat heals SSE state regardless.
   if (updated) {
     try {
       if (data.error) {

--- a/packages/backend/tests/integration/agent-heartbeat.test.ts
+++ b/packages/backend/tests/integration/agent-heartbeat.test.ts
@@ -767,5 +767,49 @@ if (!IS_ISOLATED) {
       })
       expect(warnCallsForAgent).toHaveLength(1)
     })
+
+    it('post-commit emit throws are swallowed so a successful tx returns 200 (issue #170)', async () => {
+      // Arrange — force emitAgentStatus to throw on the post-commit
+      // broadcast. The DB transaction has already committed by the time
+      // emitAgentStatus is called (see services/agents.ts:659-683), so the
+      // failure must be logged and absorbed rather than propagated to
+      // the route's new HEARTBEAT_ERROR catch — otherwise the route
+      // would return 500 to an agent whose state was actually persisted,
+      // misleading operators and breaking the wire signal's contract
+      // that HEARTBEAT_ERROR means the transaction itself failed.
+      emitAgentStatusMock.mockImplementationOnce(() => {
+        throw new Error('SSE bus dropped the connection')
+      })
+
+      const token = agentToken(TEST_AGENT_TOKEN)
+
+      // Act — vanilla online heartbeat, no error payload, default state.
+      const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ status: 'online' }),
+      })
+
+      // Assert — the route returns 200 (DB state was committed), and
+      // the post-commit failure was logged at error level for ops.
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as Record<string, unknown>
+      expect(body['acknowledged']).toBe(true)
+      // DB UPDATE landed before the throw, so the captured update is present.
+      expect(state.capturedAgentUpdates.some((u) => u.status === 'online')).toBe(true)
+      // The post-commit hardening logs at error level with the agentId.
+      const postCommitErrorLogs = loggerMock.error.mock.calls.filter((call) => {
+        const arg = call[0] as Record<string, unknown> | undefined
+        return (
+          arg?.['agentId'] === 1 &&
+          typeof call[1] === 'string' &&
+          (call[1] as string).startsWith('Post-commit heartbeat emit/audit failed')
+        )
+      })
+      expect(postCommitErrorLogs).toHaveLength(1)
+    })
   })
 }

--- a/packages/backend/tests/integration/agent-heartbeat.test.ts
+++ b/packages/backend/tests/integration/agent-heartbeat.test.ts
@@ -768,13 +768,13 @@ if (!IS_ISOLATED) {
       expect(warnCallsForAgent).toHaveLength(1)
     })
 
-    it('post-commit emit throws are swallowed so a successful tx returns 200 (issue #170)', async () => {
+    it('post-commit emitAgentStatus throw is swallowed so a successful tx returns 200', async () => {
       // Arrange — force emitAgentStatus to throw on the post-commit
       // broadcast. The DB transaction has already committed by the time
-      // emitAgentStatus is called (see services/agents.ts:659-683), so the
+      // the post-commit emit block in processHeartbeat runs, so the
       // failure must be logged and absorbed rather than propagated to
-      // the route's new HEARTBEAT_ERROR catch — otherwise the route
-      // would return 500 to an agent whose state was actually persisted,
+      // the route's HEARTBEAT_ERROR catch — otherwise the route would
+      // return 500 to an agent whose state was actually persisted,
       // misleading operators and breaking the wire signal's contract
       // that HEARTBEAT_ERROR means the transaction itself failed.
       emitAgentStatusMock.mockImplementationOnce(() => {
@@ -800,14 +800,125 @@ if (!IS_ISOLATED) {
       expect(body['acknowledged']).toBe(true)
       // DB UPDATE landed before the throw, so the captured update is present.
       expect(state.capturedAgentUpdates.some((u) => u.status === 'online')).toBe(true)
-      // The post-commit hardening logs at error level with the agentId.
+      // The post-commit hardening logs at error level with the
+      // structured `err` + `agentId` + `projectId` context. Filter
+      // structurally rather than on the message-prefix so a future
+      // log-message refactor does not silently break this assertion.
       const postCommitErrorLogs = loggerMock.error.mock.calls.filter((call) => {
         const arg = call[0] as Record<string, unknown> | undefined
-        return (
-          arg?.['agentId'] === 1 &&
-          typeof call[1] === 'string' &&
-          (call[1] as string).startsWith('Post-commit heartbeat emit/audit failed')
-        )
+        return arg?.['agentId'] === 1 && arg?.['projectId'] === 7 && arg?.['err'] !== undefined
+      })
+      expect(postCommitErrorLogs).toHaveLength(1)
+    })
+
+    it('post-commit emitAgentError throw is swallowed when heartbeat carries an error payload', async () => {
+      // Arrange — pin the emitAgentError branch of the same try/catch.
+      // The previous test covers emitAgentStatus; this one covers the
+      // sibling branch reached only when `data.error` is present.
+      emitAgentErrorMock.mockImplementationOnce(() => {
+        throw new Error('SSE bus dropped the connection')
+      })
+
+      const token = agentToken(TEST_AGENT_TOKEN)
+
+      // Act — heartbeat with a warning error payload triggers
+      // emitAgentError on the post-commit path.
+      const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          status: 'online',
+          error: { severity: 'warning', message: 'temperature spike' },
+        }),
+      })
+
+      // Assert — 200 + DB state committed + post-commit error logged.
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as Record<string, unknown>
+      expect(body['acknowledged']).toBe(true)
+      expect(state.capturedErrors).toHaveLength(1)
+      expect(state.capturedAgentUpdates.some((u) => u.status === 'online')).toBe(true)
+      const postCommitErrorLogs = loggerMock.error.mock.calls.filter((call) => {
+        const arg = call[0] as Record<string, unknown> | undefined
+        return arg?.['agentId'] === 1 && arg?.['projectId'] === 7 && arg?.['err'] !== undefined
+      })
+      expect(postCommitErrorLogs).toHaveLength(1)
+    })
+
+    it('post-commit logStatusTransition throw is swallowed across a real transition', async () => {
+      // Arrange — the logger.info call inside logStatusTransition is the
+      // third call site protected by the post-commit try/catch. Force
+      // logger.info to throw the first time it is invoked with the
+      // 'Agent status transition' message. The agent starts in 'busy'
+      // and the heartbeat moves it to 'online' — a real (not no-op)
+      // transition that hits logStatusTransition.
+      state.agent = { id: 1, projectId: 7, status: 'busy', capabilities: {} }
+      // Persistent (not Once) so the request-middleware's earlier info
+      // logs flow through; only the audit-log call throws.
+      loggerMock.info.mockImplementation((_arg: unknown, msg?: string) => {
+        if (msg === 'Agent status transition') {
+          throw new Error('log sink unavailable')
+        }
+      })
+
+      const token = agentToken(TEST_AGENT_TOKEN)
+
+      const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ status: 'online' }),
+      })
+
+      // Assert — the route returns 200 even though the audit log throw
+      // was triggered inside the post-commit try/catch.
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as Record<string, unknown>
+      expect(body['acknowledged']).toBe(true)
+      expect(state.capturedAgentUpdates.some((u) => u.status === 'online')).toBe(true)
+      const postCommitErrorLogs = loggerMock.error.mock.calls.filter((call) => {
+        const arg = call[0] as Record<string, unknown> | undefined
+        return arg?.['agentId'] === 1 && arg?.['projectId'] === 7 && arg?.['err'] !== undefined
+      })
+      expect(postCommitErrorLogs).toHaveLength(1)
+    })
+
+    it('recovery heartbeat (prior status=error) × post-commit throw still returns 200', async () => {
+      // Arrange — agent in status='error' posts a clean heartbeat to
+      // come back online. The transition fires logStatusTransition AND
+      // emitAgentStatus on the post-commit path; if either throws, the
+      // hardening must still let the DB commit stand on the wire so
+      // the agent can actually recover.
+      state.agent = { id: 1, projectId: 7, status: 'error', capabilities: {} }
+      emitAgentStatusMock.mockImplementationOnce(() => {
+        throw new Error('SSE bus dropped the connection')
+      })
+
+      const token = agentToken(TEST_AGENT_TOKEN)
+
+      const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ status: 'online' }),
+      })
+
+      // Assert — recovery succeeds at the DB layer despite the SSE
+      // failure. Future heartbeats heal SSE on the next tick.
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as Record<string, unknown>
+      expect(body['acknowledged']).toBe(true)
+      expect(state.capturedAgentUpdates.some((u) => u.status === 'online')).toBe(true)
+      const postCommitErrorLogs = loggerMock.error.mock.calls.filter((call) => {
+        const arg = call[0] as Record<string, unknown> | undefined
+        return arg?.['agentId'] === 1 && arg?.['projectId'] === 7 && arg?.['err'] !== undefined
       })
       expect(postCommitErrorLogs).toHaveLength(1)
     })

--- a/packages/backend/tests/unit/agent-api-contract.test.ts
+++ b/packages/backend/tests/unit/agent-api-contract.test.ts
@@ -150,6 +150,18 @@ mock.module('../../src/services/tasks.js', () => ({
   projectAgentTaskRows: realProjectAgentTaskRows,
 }))
 
+// Pull the real pure helpers in BEFORE mock.module runs for crackers.js
+// so the mock factory can re-export them. Without this, sibling tests
+// (crackers-routes.test.ts and any compareCrackerVersions unit suite)
+// would receive our stubs instead of the genuine impls — process-global
+// mock.module merge per GOTCHAS.md "Re-export the real implementation
+// when you must mock siblings."
+import {
+  compareCrackerVersions as realCompareCrackerVersions,
+  isKnownEngine as realIsKnownEngine,
+  normalizeEngineName as realNormalizeEngineName,
+} from '../../src/services/crackers.js'
+
 // Mock resources.js and crackers.js so the /resources and /cracker routes
 // have reachable rejection paths in the contract test. The real modules
 // touch the DB and object store; here we only validate the wire envelope
@@ -161,15 +173,14 @@ mock.module('../../src/services/resources.js', () => ({
 }))
 
 mock.module('../../src/services/crackers.js', () => ({
+  // DB-touching surfaces get stubbed; pure helpers are re-exported real.
   getLatestCracker: mock(() => Promise.resolve(null)),
   getCrackerDownloadUrl: mock(() =>
     Promise.resolve({ url: 'https://example.test/cracker', expiresIn: 600 })
   ),
-  compareCrackerVersions: mock(() => 0),
-  isKnownEngine: mock(() => true),
-  normalizeEngineName: mock((value: unknown) =>
-    typeof value === 'string' && value.length > 0 ? value.toLowerCase() : 'hashcat'
-  ),
+  compareCrackerVersions: realCompareCrackerVersions,
+  isKnownEngine: realIsKnownEngine,
+  normalizeEngineName: realNormalizeEngineName,
 }))
 
 mock.module('../../src/db/index.js', () => ({

--- a/packages/backend/tests/unit/agent-api-contract.test.ts
+++ b/packages/backend/tests/unit/agent-api-contract.test.ts
@@ -122,6 +122,17 @@ const mockCamelCaseTask = {
   updatedAt: mockSnakeCaseTaskRow.updated_at,
 }
 
+// Pull the real pure helpers in BEFORE mock.module runs so the mock
+// factory can re-export them. Without re-export, `agents-service.test.ts`
+// would receive our stubs instead of the genuine implementations for
+// any file bun loads after this one — the same Linux/macOS-load-order
+// CI flake documented in GOTCHAS.md "Re-export the real implementation
+// when you must mock siblings."
+import {
+  AGENT_TASK_ACTIVE_STATUSES as realAgentTaskActiveStatuses,
+  projectAgentTaskRows as realProjectAgentTaskRows,
+} from '../../src/services/tasks.js'
+
 // Mock tasks.js so the real module is never cached — the snake_case→camelCase
 // mapping is validated in tasks.test.ts; here we only test the route contract.
 // This also removes the need to mock campaigns.js (which tasks.js imported).
@@ -133,6 +144,32 @@ mock.module('../../src/services/tasks.js', () => ({
   reassignStaleTasks: mock(() => Promise.resolve([])),
   getTaskById: mock(() => Promise.resolve(null)),
   listTasks: mock(() => Promise.resolve([])),
+  getZapsForTask: mock(() => Promise.resolve({ taskId: 1, hashes: [] })),
+  // Re-export real impls so sibling tests see the genuine functions.
+  AGENT_TASK_ACTIVE_STATUSES: realAgentTaskActiveStatuses,
+  projectAgentTaskRows: realProjectAgentTaskRows,
+}))
+
+// Mock resources.js and crackers.js so the /resources and /cracker routes
+// have reachable rejection paths in the contract test. The real modules
+// touch the DB and object store; here we only validate the wire envelope
+// and exercise the route-level catch with mockImplementationOnce.
+mock.module('../../src/services/resources.js', () => ({
+  getAgentDownloadUrl: mock(() =>
+    Promise.resolve({ url: 'https://example.test/object', expiresIn: 600 })
+  ),
+}))
+
+mock.module('../../src/services/crackers.js', () => ({
+  getLatestCracker: mock(() => Promise.resolve(null)),
+  getCrackerDownloadUrl: mock(() =>
+    Promise.resolve({ url: 'https://example.test/cracker', expiresIn: 600 })
+  ),
+  compareCrackerVersions: mock(() => 0),
+  isKnownEngine: mock(() => true),
+  normalizeEngineName: mock((value: unknown) =>
+    typeof value === 'string' && value.length > 0 ? value.toLowerCase() : 'hashcat'
+  ),
 }))
 
 mock.module('../../src/db/index.js', () => ({
@@ -141,6 +178,22 @@ mock.module('../../src/db/index.js', () => ({
     execute: mockExecute,
   },
   client: {},
+}))
+
+// Mock the logger so route-layer log-shape assertions (the hasError
+// branch on /heartbeat's failure-path log, and similar structured logs
+// on other agent routes) can verify their argument shape without
+// scraping stdout. Mirrors the integration test's pattern in
+// tests/integration/agent-heartbeat.test.ts.
+const loggerMock = {
+  info: mock(),
+  warn: mock(),
+  error: mock(),
+  debug: mock(),
+}
+
+mock.module('../../src/config/logger.js', () => ({
+  logger: loggerMock,
 }))
 
 import { app } from '../../src/index.js'
@@ -280,12 +333,10 @@ describe('Agent API: POST /heartbeat', () => {
   it('returns Agent-shaped envelope with HEARTBEAT_ERROR when processHeartbeat throws', async () => {
     // Arrange — force the service to reject so the route's failure path
     // is exercised. The negative-shape assertions on `timestamp` and
-    // `requestId` are what discriminate the Agent envelope from the
-    // dashboard envelope emitted by the global `app.onError`; without
-    // them a regression that falls through to the global handler could
-    // still satisfy `error.code === 'HEARTBEAT_ERROR'` by accident in a
-    // future world where that code is assigned globally. See
-    // GitHub #170.
+    // `requestId` discriminate the Agent envelope from the dashboard
+    // envelope emitted by the global `app.onError`; without them a
+    // regression that falls through to the global handler could still
+    // satisfy `error.code === 'HEARTBEAT_ERROR'` by accident.
     const { processHeartbeat } = await import('../../src/services/agents.js')
     ;(
       processHeartbeat as unknown as { mockImplementationOnce: (fn: () => unknown) => void }
@@ -307,13 +358,64 @@ describe('Agent API: POST /heartbeat', () => {
     expect(res.status).toBe(500)
     const body = (await res.json()) as { error: Record<string, unknown> }
     expect(body.error.code).toBe('HEARTBEAT_ERROR')
-    expect(typeof body.error.message).toBe('string')
-    expect((body.error.message as string).length).toBeGreaterThan(0)
+    // Pin to the literal message. A regression that switches the wire
+    // message to `err.message` (e.g., 'db down') would leak internal
+    // diagnostic detail to agents; asserting the static string blocks
+    // that class of change.
+    expect(body.error.message).toBe('Failed to process heartbeat')
     // Negative shape: the Agent envelope omits `timestamp` and
     // `requestId`. Their presence would mean we fell through to the
     // dashboard envelope at `app.onError`.
     expect(body.error['timestamp']).toBeUndefined()
     expect(body.error['requestId']).toBeUndefined()
+    // Log shape: the route logs the four documented keys (err, agentId,
+    // status, hasError). No error payload was posted so hasError stays
+    // false; the hasError=true branch is pinned by the next test.
+    const heartbeatErrorLogs = loggerMock.error.mock.calls.filter((call) => {
+      const arg = call[0] as Record<string, unknown> | undefined
+      return arg?.['err'] !== undefined && arg?.['agentId'] === 1
+    })
+    expect(heartbeatErrorLogs).toHaveLength(1)
+    const logCtx = heartbeatErrorLogs[0]?.[0] as Record<string, unknown>
+    expect(logCtx['status']).toBe('online')
+    expect(logCtx['hasError']).toBe(false)
+  })
+
+  it('logs hasError=true when heartbeat carries an error payload and processHeartbeat throws', async () => {
+    // Arrange — pin the second branch of the route's failure-path log
+    // (`hasError: Boolean(data.error)`). Without this test a regression
+    // that always logs `hasError: false` would land green.
+    loggerMock.error.mockClear()
+    const { processHeartbeat } = await import('../../src/services/agents.js')
+    ;(
+      processHeartbeat as unknown as { mockImplementationOnce: (fn: () => unknown) => void }
+    ).mockImplementationOnce(() => Promise.reject(new Error('db down')))
+
+    const token = agentToken(TEST_AGENT_TOKEN)
+
+    // Act
+    const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        status: 'error',
+        error: { severity: 'fatal', message: 'gpu hung' },
+      }),
+    })
+
+    // Assert
+    expect(res.status).toBe(500)
+    const heartbeatErrorLogs = loggerMock.error.mock.calls.filter((call) => {
+      const arg = call[0] as Record<string, unknown> | undefined
+      return arg?.['err'] !== undefined && arg?.['agentId'] === 1
+    })
+    expect(heartbeatErrorLogs).toHaveLength(1)
+    const logCtx = heartbeatErrorLogs[0]?.[0] as Record<string, unknown>
+    expect(logCtx['status']).toBe('error')
+    expect(logCtx['hasError']).toBe(true)
   })
 
   it('accepts a heartbeat with currentTask and warning error', async () => {
@@ -714,5 +816,140 @@ describe('Agent API: POST /errors', () => {
     })
 
     expect(res.status).toBe(400)
+  })
+})
+
+// ─── Failure-path envelope contract across all wrapped agent routes ──
+//
+// Every agent route now wraps its primary service call in try/catch and
+// returns the Agent envelope `{ error: { code, message } }` at HTTP 500
+// instead of falling through to the global `app.onError` (which would
+// emit the dashboard envelope). These tests pin each route's coarse
+// code value AND assert the negative envelope shape — the same
+// regression guard already in place for HEARTBEAT_ERROR.
+
+/**
+ * Verify that the response is the Agent envelope at HTTP 500 with the
+ * expected coarse code. `timestamp`/`requestId` MUST be absent;
+ * presence means we fell through to the dashboard envelope at
+ * `app.onError`.
+ */
+async function expectAgentFailureEnvelope(res: Response, expectedCode: string): Promise<void> {
+  expect(res.status).toBe(500)
+  const body = (await res.json()) as { error: Record<string, unknown> }
+  expect(body.error.code).toBe(expectedCode)
+  expect(typeof body.error.message).toBe('string')
+  expect((body.error.message as string).length).toBeGreaterThan(0)
+  expect(body.error['timestamp']).toBeUndefined()
+  expect(body.error['requestId']).toBeUndefined()
+}
+
+describe('Agent API: failure-path envelope shape', () => {
+  it('POST /tasks/next returns TASK_ASSIGN_ERROR when assignNextTask throws', async () => {
+    const tasksMod = await import('../../src/services/tasks.js')
+    ;(
+      tasksMod.assignNextTask as unknown as { mockImplementationOnce: (fn: () => unknown) => void }
+    ).mockImplementationOnce(() => Promise.reject(new Error('db down')))
+
+    const token = agentToken(TEST_AGENT_TOKEN)
+    const res = await app.request(`${AGENT_BASE}/tasks/next`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${token}` },
+    })
+
+    await expectAgentFailureEnvelope(res, 'TASK_ASSIGN_ERROR')
+  })
+
+  it('POST /tasks/:id/report returns TASK_REPORT_ERROR when updateTaskProgress throws', async () => {
+    const tasksMod = await import('../../src/services/tasks.js')
+    ;(
+      tasksMod.updateTaskProgress as unknown as {
+        mockImplementationOnce: (fn: () => unknown) => void
+      }
+    ).mockImplementationOnce(() => Promise.reject(new Error('db down')))
+
+    const token = agentToken(TEST_AGENT_TOKEN)
+    const res = await app.request(`${AGENT_BASE}/tasks/42/report`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ status: 'running' }),
+    })
+
+    await expectAgentFailureEnvelope(res, 'TASK_REPORT_ERROR')
+  })
+
+  it('GET /tasks/:id/zaps returns TASK_ZAP_ERROR when getZapsForTask throws', async () => {
+    const tasksMod = await import('../../src/services/tasks.js')
+    ;(
+      tasksMod.getZapsForTask as unknown as { mockImplementationOnce: (fn: () => unknown) => void }
+    ).mockImplementationOnce(() => Promise.reject(new Error('db down')))
+
+    const token = agentToken(TEST_AGENT_TOKEN)
+    const res = await app.request(`${AGENT_BASE}/tasks/42/zaps`, {
+      method: 'GET',
+      headers: { authorization: `Bearer ${token}` },
+    })
+
+    await expectAgentFailureEnvelope(res, 'TASK_ZAP_ERROR')
+  })
+
+  it('POST /errors returns ERROR_INGEST_ERROR when logAgentError throws', async () => {
+    const agentsMod = await import('../../src/services/agents.js')
+    ;(
+      agentsMod.logAgentError as unknown as { mockImplementationOnce: (fn: () => unknown) => void }
+    ).mockImplementationOnce(() => Promise.reject(new Error('db down')))
+
+    const token = agentToken(TEST_AGENT_TOKEN)
+    const res = await app.request(`${AGENT_BASE}/errors`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ severity: 'warning', message: 'test' }),
+    })
+
+    await expectAgentFailureEnvelope(res, 'ERROR_INGEST_ERROR')
+  })
+
+  it('GET /resources/:type/:id/download-url returns RESOURCE_URL_ERROR when getAgentDownloadUrl throws', async () => {
+    const resourcesMod = await import('../../src/services/resources.js')
+    ;(
+      resourcesMod.getAgentDownloadUrl as unknown as {
+        mockImplementationOnce: (fn: () => unknown) => void
+      }
+    ).mockImplementationOnce(() => Promise.reject(new Error('object store down')))
+
+    const token = agentToken(TEST_AGENT_TOKEN)
+    const res = await app.request(`${AGENT_BASE}/resources/wordlist/1/download-url`, {
+      method: 'GET',
+      headers: { authorization: `Bearer ${token}` },
+    })
+
+    await expectAgentFailureEnvelope(res, 'RESOURCE_URL_ERROR')
+  })
+
+  it('POST /cracker/check-update returns CRACKER_UPDATE_ERROR when getLatestCracker throws', async () => {
+    const crackersMod = await import('../../src/services/crackers.js')
+    ;(
+      crackersMod.getLatestCracker as unknown as {
+        mockImplementationOnce: (fn: () => unknown) => void
+      }
+    ).mockImplementationOnce(() => Promise.reject(new Error('db down')))
+
+    const token = agentToken(TEST_AGENT_TOKEN)
+    const res = await app.request(`${AGENT_BASE}/cracker/check-update`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ engine: 'hashcat', platform: 'linux-x86_64', version: '6.2.7' }),
+    })
+
+    await expectAgentFailureEnvelope(res, 'CRACKER_UPDATE_ERROR')
   })
 })

--- a/packages/backend/tests/unit/agent-api-contract.test.ts
+++ b/packages/backend/tests/unit/agent-api-contract.test.ts
@@ -277,6 +277,45 @@ describe('Agent API: POST /heartbeat', () => {
     expect(parsed.hasHighPriorityTasks).toBe(true)
   })
 
+  it('returns Agent-shaped envelope with HEARTBEAT_ERROR when processHeartbeat throws', async () => {
+    // Arrange — force the service to reject so the route's failure path
+    // is exercised. The negative-shape assertions on `timestamp` and
+    // `requestId` are what discriminate the Agent envelope from the
+    // dashboard envelope emitted by the global `app.onError`; without
+    // them a regression that falls through to the global handler could
+    // still satisfy `error.code === 'HEARTBEAT_ERROR'` by accident in a
+    // future world where that code is assigned globally. See
+    // GitHub #170.
+    const { processHeartbeat } = await import('../../src/services/agents.js')
+    ;(
+      processHeartbeat as unknown as { mockImplementationOnce: (fn: () => unknown) => void }
+    ).mockImplementationOnce(() => Promise.reject(new Error('db down')))
+
+    const token = agentToken(TEST_AGENT_TOKEN)
+
+    // Act
+    const res = await app.request(`${AGENT_BASE}/heartbeat`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ status: 'online' }),
+    })
+
+    // Assert
+    expect(res.status).toBe(500)
+    const body = (await res.json()) as { error: Record<string, unknown> }
+    expect(body.error.code).toBe('HEARTBEAT_ERROR')
+    expect(typeof body.error.message).toBe('string')
+    expect((body.error.message as string).length).toBeGreaterThan(0)
+    // Negative shape: the Agent envelope omits `timestamp` and
+    // `requestId`. Their presence would mean we fell through to the
+    // dashboard envelope at `app.onError`.
+    expect(body.error['timestamp']).toBeUndefined()
+    expect(body.error['requestId']).toBeUndefined()
+  })
+
   it('accepts a heartbeat with currentTask and warning error', async () => {
     // Arrange
     const token = agentToken(TEST_AGENT_TOKEN)

--- a/packages/frontend/tests/setup.ts
+++ b/packages/frontend/tests/setup.ts
@@ -27,6 +27,14 @@ Object.assign(globalThis, {
   HTMLDivElement: window.HTMLDivElement,
   HTMLSpanElement: window.HTMLSpanElement,
   MutationObserver: window.MutationObserver,
+  // happy-dom v20 ships ResizeObserver on window but the previous list
+  // didn't surface it on globalThis. ReactFlow (loaded indirectly by
+  // CampaignDetailPage and other graph-rendering pages) reads it from the
+  // global scope at module-init time and throws `ReferenceError:
+  // ResizeObserver is not defined` on Linux happy-dom — the macOS build
+  // happens to have a fallback that masks this. Injecting the global
+  // keeps the polyfill portable across runners.
+  ResizeObserver: window.ResizeObserver,
   Node: window.Node,
   Text: window.Text,
   DocumentFragment: window.DocumentFragment,

--- a/packages/frontend/tests/setup.ts
+++ b/packages/frontend/tests/setup.ts
@@ -27,14 +27,19 @@ Object.assign(globalThis, {
   HTMLDivElement: window.HTMLDivElement,
   HTMLSpanElement: window.HTMLSpanElement,
   MutationObserver: window.MutationObserver,
-  // happy-dom v20 ships ResizeObserver on window but the previous list
-  // didn't surface it on globalThis. ReactFlow (loaded indirectly by
-  // CampaignDetailPage and other graph-rendering pages) reads it from the
-  // global scope at module-init time and throws `ReferenceError:
-  // ResizeObserver is not defined` on Linux happy-dom — the macOS build
-  // happens to have a fallback that masks this. Injecting the global
-  // keeps the polyfill portable across runners.
+  // happy-dom v20 ships these on window but the previous list didn't
+  // surface them on globalThis. ReactFlow (loaded indirectly by
+  // CampaignDetailPage and other graph-rendering pages) reads
+  // ResizeObserver + SVG element classes from the global scope at
+  // module-init time and throws `ReferenceError` on Linux happy-dom —
+  // the macOS build happens to have fallbacks that mask this. Injecting
+  // them keeps the polyfill portable across runners.
   ResizeObserver: window.ResizeObserver,
+  IntersectionObserver: window.IntersectionObserver,
+  SVGElement: window.SVGElement,
+  SVGSVGElement: window.SVGSVGElement,
+  Image: window.Image,
+  HTMLImageElement: window.HTMLImageElement,
   Node: window.Node,
   Text: window.Text,
   DocumentFragment: window.DocumentFragment,

--- a/packages/openapi/agent-api.yaml
+++ b/packages/openapi/agent-api.yaml
@@ -67,8 +67,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HeartbeatResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
         '401':
           $ref: '#/components/responses/AuthError'
+        '500':
+          $ref: '#/components/responses/ServerError'
 
   /tasks/next:
     post:
@@ -91,6 +95,8 @@ paths:
                       - type: 'null'
         '401':
           $ref: '#/components/responses/AuthError'
+        '500':
+          $ref: '#/components/responses/ServerError'
 
   /tasks/{taskId}/report:
     post:
@@ -114,8 +120,12 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/Acknowledged'
+        '400':
+          $ref: '#/components/responses/ValidationError'
         '401':
           $ref: '#/components/responses/AuthError'
+        '500':
+          $ref: '#/components/responses/ServerError'
 
   /tasks/{taskId}/zaps:
     get:
@@ -157,6 +167,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ZapResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
         '401':
           $ref: '#/components/responses/AuthError'
         '404':
@@ -165,6 +177,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ServerError'
 
   /benchmark:
     post:
@@ -182,8 +196,12 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/Acknowledged'
+        '400':
+          $ref: '#/components/responses/ValidationError'
         '401':
           $ref: '#/components/responses/AuthError'
+        '500':
+          $ref: '#/components/responses/ServerError'
 
   /errors:
     post:
@@ -201,8 +219,12 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/Acknowledged'
+        '400':
+          $ref: '#/components/responses/ValidationError'
         '401':
           $ref: '#/components/responses/AuthError'
+        '500':
+          $ref: '#/components/responses/ServerError'
 
   /cracker/check-update:
     post:
@@ -234,6 +256,62 @@ paths:
           $ref: '#/components/responses/ValidationError'
         '401':
           $ref: '#/components/responses/AuthError'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+  /resources/{type}/{id}/download-url:
+    get:
+      operationId: getResourceDownloadUrl
+      summary: Presigned download URL for a resource bound to this agent's project
+      description: |
+        Returns a short-lived presigned URL the agent uses to fetch a
+        resource (wordlist, rule, mask) from object storage. The resource
+        must belong to a project the agent is a member of; cross-project
+        lookups return 404. The URL is single-use and expires per the
+        `expiresIn` field. Failures during URL generation return the
+        Agent envelope at HTTP 500 with code `RESOURCE_URL_ERROR`.
+      tags: [Resources]
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: type
+          in: path
+          required: true
+          description: Resource kind (e.g., `wordlist`, `rule`, `mask`).
+          schema:
+            type: string
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Presigned download URL
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [url, expiresIn]
+                properties:
+                  url:
+                    type: string
+                    format: uri
+                  expiresIn:
+                    type: integer
+                    description: Seconds until the URL expires.
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/AuthError'
+        '404':
+          description: Resource not found or has no file
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ServerError'
 
 components:
   securitySchemes:
@@ -731,6 +809,22 @@ components:
 
     ValidationError:
       description: Request body or query parameters failed validation
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+
+    ServerError:
+      description: |
+        Server-side processing failed. Each route returns its own coarse
+        error code on the catch-all failure path so agents can switch on
+        `error.code` and treat known codes specifically. Known codes:
+        `HEARTBEAT_ERROR`, `BENCHMARK_ERROR`, `TASK_ASSIGN_ERROR`,
+        `TASK_REPORT_ERROR`, `TASK_ZAP_ERROR`, `ERROR_INGEST_ERROR`,
+        `RESOURCE_URL_ERROR`, `CRACKER_UPDATE_ERROR`. The response shape
+        is the Agent envelope (`{ error: { code, message } }`) — no
+        `timestamp` or `requestId` fields. Distinct from the dashboard
+        envelope returned by other API surfaces on internal errors.
       content:
         application/json:
           schema:


### PR DESCRIPTION
## Summary

Closes #170. Restores the documented Agent API envelope (`{ error: { code, message } }`) on every server-side failure path across the entire agent surface, and pins the shape with contract + integration tests. Originally scoped to `/heartbeat` only; expanded during multi-agent code review to cover every agent route + their OpenAPI contract.

The original bug: `POST /api/v1/agent/heartbeat` did not wrap `processHeartbeat()` in `try/catch`, so failures fell through to the global `app.onError` which emits the **dashboard** envelope (`{ error: { code: 'INTERNAL_SERVER_ERROR', timestamp, requestId } }`). Same drift existed on `/tasks/next`, `/tasks/:id/report`, `/tasks/:id/zaps`, `/errors`, `/resources/:type/:id/download-url`, and `/cracker/check-update` — flagged by `ce-reliability-reviewer` and `silent-failure-hunter` during review.

The PR also hardens `processHeartbeat`'s post-commit work (SSE emits + audit log) so a thrown emit cannot cause the route to return `HEARTBEAT_ERROR` 500 *after* the DB transaction has already committed.

## What changed

| Layer | Surface | Change |
|---|---|---|
| Route | `packages/backend/src/routes/agent/index.ts` | All 7 agent routes wrap their primary service calls in `try/catch`. Each catch logs structured context and returns the Agent envelope at HTTP 500 with a route-specific coarse code: `HEARTBEAT_ERROR`, `TASK_ASSIGN_ERROR`, `TASK_REPORT_ERROR`, `TASK_ZAP_ERROR`, `ERROR_INGEST_ERROR`, `RESOURCE_URL_ERROR`, `CRACKER_UPDATE_ERROR` (alongside the pre-existing `BENCHMARK_ERROR`). Static leak-safe messages; full error stays in the server-side log. |
| Service | `packages/backend/src/services/agents.ts` | `processHeartbeat`'s post-commit block (`emitAgentError`, `emitAgentStatus`, `logStatusTransition`) wrapped in its own `try/catch` that logs at error level with `{ agentId, projectId }` and does **not** rethrow. The DB transaction has already committed at that point; a flaky SSE bus or audit sink should not undo that on the wire. Block-level catch on purpose — shared SSE failure mode means short-circuiting the remaining emits is the right call, and the next heartbeat heals. |
| OpenAPI | `packages/openapi/agent-api.yaml` | New shared `ServerError` response component enumerating every Agent-envelope failure code. Referenced from every documented agent route alongside `ValidationError` where applicable. Previously undocumented `/resources/{type}/{id}/download-url` route now spec'd. |
| Tests (unit) | `packages/backend/tests/unit/agent-api-contract.test.ts` | 7 new failure-envelope tests pinning each route's coarse code + the negative envelope shape (`error.timestamp` / `error.requestId` undefined). `hasError=true` log-branch test. Logger mocked so log-shape assertions verify directly. Heartbeat message pinned to literal `'Failed to process heartbeat'` (leak-safe assertion). |
| Tests (integration) | `packages/backend/tests/integration/agent-heartbeat.test.ts` | 4 post-commit-throw tests covering all three call sites in the new service-layer catch: `emitAgentStatus` throw (vanilla heartbeat), `emitAgentError` throw (heartbeat with error payload), `logStatusTransition` throw (across a real status transition), recovery heartbeat (prior status=error) × `emitAgentStatus` throw. |
| Tests (frontend setup) | `packages/frontend/tests/setup.ts` | Injected `ResizeObserver`, `IntersectionObserver`, `SVGElement`, `SVGSVGElement`, `Image`, `HTMLImageElement` onto `globalThis`. happy-dom v20 puts these on `window` but the setup wasn't bridging them; ReactFlow consumers (CampaignDetailPage) threw `ReferenceError` on Linux CI but passed on macOS. CI portability fix surfaced when the original heartbeat PR triggered ci-check. |

## Test plan

- [x] `just check` (format + lint + type-check + build) green
- [x] `just ci-check` (full test suite) green
- [x] Backend: **508 pass / 0 fail** (was 501 before this PR; +7 new tests on top of the original commits)
- [x] Frontend E2E: 3 pass
- [x] Each route's new contract test fails on `main` (proven during TDD; current handlers fall through to `app.onError` with `code === 'INTERNAL_SERVER_ERROR'`) and passes after the route-level fix
- [x] Each post-commit-throw integration test fails without the service-level `try/catch` and passes after it
- [x] No regression in existing /heartbeat contract or integration tests (legacy back-compat, high-priority-flag, currentTask+warning, fatal+no-task, recovery-from-error, size-cap boundaries, validation paths, strict middleware)

## Review process

Branch driven through the `superpowers/lfg` autonomous pipeline (plan → work → multi-agent code review → autofix → browser smoke → PR), then iterated through a second `/pr-review-toolkit` pass after the user requested "fix all valid findings; do not defer."

**First pass** (5-agent `ce-code-review`): correctness ✓, security ✓, api-contract ✓ (deferred OpenAPI noted), testing surfaced P3 at confidence 50 (pin literal message — applied in iteration 2), reliability surfaced REL-001 (post-commit hardening — applied inline as the second commit).

**Second pass** (4-agent `/pr-review-toolkit`): the testing reviewer flagged 4 coverage gaps (post-commit branches, recovery × post-commit throw, `hasError=true` log branch, literal message pinning) — all addressed. The comment-analyzer flagged 6 stale refs (gitignored plan path, "See GitHub #170" × 4, brittle line range, "below" cardinal reference) — all stripped. The silent-failure-hunter flagged the OpenAPI sync gap (now fixed) and the same envelope drift on other agent routes (now wrapped). The code-reviewer flagged the OpenAPI gap (same finding, same fix) and the brittle log `startsWith` coupling in the integration test (replaced with structural filtering).

Zero residual findings. No follow-up issues filed.

Refs: #170, #169 (initial review trail), `ce-reliability-reviewer` REL-001 (applied inline)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7-D97757?logo=claude&logoColor=white)
