### PR TITLE
fix(openapi): correct /resources route description for resource types and presigned URL reuse

### DIFF
--- a/packages/openapi/agent-api.yaml
+++ b/packages/openapi/agent-api.yaml
@@ -265,11 +265,13 @@ paths:
       summary: Presigned download URL for a resource bound to this agent's project
       description: |
         Returns a short-lived presigned URL the agent uses to fetch a
-        resource (wordlist, rule, mask) from object storage. The resource
-        must belong to a project the agent is a member of; cross-project
-        lookups return 404. The URL is single-use and expires per the
-        `expiresIn` field. Failures during URL generation return the
-        Agent envelope at HTTP 500 with code `RESOURCE_URL_ERROR`.
+        resource (hash list, wordlist, rule list, mask list) from object
+        storage. The resource must belong to a project the agent is a
+        member of; cross-project lookups return 404. The URL is a
+        standard S3 `GetObject` presigned URL — it is reusable until it
+        expires per the `expiresIn` field (currently 6 hours), not
+        single-use. Failures during URL generation return the Agent
+        envelope at HTTP 500 with code `RESOURCE_URL_ERROR`.
       tags: [Resources]
       security:
         - BearerAuth: []
@@ -277,9 +279,13 @@ paths:
         - name: type
           in: path
           required: true
-          description: Resource kind (e.g., `wordlist`, `rule`, `mask`).
+          description: |
+            Resource kind. Must be one of the documented values
+            recognized by `getAgentDownloadUrl`'s table map; unknown
+            values return 404.
           schema:
             type: string
+            enum: [hash-lists, wordlists, rulelists, masklists]
         - name: id
           in: path
           required: true


### PR DESCRIPTION
## Summary

Follow-up to #176 (merged). Two `copilot-pull-request-reviewer` findings on `packages/openapi/agent-api.yaml` were raised after that PR opened and were not resolved before merge. Both are spec-vs-implementation drifts on the newly-documented `/resources/{type}/{id}/download-url` operation that would mislead anyone generating an agent client from the spec.

**Scope:** 1 file, +12 / −6, spec-only. No code changes; no test changes required.
**Risk:** 🟢 Low. Documentation correctness only.
**Review time:** ~3 minutes (one diff side-by-side check against `services/resources.ts` + `lib/storage.ts`).

---

## What changed

### Finding 1 — Resource type values were singular; the implementation accepts plural

The spec showed singular examples (`wordlist`, `rule`, `mask`) with no enum constraint, but `getAgentDownloadUrl` at `packages/backend/src/services/resources.ts:586-591` only recognizes the plural keys plus `hash-lists`:

```ts
const tableMap: Record<string, ResourceTable | typeof hashLists> = {
  'hash-lists': hashLists,
  wordlists: wordLists,
  rulelists: ruleLists,
  masklists: maskLists,
}
```

A generated client following the spec would receive 404 on every request because the URL path segment wouldn't match the table map key. Fix: constrain the `type` path parameter with an explicit `enum` that mirrors the table map verbatim, plus update prose to use the plural forms.

| Field | Before | After |
|---|---|---|
| Prose description | "a resource (wordlist, rule, mask)" | "a resource (hash list, wordlist, rule list, mask list)" |
| `type` parameter description | "Resource kind (e.g., \`wordlist\`, \`rule\`, \`mask\`)." | "Resource kind. Must be one of the documented values recognized by `getAgentDownloadUrl`'s table map; unknown values return 404." |
| `type` parameter schema | `type: string` (unconstrained) | `type: string`, `enum: [hash-lists, wordlists, rulelists, masklists]` |

### Finding 2 — "URL is single-use" claim contradicts S3 GetObject semantics

The spec claimed `The URL is single-use and expires per the expiresIn field`, but `getPresignedUrl` at `packages/backend/src/lib/storage.ts` wraps `@aws-sdk/s3-request-presigner`'s `getSignedUrl` with only an expiration. Standard S3 `GetObject` presigned URLs are **reusable** until they expire — there is no per-use invalidation. Fix: reword to reflect actual semantics and name the underlying S3 operation.

| Field | Before | After |
|---|---|---|
| Reuse claim | "The URL is single-use and expires per the `expiresIn` field." | "The URL is a standard S3 `GetObject` presigned URL — it is reusable until it expires per the `expiresIn` field (currently 6 hours), not single-use." |

---

## How to verify

```bash
# 1. Confirm the table map and the new enum agree
grep -A 5 "tableMap" packages/backend/src/services/resources.ts
grep -A 1 "enum:" packages/openapi/agent-api.yaml | grep -A 1 "type:"

# 2. Confirm getSignedUrl is the underlying call (not a single-use variant)
grep -n "getSignedUrl\|getPresignedUrl" packages/backend/src/lib/storage.ts

# 3. Spec validates
just check
```

---

## Test plan

- [x] `just check` (format + lint + type-check + build) green
- [x] No new code paths to test — this PR is a documentation fix on the OpenAPI surface only.
- [x] Existing contract test `GET /resources/:type/:id/download-url returns RESOURCE_URL_ERROR when getAgentDownloadUrl throws` at `packages/backend/tests/unit/agent-api-contract.test.ts` continues to pass; it exercises the catch path via `mockImplementationOnce` regardless of the `type` value.
- [x] No generated-client regeneration in-tree (this repo doesn't ship a generated agent client; the Go-based agent generates from this spec out-of-tree).

---

## Review checklist

- [x] Spec is now consistent with `getAgentDownloadUrl`'s accepted keys (verified against `packages/backend/src/services/resources.ts:586-591`).
- [x] Spec is consistent with the underlying S3 SDK semantics (verified against `packages/backend/src/lib/storage.ts` `getSignedUrl` wrapping).
- [x] `enum` values match the table map keys character-for-character (`hash-lists`, `wordlists`, `rulelists`, `masklists`).
- [x] No other spec routes affected; the broader `ServerError` envelope wiring from #176 stays intact.
- [x] Both threads on #176 (https://github.com/EvilBit-Labs/hash_hive/pull/176#discussion_r3308089398 and https://github.com/EvilBit-Labs/hash_hive/pull/176#discussion_r3308089422) reference this PR in their resolution replies.

---

## Risk assessment

| Factor | Score | Notes |
|---|---|---|
| Size | 1/10 | 1 file, +12 / −6, all documentation strings + one enum array |
| Complexity | 1/10 | Pure spec change; no runtime branches affected |
| Test coverage | 1/10 | No test changes needed; existing route test unaffected |
| Dependencies | 1/10 | No npm/yarn/lockfile changes |
| Security | 1/10 | Documentation-only; the underlying S3 URL behavior (reusable until expiry) is unchanged and was always the case — the spec was the misleading party |

**Overall: 🟢 Low.** Safe to fast-merge after spec-vs-source double-check.

---

## Why not inline in #176

#176 was already merged when both copilot comments came in and stayed unresolved through the merge window. The two findings are valid and small enough to land as a focused follow-up rather than amend a merged squash commit; the threads on #176 have been resolved with pointers to this PR.

Refs: #176, copilot comments [r3308089398](https://github.com/EvilBit-Labs/hash_hive/pull/176#discussion_r3308089398) and [r3308089422](https://github.com/EvilBit-Labs/hash_hive/pull/176#discussion_r3308089422)

