### PR TITLE
test(contract): apply contract-test-mocks convention (U0-U3 of 6)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,8 +14,8 @@
       "name": "@hashhive/backend",
       "version": "1.0.0",
       "dependencies": {
-        "@aws-sdk/client-s3": "3.1052.0",
-        "@aws-sdk/s3-request-presigner": "3.1052.0",
+        "@aws-sdk/client-s3": "3.1054.0",
+        "@aws-sdk/s3-request-presigner": "3.1054.0",
         "@hashhive/shared": "workspace:*",
         "@hono/zod-openapi": "^1.4.0",
         "@hono/zod-validator": "^0.8.0",
@@ -56,7 +56,7 @@
         "zustand": "^5.0.13",
       },
       "devDependencies": {
-        "@aws-sdk/client-s3": "^3.1052.0",
+        "@aws-sdk/client-s3": "^3.1054.0",
         "@playwright/test": "^1.60.0",
         "@tailwindcss/vite": "^4.3.0",
         "@testcontainers/postgresql": "^12.0.0",
@@ -111,53 +111,53 @@
 
     "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
 
-    "@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.1052.0", "", { "dependencies": { "@aws-crypto/sha1-browser": "5.2.0", "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.13", "@aws-sdk/credential-provider-node": "^3.972.44", "@aws-sdk/middleware-bucket-endpoint": "^3.972.15", "@aws-sdk/middleware-expect-continue": "^3.972.13", "@aws-sdk/middleware-flexible-checksums": "^3.974.21", "@aws-sdk/middleware-location-constraint": "^3.972.11", "@aws-sdk/middleware-sdk-s3": "^3.972.42", "@aws-sdk/middleware-ssec": "^3.972.11", "@aws-sdk/signature-v4-multi-region": "^3.996.28", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/fetch-http-handler": "^5.4.3", "@smithy/node-http-handler": "^4.7.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-8fgQHfk1WjGUyowyqtMwq9HzZvIQQ86cqn9IZW5Qkq8kaolVjMmZez60qVYxKYvKhVRYUP5hWYPVCyraoud0AA=="],
+    "@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.1054.0", "", { "dependencies": { "@aws-crypto/sha1-browser": "5.2.0", "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.14", "@aws-sdk/credential-provider-node": "^3.972.45", "@aws-sdk/middleware-bucket-endpoint": "^3.972.16", "@aws-sdk/middleware-expect-continue": "^3.972.13", "@aws-sdk/middleware-flexible-checksums": "^3.974.22", "@aws-sdk/middleware-location-constraint": "^3.972.11", "@aws-sdk/middleware-sdk-s3": "^3.972.43", "@aws-sdk/middleware-ssec": "^3.972.11", "@aws-sdk/signature-v4-multi-region": "^3.996.29", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/fetch-http-handler": "^5.4.3", "@smithy/node-http-handler": "^4.7.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-2ue7uVqaHYX4rytkcrLySYU/m/ZlRbL8KojWefbR24B0/TcFkqN2IovpBFrnmla/dtZAn9eVSlhHeEddOghZ5w=="],
 
-    "@aws-sdk/core": ["@aws-sdk/core@3.974.13", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@aws-sdk/xml-builder": "^3.972.25", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.3", "@smithy/signature-v4": "^5.4.2", "@smithy/types": "^4.14.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-+Y5/4tHki0uYgyx8eun146DegRVQBpdKGK5RbV0FTKJPpaKTchvqVxrrRFK6Wk0JksO4iAZKw3eqxGEIwtO98w=="],
+    "@aws-sdk/core": ["@aws-sdk/core@3.974.15", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@aws-sdk/xml-builder": "^3.972.26", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.5", "@smithy/signature-v4": "^5.4.5", "@smithy/types": "^4.14.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw=="],
 
     "@aws-sdk/crc64-nvme": ["@aws-sdk/crc64-nvme@3.972.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-P+QGozmXn2mZZI7sDgk+aUm+RTI61MPSFB+Ir2vjEjEbEsE4e7hYtzrDvAUxZy9ko81h53e11+F/GYlvwDkaOQ=="],
 
-    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.39", "", { "dependencies": { "@aws-sdk/core": "^3.974.13", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-29wX9zpAvEt1vcj0psha+y6ygBHy2V/S72mp6e7q0KARLWXq+pwE/lR6qGkwknQvruh52lXvlqZIga8Hdxkucw=="],
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.41", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-n1EbJ98yvPWWdHZZv8bRBMqqDQJrtgtxyJ4xLy2Uqrh25BCOZQ7nnS1CsFXvuH8r0b0KVHDZEGEH5FxmEMP8jg=="],
 
-    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.41", "", { "dependencies": { "@aws-sdk/core": "^3.974.13", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/fetch-http-handler": "^5.4.3", "@smithy/node-http-handler": "^4.7.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-IA3CQTjtJkb6u1H4mE4936c8OPBMa9Jggtwe8U2Mqw/vvb/tZ5Ebd0mcZcX0uKWQhOyYo/+qNIwkV5Xh+FeJJA=="],
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.43", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/fetch-http-handler": "^5.4.5", "@smithy/node-http-handler": "^4.7.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-TT76RN1NkI9WoyZqCNxOw6/WBMF7pYOTJcXbMokNFU+euSG40Kaf/t/FhDACVZWP+43wEM6ZynIPIkzS1wR1iA=="],
 
-    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.972.43", "", { "dependencies": { "@aws-sdk/core": "^3.974.13", "@aws-sdk/credential-provider-env": "^3.972.39", "@aws-sdk/credential-provider-http": "^3.972.41", "@aws-sdk/credential-provider-login": "^3.972.43", "@aws-sdk/credential-provider-process": "^3.972.39", "@aws-sdk/credential-provider-sso": "^3.972.43", "@aws-sdk/credential-provider-web-identity": "^3.972.43", "@aws-sdk/nested-clients": "^3.997.11", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/credential-provider-imds": "^4.3.2", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-4mzII+3mZEVXXE1xzrLQrCJL7/r62A63bA6SVzZoNL5rqCJghpf+xgGltVrIBBs0n+mOZBKrQl2tRREtvZ5l6A=="],
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.972.46", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/credential-provider-env": "^3.972.41", "@aws-sdk/credential-provider-http": "^3.972.43", "@aws-sdk/credential-provider-login": "^3.972.45", "@aws-sdk/credential-provider-process": "^3.972.41", "@aws-sdk/credential-provider-sso": "^3.972.45", "@aws-sdk/credential-provider-web-identity": "^3.972.45", "@aws-sdk/nested-clients": "^3.997.13", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/credential-provider-imds": "^4.3.6", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-hvcgcwOiS0nb2XFb5Op1Pz/vYaWz5K8kKullziGpdNRuG0NwzRXseuPt2CoBqknHGaSPVesu1aOn2OcctEYdCA=="],
 
-    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.43", "", { "dependencies": { "@aws-sdk/core": "^3.974.13", "@aws-sdk/nested-clients": "^3.997.11", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-HG7kQCwXtbv3oBV61Ins0oNX8KKyvrMqqRkb6ZiAfQHbMuHaiNaEb2KnpKLPkNpqImSBK82UkVE/kaY6IfWikA=="],
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.45", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/nested-clients": "^3.997.13", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-MZQv4SNjByk1iOKmrqmzcUF/uCB05wjvEHyXKxmGQTUANTIVayX6HPUF0bzkWLvtnkH7sAn9kUCfkXbSpj9sDA=="],
 
-    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.44", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.39", "@aws-sdk/credential-provider-http": "^3.972.41", "@aws-sdk/credential-provider-ini": "^3.972.43", "@aws-sdk/credential-provider-process": "^3.972.39", "@aws-sdk/credential-provider-sso": "^3.972.43", "@aws-sdk/credential-provider-web-identity": "^3.972.43", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/credential-provider-imds": "^4.3.2", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-sDaBIT0yrNNIPfvlsiTCmANm07zKju+ipWODjEXgZlsjMeIJR3LVp7RDyAOzUoAsTbDfYKDWp+i5WrFiQP6rmQ=="],
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.47", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.41", "@aws-sdk/credential-provider-http": "^3.972.43", "@aws-sdk/credential-provider-ini": "^3.972.46", "@aws-sdk/credential-provider-process": "^3.972.41", "@aws-sdk/credential-provider-sso": "^3.972.45", "@aws-sdk/credential-provider-web-identity": "^3.972.45", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/credential-provider-imds": "^4.3.6", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-HrId+C0DWA5qDIyLG64/kjUB2RNtPypxmABnIctK+TA1P1kHlOYoE/Wf5T5tKOMKgb08P7k/zNyhvfJ3lh5Oag=="],
 
-    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.39", "", { "dependencies": { "@aws-sdk/core": "^3.974.13", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-2k/amBifLd75eXNwgvPw/2lKYSQ3NhvHQgkVKVjfUq13/eJ3JRtHmznuFenn74OK3sSfp4SMy1YB2w+UVXoKqA=="],
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.41", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-7I/n1zkysouLOWvkEhjNEP4vMnD2v4kzzr3/3QBdrripEpn7ap1/I5DF3Hou1SUqkKWo1f3oPGMyFAA1FAMvsQ=="],
 
-    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.972.43", "", { "dependencies": { "@aws-sdk/core": "^3.974.13", "@aws-sdk/nested-clients": "^3.997.11", "@aws-sdk/token-providers": "3.1052.0", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-LPc3+Y4vhH1T4x6CMqwCM6hk5+SRf/Lwmgm8INm95wxTtIRHcMwQUVkDzWu4Iw/RSncxYM2BC01OrYbxOPZvyg=="],
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.972.45", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/nested-clients": "^3.997.13", "@aws-sdk/token-providers": "3.1056.0", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-oHgbz/eFD8IKiksqDsz9ZMU4A59BpQq4QwJedBnGD80ZqYcHPPHZBwjBnxLVkB7iRVVHWpDclR8yWdD2PkQIUA=="],
 
-    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.43", "", { "dependencies": { "@aws-sdk/core": "^3.974.13", "@aws-sdk/nested-clients": "^3.997.11", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-wQtL34lUD/09VXjwAUo2T+I3aEXRDxMB3DKmTJL/Zj0Gi6sLDTrVhae1XVt01yzkquOWajI/sZW72JGDZ1ciTw=="],
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.45", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/nested-clients": "^3.997.13", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-CDhzKdb2onv5bpnjn/acgdNmJOQthPDLsPizU7rZflsEcgMMp8Mlri+U5hdxf8ldvZJpvM3vLU6D56vfJm5AMQ=="],
 
-    "@aws-sdk/middleware-bucket-endpoint": ["@aws-sdk/middleware-bucket-endpoint@3.972.15", "", { "dependencies": { "@aws-sdk/core": "^3.974.13", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-O2HDANa+MrvbxpaRVQDiH3T13uAa9AkMjKyZmDygwauAmmvqZ5B0iRmKW+fuVGW6NPXuyXurFgIx69lSvmAWGA=="],
+    "@aws-sdk/middleware-bucket-endpoint": ["@aws-sdk/middleware-bucket-endpoint@3.972.17", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-lbDmWuHenc+kiwCNrxz4MyN6nkxCWyTXPIWuspJN0ibziu+8CXci7vI1bK9MAkwy8cwJOEXNu0gBM5S0uTGRIg=="],
 
     "@aws-sdk/middleware-expect-continue": ["@aws-sdk/middleware-expect-continue@3.972.13", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-sHiqIFg8o2ipT7t40B89Vj0ubSUtY6OSt/+Ee/OXhHch5K4+81zP2+QX8Lkc/nJ2QSmCySxOke7TEbmX69fe2g=="],
 
-    "@aws-sdk/middleware-flexible-checksums": ["@aws-sdk/middleware-flexible-checksums@3.974.21", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@aws-crypto/crc32c": "5.2.0", "@aws-crypto/util": "5.2.0", "@aws-sdk/core": "^3.974.13", "@aws-sdk/crc64-nvme": "^3.972.9", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-alAu9heyiBK/OmRNXVxq8mmPTgeW2AQ6EYjRsI38kPZa1MZvt2Jh+BlGq7/GG9OVXOaEgD7DlGj/Lzfy5OmuEg=="],
+    "@aws-sdk/middleware-flexible-checksums": ["@aws-sdk/middleware-flexible-checksums@3.974.23", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@aws-crypto/crc32c": "5.2.0", "@aws-crypto/util": "5.2.0", "@aws-sdk/core": "^3.974.15", "@aws-sdk/crc64-nvme": "^3.972.9", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-4nPKARo2lfKvQGUt2fPA5NlS/mEohckdxpuC9ecbjVfj7B7NFFYHeTg+Bf5BEQwdn3yRfUIzFiEkPp8Yuaw3wA=="],
 
     "@aws-sdk/middleware-location-constraint": ["@aws-sdk/middleware-location-constraint@3.972.11", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-hkfspNUP4criAH6ton6BGKgnm5dZx+7bUOy1YqlTfejDeUPAM23D81q/IX+hdlS3KUsfwGz5ADTqZWKBEUpf4A=="],
 
-    "@aws-sdk/middleware-sdk-s3": ["@aws-sdk/middleware-sdk-s3@3.972.42", "", { "dependencies": { "@aws-sdk/core": "^3.974.13", "@aws-sdk/signature-v4-multi-region": "^3.996.28", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/signature-v4": "^5.4.2", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-/xNqNGXv9LaxZd25L9VV4pnSOw9OdDNO4rAHamM+h3KQBSITljIH9vk3dveGga1I2j36lQd0rdG3gjNEXvtNew=="],
+    "@aws-sdk/middleware-sdk-s3": ["@aws-sdk/middleware-sdk-s3@3.972.44", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/signature-v4-multi-region": "^3.996.30", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-8HQsRg1NpX8vR4vNl1E8pyLnqZroq9VSL2vZQVSgBqp6wv6365LzYD08/c9FFh/9FTg7YRc7aTtEmXF0ir/pqg=="],
 
     "@aws-sdk/middleware-ssec": ["@aws-sdk/middleware-ssec@3.972.11", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-7PQvGNhtveKlvVqNahqWx5yrwxP7ecwAoB1dYBf8eKwfo2tzzCbNnW+q2nO3N066ktQaB4iBQbDRWtizm+amoQ=="],
 
-    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.11", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.13", "@aws-sdk/signature-v4-multi-region": "^3.996.28", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/fetch-http-handler": "^5.4.3", "@smithy/node-http-handler": "^4.7.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-nWXXJ1r/r8N2Gw1pWolRgED38/A9A8DHR2ETWIv220zh4PZHcybbR4hUVWWktmNXTRHzDJwRluapHn0rZxuoqA=="],
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.13", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.15", "@aws-sdk/signature-v4-multi-region": "^3.996.30", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/fetch-http-handler": "^5.4.5", "@smithy/node-http-handler": "^4.7.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-2pA6eyb5nSo/ZD2cayhOTEMoGQYgspq0RI05GDLkzQ3ajZ6isS6waV6E92Am/hz4LIlLUTrbwPLurJ/fuiHvkg=="],
 
-    "@aws-sdk/s3-request-presigner": ["@aws-sdk/s3-request-presigner@3.1052.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.13", "@aws-sdk/signature-v4-multi-region": "^3.996.28", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-VDULO8AQlgcYZHRYn3qaBfYiM//aWxdlvQsTdcP+EQgSjki3z+mhD7rMy1RKnu4VvRK/xjJFOKwMA3cDM8eLtw=="],
+    "@aws-sdk/s3-request-presigner": ["@aws-sdk/s3-request-presigner@3.1054.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.14", "@aws-sdk/signature-v4-multi-region": "^3.996.29", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-rgSDc0LwzM1yUL/UouFLR72HV5lhgdQRQlp8WWWot+q3nhBYrj+mklreWh28q9bGkgrNGWrcpMRp4Y3rC4sxVw=="],
 
-    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.28", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/signature-v4": "^5.4.2", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-qs9z5LqXO/CZC2Lg9SGKpoLU8Rhi+m2pFKZqfO9pytX1clc0katqtsDNupJxFy0xT9wsZSPzM2v1y+/H/zfp5Q=="],
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.30", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@smithy/signature-v4": "^5.4.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-HULDLMVzkmTSEv6//7kx2kRevp/VYUpm8hJNNFbmhxDn0fUiGTxVcM9yg31TukvTq8nyOBDUN2gH0o5IRbKjdw=="],
 
-    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1052.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.13", "@aws-sdk/nested-clients": "^3.997.11", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-QqZNB3so7UIDxZtroc85TQaLVxdZRFm0eWM1CSR2N+b06as9TOrilvrlTZuj3guYlxMs6yLOgGxnklJ5qMYtTw=="],
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1056.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/nested-clients": "^3.997.13", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-81duvlltQlsfn5K+o8zILcystBRdbT1G2JJYVCML5NZHBz4CL/zf+sAemCtBh/uh6RQUMyInGeZLQ7/8igZhbA=="],
 
     "@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
 
     "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.4", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-H1onv5SkgPBK2P6JR2MjGgbOnttoNzSPIRoeZTNPZYyaplwGg50zS3amXvXqF0/qfXpWEC9rLWU564QTB9bSog=="],
 
-    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.25", "", { "dependencies": { "@nodable/entities": "2.1.0", "@smithy/types": "^4.14.2", "fast-xml-parser": "5.7.3", "tslib": "^2.6.2" } }, "sha512-GH+Kjz4nPKWKHnsiQpnhP1MJdTGIcK4rAka6tzakgjjUkVgNsmPeEbbRAf09SzS1hjGu6duGHCBsxYke0BhHjQ=="],
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.26", "", { "dependencies": { "@smithy/types": "^4.14.2", "fast-xml-parser": "5.7.3", "tslib": "^2.6.2" } }, "sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g=="],
 
     "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.3", "", {}, "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw=="],
 
@@ -395,7 +395,7 @@
 
     "@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
 
-    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.3.4", "", { "dependencies": { "@smithy/core": "^3.24.4", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-vKW0MEFRU4Y3MkVZUkpJm+g9qyPGLCXhc0YLggUdSdBB4g7IaSSsCE75P9rBXyWHrXY1UYSQUl8/DwsTR7QciA=="],
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.3.6", "", { "dependencies": { "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-tHhdiWZfG1ZIh2YcRfPJmY2gHcBmqbAzqm3ER4TIDFYsSEqTD5tICT7cgQ/kI8LRakxp12myOYyK68XPn7MnHw=="],
 
     "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.4.4", "", { "dependencies": { "@smithy/core": "^3.24.4", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ=="],
 
@@ -403,7 +403,7 @@
 
     "@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.4", "", { "dependencies": { "@smithy/core": "^3.24.4", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-HIeF+1vrDGzPkkv39Hj2vlHSXHY3p958jd/8ZnePIY6+ZOsQX8coyEUKO5yQu4r0bQIVsbpotVIrXXwyycMStQ=="],
 
-    "@smithy/signature-v4": ["@smithy/signature-v4@5.4.4", "", { "dependencies": { "@smithy/core": "^3.24.4", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-e5UtkMvsatzBfbeBZjEOt0k0Z3BEsjTFL/n6fdO5vtBLe67tdy0dX7xw2DU7uZ3acwoHyeCqpU2Fzb7pxwHb6Q=="],
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.4.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-QBJKWGqIknH0dc9LWpfH1mkdokAx6iXYN3UcQ3eY6uIEyScuoQAhfl94ge7ozUy9WgFUdE8xsvwBjaYBbWmPNA=="],
 
     "@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
@@ -1081,11 +1081,45 @@
 
     "@aws-crypto/util/@aws-sdk/types": ["@aws-sdk/types@3.973.1", "", { "dependencies": { "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg=="],
 
+    "@aws-sdk/core/@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
+
+    "@aws-sdk/credential-provider-env/@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
+
+    "@aws-sdk/credential-provider-http/@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
+
+    "@aws-sdk/credential-provider-http/@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.4.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-SK3VMeH0fibgdTg2QeB+O4p7Yy/2E5HBOHJeC58FshkDdeuX8lOgO7PfjYfLyPLP1ch55j91cQqKBzDS0mRjSQ=="],
+
+    "@aws-sdk/credential-provider-http/@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3dA9TQ+ybRSZ/m0wnbZhiBy4Dezjgq1Ib/ZZrYTpJDBgpoLLU/SDzZc/g0x0MNAdOJe1wPcM+x2PBRmoOur+Sw=="],
+
+    "@aws-sdk/credential-provider-ini/@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
+
+    "@aws-sdk/credential-provider-login/@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
+
+    "@aws-sdk/credential-provider-node/@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
+
+    "@aws-sdk/credential-provider-process/@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
+
+    "@aws-sdk/credential-provider-sso/@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
+
+    "@aws-sdk/credential-provider-web-identity/@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
+
+    "@aws-sdk/middleware-bucket-endpoint/@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
+
+    "@aws-sdk/middleware-flexible-checksums/@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
+
+    "@aws-sdk/middleware-sdk-s3/@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
+
+    "@aws-sdk/nested-clients/@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
+
+    "@aws-sdk/nested-clients/@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.4.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-SK3VMeH0fibgdTg2QeB+O4p7Yy/2E5HBOHJeC58FshkDdeuX8lOgO7PfjYfLyPLP1ch55j91cQqKBzDS0mRjSQ=="],
+
+    "@aws-sdk/nested-clients/@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3dA9TQ+ybRSZ/m0wnbZhiBy4Dezjgq1Ib/ZZrYTpJDBgpoLLU/SDzZc/g0x0MNAdOJe1wPcM+x2PBRmoOur+Sw=="],
+
+    "@aws-sdk/token-providers/@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
+
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
     "@grpc/grpc-js/@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="],
-
-    "@hashhive/frontend/@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.1053.0", "", { "dependencies": { "@aws-crypto/sha1-browser": "5.2.0", "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.13", "@aws-sdk/credential-provider-node": "^3.972.44", "@aws-sdk/middleware-bucket-endpoint": "^3.972.15", "@aws-sdk/middleware-expect-continue": "^3.972.13", "@aws-sdk/middleware-flexible-checksums": "^3.974.21", "@aws-sdk/middleware-location-constraint": "^3.972.11", "@aws-sdk/middleware-sdk-s3": "^3.972.42", "@aws-sdk/middleware-ssec": "^3.972.11", "@aws-sdk/signature-v4-multi-region": "^3.996.28", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/fetch-http-handler": "^5.4.3", "@smithy/node-http-handler": "^4.7.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-/oGxoB6p1Nqs935Blt+v1o+anSCEf2n3RjIrcLz84i4cn2Gr+Z7JpDdUkG5+74r5ctqEPG7k/phTGbJ9fNKnHg=="],
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
@@ -1104,6 +1138,10 @@
     "@reactflow/node-resizer/zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
 
     "@reactflow/node-toolbar/zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
+
+    "@smithy/credential-provider-imds/@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
+
+    "@smithy/signature-v4/@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 

--- a/docs/solutions/conventions/contract-test-mocks-mirror-service-not-schema.md
+++ b/docs/solutions/conventions/contract-test-mocks-mirror-service-not-schema.md
@@ -143,11 +143,18 @@ mock.module('../../src/services/tasks.js', () => ({
 Real service in `packages/backend/src/services/tasks/zaps.ts`:
 
 ```ts
-export async function getZapsForTask(...): Promise<{ zaps: string[]; hasMore: boolean }> {
+export async function getZapsForTask(
+  ...
+): Promise<{ zaps: string[]; hasMore: boolean } | { error: string }> {
   // ...
   return { zaps, hasMore }
 }
 ```
+
+The discriminated union is the safety net — the route's `'error' in result`
+branch handles the failure case, and the test fixture below pins the success
+variant. A `satisfies` pin against the full union keeps both branches
+honest as the service evolves.
 
 595 tests pass. The OpenAPI spec advertises `{ taskId, hashes }`. The agent receives `{ zaps, hasMore }`. The Go client drops both fields.
 

--- a/docs/solutions/conventions/contract-test-mocks-mirror-service-not-schema.md
+++ b/docs/solutions/conventions/contract-test-mocks-mirror-service-not-schema.md
@@ -26,9 +26,9 @@ tags:
 
 ## Context
 
-In PR #190 (the route-as-spec OpenAPI migration), three wire-contract regressions landed in a single commit and all 595 backend tests passed. The most severe: `packages/backend/src/routes/agent/index.ts` declared the `GET /tasks/{taskId}/zaps` response as `{ taskId: number, hashes: string[] }`, but the real service `getZapsForTask` in `packages/backend/src/services/tasks/zaps.ts` returns `{ zaps: string[], hasMore: boolean }`. The route handler does `c.json(result, 200)` and passes the service return verbatim.
+In PR #190 (the route-as-spec OpenAPI migration), three wire-contract regressions landed in a single commit and all 595 backend tests passed. The most severe: `packages/backend/src/routes/agent/index.ts` declared the `GET /tasks/{taskId}/zaps` response as `{ taskId: number, hashes: string[] }`, but the real service `getZapsForTask` in `packages/backend/src/services/tasks/zaps.ts` returns `{ zaps: string[], hasMore: boolean } | { error: string }` (the route maps the `error` arm to a 404). The route handler does `c.json(result, 200)` and passes the service return verbatim.
 
-`OpenAPIHono.c.json()` does **not** validate the body against the declared response schema at runtime — it's a compile-time narrowing tool only. So the wrong-schema-vs-real-shape mismatch produced no runtime error.
+The Hono context's `c.json(...)` (the call site `OpenAPIHono` routes hand off to) does **not** validate the body against the declared response schema at runtime — `@hono/zod-openapi`'s response schema is a compile-time narrowing tool only. So the wrong-schema-vs-real-shape mismatch produced no runtime error.
 
 The contract test at `packages/backend/tests/unit/agent-api-contract.test.ts:147` (before the fix) returned `{ taskId: 1, hashes: [] }` from the `getZapsForTask` mock — matching the route schema, not the real service. So the route schema, the test mock, and the runtime response builder all agreed on the wrong shape. The test suite was green. The generated OpenAPI spec at `/api/v1/agent/openapi.json` actively lied about the wire contract, and agent codegen would have produced a Go client that silently dropped cracked hash lists.
 
@@ -45,19 +45,25 @@ Two reinforcing techniques. Both are required on any contract test that mocks a 
 **1. Pin the mock shape to the real service return type via `satisfies` (static fixtures).**
 
 ```ts
-import type { getZapsForTask } from '../../src/services/tasks/zaps.js'
+// Type-only import via `typeof import('...').fn` so the snippet is
+// copy/paste-safe in a type-checked file. A plain `import type { fn }`
+// followed by `typeof fn` won't compile — `typeof` requires a value
+// symbol, and `import type` only brings the type into scope.
+type GetZapsForTask = typeof import('../../src/services/tasks/zaps.js').getZapsForTask
 
 const zapsResult = {
   zaps: ['5f4dcc3b5aa765d61d8327deb882cf99:password'],
   hasMore: false,
-} satisfies Awaited<ReturnType<typeof getZapsForTask>>
+} satisfies Awaited<ReturnType<GetZapsForTask>>
 
 mock.module('../../src/services/tasks.js', () => ({
   getZapsForTask: async () => zapsResult,
 }))
 ```
 
-`satisfies Awaited<ReturnType<typeof svc>>` lifts the mock into the type-check scope of the real service. If the service signature later changes, the mock fails type-check at `just check`. If the route schema drifts from the service, the route test will fail when the real response shape doesn't match what the contract test expects.
+`satisfies Awaited<ReturnType<GetZapsForTask>>` lifts the mock into the type-check scope of the real service. If the service signature later changes, the mock fails type-check in any tool that includes the test file — `tsc` runs covering `tests/**`, type-aware ESLint, your editor, or any CI step that widens the type-check scope.
+
+**Important enforcement caveat:** `packages/backend/tsconfig.json` currently scopes `tsc --noEmit` to `src/**/*` (tests are excluded — documented in `GOTCHAS.md` "Tests are NOT in the type-check scope"). With the default scope, `just check` does **not** validate the `satisfies` constraint in `tests/**`. The pin is still load-bearing: editor type-checking, type-aware linters, and any future widening of the tsc scope will catch drift the moment the test file enters the type-check graph. Treat the pin as documentation-plus-future-guarantee rather than as a today-CI-enforced invariant until the test scope is widened.
 
 **2. Type the factory body via `typeof svc` (dynamic-return mocks).**
 
@@ -73,9 +79,11 @@ mock.module('../../src/services/campaigns.js', () => ({
 The convention's static-fixture `satisfies` pattern can't apply directly here — there's no single fixture to pin. Instead, type the factory's callable shape:
 
 ```ts
-import type { getCampaignById } from '../../src/services/campaigns.js'
+// Same type-only `typeof import('...').fn` idiom — no runtime import
+// and no `import type` + `typeof` foot-gun.
+type GetCampaignById = typeof import('../../src/services/campaigns.js').getCampaignById
 
-const getCampaignByIdMock: typeof getCampaignById = async (id) =>
+const getCampaignByIdMock: GetCampaignById = async (id) =>
   mockCampaigns.find((c) => c.id === id) ?? null
 
 mock.module('../../src/services/campaigns.js', () => ({
@@ -83,7 +91,7 @@ mock.module('../../src/services/campaigns.js', () => ({
 }))
 ```
 
-This requires that the underlying `mockCampaigns` state array carries full rows satisfying the real `Awaited<ReturnType<typeof getCampaignById>>` shape, not a stripped-down test-fixture shape. Expanding state arrays to carry full rows is part of adopting this convention for dynamic-return tests.
+This requires that the underlying `mockCampaigns` state array carries full rows satisfying the real `Awaited<ReturnType<GetCampaignById>>` shape, not a stripped-down test-fixture shape. Expanding state arrays to carry full rows is part of adopting this convention for dynamic-return tests.
 
 **3. Add negative-shape assertions on every RED-fixed route and one representative case per YELLOW route per surface.**
 
@@ -100,7 +108,7 @@ The negative assertion is cheap insurance against silent regression. A YELLOW ro
 
 ## Why This Matters
 
-Routes that pass service results verbatim through `OpenAPIHono.c.json()` have **no runtime validation** between the service return value and the declared response schema. TypeScript narrowing only fires if you construct an object literal at the `c.json` call site; passing a variable typed as `unknown` or as the service return type silently widens, and the schema becomes documentation-only.
+Routes that pass service results verbatim through Hono's `c.json(...)` have **no runtime validation** between the service return value and the declared `@hono/zod-openapi` response schema. TypeScript narrowing only fires if you construct an object literal at the `c.json` call site; passing a variable typed as `unknown` or as the service return type silently widens, and the schema becomes documentation-only.
 
 This means the OpenAPI spec — the artifact downstream clients are generated from — can diverge from reality without any test catching it, as long as the test mock agrees with the (wrong) schema. The failure mode is the worst kind: green CI, generated client compiles, runtime behavior silently drops or mistypes fields. For HashHive's agent API specifically, the consumers are out-of-process Go binaries built from the spec; a wrong schema isn't a typo, it's a wire break that ships to every deployed agent on the next codegen.
 
@@ -169,15 +177,16 @@ const zapResponseSchema = z.object({
 })
 ```
 
-Test mock pinned to the real return type:
+Test mock pinned to the real return type (using `typeof import(...).fn`
+so the snippet is copy/paste-safe in a type-checked file):
 
 ```ts
-import type { getZapsForTask } from '../../src/services/tasks/zaps.js'
+type GetZapsForTask = typeof import('../../src/services/tasks/zaps.js').getZapsForTask
 
 const zapsResult = {
   zaps: ['5f4dcc3b5aa765d61d8327deb882cf99:password'],
   hasMore: false,
-} satisfies Awaited<ReturnType<typeof getZapsForTask>>
+} satisfies Awaited<ReturnType<GetZapsForTask>>
 
 mock.module('../../src/services/tasks.js', () => ({
   getZapsForTask: async () => zapsResult,

--- a/docs/solutions/conventions/contract-test-mocks-mirror-service-not-schema.md
+++ b/docs/solutions/conventions/contract-test-mocks-mirror-service-not-schema.md
@@ -1,0 +1,211 @@
+---
+module: packages/backend/tests, packages/backend/src/routes
+date: 2026-06-03
+problem_type: convention
+component: testing_framework
+severity: high
+related_components:
+  - documentation
+applies_when:
+  - "Authoring or updating contract tests for OpenAPIHono routes (agent, dashboard, or control surfaces)"
+  - "Mocking a service module imported by a route handler under test"
+  - "Adding or renaming fields in a route's request/response zod schema"
+  - "Reviewing a PR that touches both a route schema and the test that covers it"
+tags:
+  - contract-tests
+  - openapi
+  - hono
+  - zod-openapi
+  - mocks
+  - wire-contract
+  - agent-api
+  - test-isolation
+---
+
+# Contract-test mocks must mirror the service, not the schema
+
+## Context
+
+In PR #190 (the route-as-spec OpenAPI migration), three wire-contract regressions landed in a single commit and all 595 backend tests passed. The most severe: `packages/backend/src/routes/agent/index.ts` declared the `GET /tasks/{taskId}/zaps` response as `{ taskId: number, hashes: string[] }`, but the real service `getZapsForTask` in `packages/backend/src/services/tasks/zaps.ts` returns `{ zaps: string[], hasMore: boolean }`. The route handler does `c.json(result, 200)` and passes the service return verbatim.
+
+`OpenAPIHono.c.json()` does **not** validate the body against the declared response schema at runtime — it's a compile-time narrowing tool only. So the wrong-schema-vs-real-shape mismatch produced no runtime error.
+
+The contract test at `packages/backend/tests/unit/agent-api-contract.test.ts:147` (before the fix) returned `{ taskId: 1, hashes: [] }` from the `getZapsForTask` mock — matching the route schema, not the real service. So the route schema, the test mock, and the runtime response builder all agreed on the wrong shape. The test suite was green. The generated OpenAPI spec at `/api/v1/agent/openapi.json` actively lied about the wire contract, and agent codegen would have produced a Go client that silently dropped cracked hash lists.
+
+The bug was caught only because a Correctness reviewer in a multi-agent ce-code-review pass opened the actual service implementation and compared shapes. Two sister regressions in the same PR were caught the same way: a path-param rename from `{taskId}` to `{id}` (breaks Go codegen argument names) and a 200 body change from `{acknowledged: true}` to `{acknowledged: true, retried: false}` (breaks consumers with `disallowUnknownFields`). All three rode the same triangle — route schema, test mock, runtime response builder all agreed on a wrong shape.
+
+The historical precedent is issue #170: same test file (`agent-api-contract.test.ts`), same class of escape (contract test happy path masked a wire-contract violation). The structural enabler is documented in `GOTCHAS.md` ("Tests are NOT in the type-check scope") — test fixtures aren't type-checked against `@hashhive/shared`, so mocks can drift from the real service signature without compiler complaint.
+
+## Guidance
+
+Test mocks for cross-boundary contracts (route ↔ service) MUST be derived from the real implementation's return type, not from the schema under test. If the mock shape comes from the same source as the schema you're validating, you're testing the schema against itself.
+
+Two reinforcing techniques. Both are required on any contract test that mocks a service whose return value the route passes through to `c.json(...)`:
+
+**1. Pin the mock shape to the real service return type via `satisfies` (static fixtures).**
+
+```ts
+import type { getZapsForTask } from '../../src/services/tasks/zaps.js'
+
+const zapsResult = {
+  zaps: ['5f4dcc3b5aa765d61d8327deb882cf99:password'],
+  hasMore: false,
+} satisfies Awaited<ReturnType<typeof getZapsForTask>>
+
+mock.module('../../src/services/tasks.js', () => ({
+  getZapsForTask: async () => zapsResult,
+}))
+```
+
+`satisfies Awaited<ReturnType<typeof svc>>` lifts the mock into the type-check scope of the real service. If the service signature later changes, the mock fails type-check at `just check`. If the route schema drifts from the service, the route test will fail when the real response shape doesn't match what the contract test expects.
+
+**2. Type the factory body via `typeof svc` (dynamic-return mocks).**
+
+Some test files (e.g., `control-routes-rbac.test.ts`) mock services whose return value is computed per-call from mutable test-state arrays:
+
+```ts
+// Anti-pattern — no type constraint on the factory body
+mock.module('../../src/services/campaigns.js', () => ({
+  getCampaignById: async (id: number) => mockCampaigns.find((c) => c.id === id) ?? null,
+}))
+```
+
+The convention's static-fixture `satisfies` pattern can't apply directly here — there's no single fixture to pin. Instead, type the factory's callable shape:
+
+```ts
+import type { getCampaignById } from '../../src/services/campaigns.js'
+
+const getCampaignByIdMock: typeof getCampaignById = async (id) =>
+  mockCampaigns.find((c) => c.id === id) ?? null
+
+mock.module('../../src/services/campaigns.js', () => ({
+  getCampaignById: getCampaignByIdMock,
+}))
+```
+
+This requires that the underlying `mockCampaigns` state array carries full rows satisfying the real `Awaited<ReturnType<typeof getCampaignById>>` shape, not a stripped-down test-fixture shape. Expanding state arrays to carry full rows is part of adopting this convention for dynamic-return tests.
+
+**3. Add negative-shape assertions on every RED-fixed route and one representative case per YELLOW route per surface.**
+
+```ts
+const body = (await res.json()) as Record<string, unknown>
+expect(body['zaps']).toBeDefined()
+expect(body['hasMore']).toBe(false)
+// Pin the absence of the wrong keys so a regression that re-adds them fails loudly.
+expect(body['taskId']).toBeUndefined()
+expect(body['hashes']).toBeUndefined()
+```
+
+The negative assertion is cheap insurance against silent regression. A YELLOW route's mock pin catches drift in the service's return type, but it does **not** catch drift in the route handler's wire synthesis (route adds a derived field the service didn't return; mock pin still passes because the service return is unchanged; wire ships the new field; OpenAPI spec doesn't declare it). Negative-shape assertions are the only guard for that class of regression.
+
+## Why This Matters
+
+Routes that pass service results verbatim through `OpenAPIHono.c.json()` have **no runtime validation** between the service return value and the declared response schema. TypeScript narrowing only fires if you construct an object literal at the `c.json` call site; passing a variable typed as `unknown` or as the service return type silently widens, and the schema becomes documentation-only.
+
+This means the OpenAPI spec — the artifact downstream clients are generated from — can diverge from reality without any test catching it, as long as the test mock agrees with the (wrong) schema. The failure mode is the worst kind: green CI, generated client compiles, runtime behavior silently drops or mistypes fields. For HashHive's agent API specifically, the consumers are out-of-process Go binaries built from the spec; a wrong schema isn't a typo, it's a wire break that ships to every deployed agent on the next codegen.
+
+The systemic fix is to make the test mock answer to the real service, not the schema. If the schema is wrong, the contract test should fail. If the service changes, the mock should fail type-check. There should be no configuration of the three (route schema, mock, real service) where two agree and one diverges silently.
+
+Without this convention, the only line of defense is human review reading the actual service implementation — a contingent, expensive, and unreliable safety net.
+
+## When to Apply
+
+Apply when all three conditions hold:
+
+- The route handler returns a value sourced from a service or repository function (not constructed inline at the `c.json` call site).
+- The endpoint is consumed by generated client code — agent API, control API, any surface where the OpenAPI spec is the contract.
+- The test mocks the service module via `mock.module(...)` rather than exercising the real implementation.
+
+This covers essentially every contract test in `packages/backend/tests/unit/*-contract.test.ts` and the route tests in `packages/backend/tests/unit/{dashboard,control,agent}-*-routes.test.ts`. Routes that build response objects inline (e.g., `c.json({ ok: true }, 200)`) get compile-time narrowing for free and don't need the mock-shape technique, but the negative-shape assertion is still cheap and worth adding when the schema has optional or recently-added fields.
+
+Skip the pattern only for routes where the service return type IS the schema source — e.g., you've already derived the route's response schema from `z.infer<typeof serviceReturnSchema>` and the service is implemented to return that exact type. In that case the three artifacts are mechanically linked and can't drift.
+
+## Examples
+
+**Broken (what PR #190 shipped before review):**
+
+`packages/backend/src/routes/agent/index.ts`:
+
+```ts
+const zapResponseSchema = z
+  .object({ taskId: z.number(), hashes: z.array(z.string()) })
+  .passthrough()
+```
+
+`packages/backend/tests/unit/agent-api-contract.test.ts:147`:
+
+```ts
+mock.module('../../src/services/tasks.js', () => ({
+  getZapsForTask: async () => ({ taskId: 1, hashes: [] }),
+}))
+```
+
+Real service in `packages/backend/src/services/tasks/zaps.ts`:
+
+```ts
+export async function getZapsForTask(...): Promise<{ zaps: string[]; hasMore: boolean }> {
+  // ...
+  return { zaps, hasMore }
+}
+```
+
+595 tests pass. The OpenAPI spec advertises `{ taskId, hashes }`. The agent receives `{ zaps, hasMore }`. The Go client drops both fields.
+
+**Fixed:**
+
+Route schema corrected to match the service:
+
+```ts
+const zapResponseSchema = z.object({
+  zaps: z.array(z.string()),
+  hasMore: z.boolean(),
+})
+```
+
+Test mock pinned to the real return type:
+
+```ts
+import type { getZapsForTask } from '../../src/services/tasks/zaps.js'
+
+const zapsResult = {
+  zaps: ['5f4dcc3b5aa765d61d8327deb882cf99:password'],
+  hasMore: false,
+} satisfies Awaited<ReturnType<typeof getZapsForTask>>
+
+mock.module('../../src/services/tasks.js', () => ({
+  getZapsForTask: async () => zapsResult,
+}))
+```
+
+Test asserts both positive shape and negative absence:
+
+```ts
+const body = (await res.json()) as Record<string, unknown>
+expect(body['zaps']).toEqual(['5f4dcc3b5aa765d61d8327deb882cf99:password'])
+expect(body['hasMore']).toBe(false)
+expect(body['taskId']).toBeUndefined()
+expect(body['hashes']).toBeUndefined()
+```
+
+Now any of three independent edits will fail the test:
+
+- changing the route schema without updating the service → test fails on real shape mismatch
+- changing the service return shape without updating the mock → fails at `satisfies`
+- re-adding `taskId`/`hashes` to the response → fails the negative assertions
+
+The three artifacts can no longer agree on a wrong shape.
+
+## Anti-patterns
+
+**Do NOT extract a `fixtureSatisfying<T>(value)` helper.** A function-parameter `value: Awaited<ReturnType<TFn>>` widens the input to the union at the call boundary — exactly the widening `satisfies` exists to prevent. The helper structurally cannot preserve discriminated-union narrowing for cases like `updateCampaign` returning `{kind: 'updated', ...} | {kind: 'not_found'} | {kind: 'not_draft', ...}`. Use the bare `satisfies` form at every call site; the small repetition is correct.
+
+**Do NOT use explicit type annotations on the fixture.** `const fixture: Awaited<ReturnType<typeof svc>> = {...}` widens the fixture's literal type to the annotation — `as const` discriminants stop narrowing. Always use `satisfies`, never `:`.
+
+## Related
+
+- [`dashboard-read-endpoint-contract.md`](./dashboard-read-endpoint-contract.md) — sibling rule for *real* responses (round-trip through `.parse()`). This doc covers the *mocked-service* case; together they form: real responses are schema-conformant; mocked services are implementation-conformant.
+- [`bun-test-mock-module-import-order.md`](./bun-test-mock-module-import-order.md) — the other half of the silent-success problem in contract tests. That one is about whether `mock.module()` takes effect; this one is about whether the mock returns the right shape once it does.
+- [`projection-narrows-zrecord-wire-shape.md`](./projection-narrows-zrecord-wire-shape.md) — same family of contract-honesty failures, on the implementation side: a projection layer lying about runtime shape via `as` cast.
+- [`shared-zod-openapi-wire-contract-mirror-2026-05-25.md`](./shared-zod-openapi-wire-contract-mirror-2026-05-25.md) — superseded ancestor. The surviving rule #2 ("test round-trips real response through shared schema") is the rule this doc extends to the mocked-test case.
+- `GOTCHAS.md` "Tests are NOT in the type-check scope" — the structural enabler this convention compensates for procedurally.
+- PR #190 (this convention's evidence base) and historical precedent issue #170 — same test file (`agent-api-contract.test.ts`), same class of bug (contract test mocked the happy path with the wrong assumption about service behavior, so a wire-contract violation shipped under a green test).

--- a/packages/backend/tests/unit/agent-api-contract.test.ts
+++ b/packages/backend/tests/unit/agent-api-contract.test.ts
@@ -73,8 +73,23 @@ import {
   scrubAgentErrorContext as realScrubAgentErrorContext,
 } from '../../src/services/agents.js'
 
+// Service type imports for satisfies-pinning per the contract-test
+// mocks convention. Each fixture below is constrained against
+// `Awaited<ReturnType<typeof svc>>` so a signature drift in the
+// service surfaces as a type-check failure here.
+type AgentsHeartbeatService = typeof import('../../src/services/agents/heartbeat.js')
+type ProcessHeartbeatResult = Awaited<ReturnType<AgentsHeartbeatService['processHeartbeat']>>
+
+// processHeartbeat real return is `{agent: Agent|null, hasHighPriorityTasks,
+// taskFailureSummary?}`. The route only reads `hasHighPriorityTasks`, but
+// the pin catches any future widening that the route would then consume.
+const processHeartbeatFixture: ProcessHeartbeatResult = {
+  agent: null,
+  hasHighPriorityTasks: false,
+}
+
 mock.module('../../src/services/agents.js', () => ({
-  processHeartbeat: mock(() => Promise.resolve({ hasHighPriorityTasks: false })),
+  processHeartbeat: mock(() => Promise.resolve(processHeartbeatFixture)),
   logAgentError: mock(() => Promise.resolve()),
   // Real impls re-exported so sibling tests see the genuine functions
   // regardless of which file bun loads first.
@@ -138,15 +153,61 @@ import {
 // Mock tasks.js so the real module is never cached — the snake_case→camelCase
 // mapping is validated in tasks.test.ts; here we only test the route contract.
 // This also removes the need to mock campaigns.js (which tasks.js imported).
+//
+// Each fixture below is pinned via `satisfies Awaited<ReturnType<typeof svc>>`
+// per the contract-test mocks convention. The convention's first applied
+// use was the ZapResponse shape fix in PR #190; these pins close the loop
+// by enforcing the constraint statically so a service-side return-type
+// change surfaces at type-check rather than as a wire-shape regression.
+type TasksService = typeof import('../../src/services/tasks.js')
+type TasksRetryService = typeof import('../../src/services/tasks/retry.js')
+type TasksZapsService = typeof import('../../src/services/tasks/zaps.js')
+
+// Extract the task-row shape that both updateTaskProgress and
+// handleTaskFailure return on the success branch. They share the
+// Drizzle `tasks` table .returning() shape; deriving the type from
+// the service signature keeps the fixture pinned to the real shape
+// without having to import the Drizzle table type directly.
+type TaskUpdateSuccess = Extract<
+  Awaited<ReturnType<TasksService['updateTaskProgress']>>,
+  { task: unknown }
+>
+type TaskRow = TaskUpdateSuccess['task']
+
+// mockCamelCaseTask is built from mockSnakeCaseTaskRow with all the
+// camelCase keys the Drizzle `.returning()` produces. The cast is
+// constrained: if mockCamelCaseTask's keys/types don't satisfy
+// TaskRow, type-check fails here rather than at the route boundary.
+const taskRowFixture = mockCamelCaseTask as TaskRow
+
+// updateTaskProgress real return is `{task} | {error}`. The route's
+// `'error' in result` branch routes to 400; the {task} branch yields
+// the 200 ack body. Pin the success branch.
+const updateTaskProgressFixture: Awaited<ReturnType<TasksService['updateTaskProgress']>> = {
+  task: taskRowFixture,
+}
+// handleTaskFailure real return is `{task, retried} | {error}`. Mock
+// the success-no-retry branch.
+const handleTaskFailureFixture: Awaited<ReturnType<TasksRetryService['handleTaskFailure']>> = {
+  task: taskRowFixture,
+  retried: false,
+}
+// getZapsForTask real return is `{zaps, hasMore} | {error}`. PR #190 fixed
+// the shape; this pin enforces it stays correct.
+const getZapsForTaskFixture: Awaited<ReturnType<TasksZapsService['getZapsForTask']>> = {
+  zaps: [],
+  hasMore: false,
+}
+
 mock.module('../../src/services/tasks.js', () => ({
   assignNextTask: mock(() => Promise.resolve(mockCamelCaseTask)),
-  updateTaskProgress: mock(() => Promise.resolve({ acknowledged: true })),
-  handleTaskFailure: mock(() => Promise.resolve({ retried: false })),
+  updateTaskProgress: mock(() => Promise.resolve(updateTaskProgressFixture)),
+  handleTaskFailure: mock(() => Promise.resolve(handleTaskFailureFixture)),
   generateTasksForAttack: mock(() => Promise.resolve({ tasks: [], count: 0 })),
   reassignStaleTasks: mock(() => Promise.resolve([])),
   getTaskById: mock(() => Promise.resolve(null)),
   listTasks: mock(() => Promise.resolve([])),
-  getZapsForTask: mock(() => Promise.resolve({ zaps: [], hasMore: false })),
+  getZapsForTask: mock(() => Promise.resolve(getZapsForTaskFixture)),
   // Re-export real impls so sibling tests see the genuine functions.
   AGENT_TASK_ACTIVE_STATUSES: realAgentTaskActiveStatuses,
   projectAgentTaskRows: realProjectAgentTaskRows,

--- a/packages/backend/tests/unit/agent-api-contract.test.ts
+++ b/packages/backend/tests/unit/agent-api-contract.test.ts
@@ -83,10 +83,13 @@ type ProcessHeartbeatResult = Awaited<ReturnType<AgentsHeartbeatService['process
 // processHeartbeat real return is `{agent: Agent|null, hasHighPriorityTasks,
 // taskFailureSummary?}`. The route only reads `hasHighPriorityTasks`, but
 // the pin catches any future widening that the route would then consume.
-const processHeartbeatFixture: ProcessHeartbeatResult = {
+// Use `satisfies` rather than a type annotation so the fixture's literal
+// types aren't widened to the service's return-type union (the convention's
+// "Do NOT use explicit type annotations on the fixture" anti-pattern).
+const processHeartbeatFixture = {
   agent: null,
   hasHighPriorityTasks: false,
-}
+} satisfies ProcessHeartbeatResult
 
 mock.module('../../src/services/agents.js', () => ({
   processHeartbeat: mock(() => Promise.resolve(processHeartbeatFixture)),
@@ -175,39 +178,70 @@ type TaskUpdateSuccess = Extract<
 type TaskRow = TaskUpdateSuccess['task']
 
 // mockCamelCaseTask is built from mockSnakeCaseTaskRow with all the
-// camelCase keys the Drizzle `.returning()` produces. The cast is
-// constrained: if mockCamelCaseTask's keys/types don't satisfy
-// TaskRow, type-check fails here rather than at the route boundary.
-const taskRowFixture = mockCamelCaseTask as TaskRow
+// camelCase keys the Drizzle `.returning()` produces. `satisfies`
+// constrains the value without widening it: if mockCamelCaseTask's
+// keys/types don't satisfy TaskRow, type-check fails here rather
+// than at the route boundary. `as` would silently accept divergence.
+const taskRowFixture = mockCamelCaseTask satisfies TaskRow
 
 // updateTaskProgress real return is `{task} | {error}`. The route's
 // `'error' in result` branch routes to 400; the {task} branch yields
-// the 200 ack body. Pin the success branch.
-const updateTaskProgressFixture: Awaited<ReturnType<TasksService['updateTaskProgress']>> = {
+// the 200 ack body. Pin the success branch. `satisfies` keeps the
+// literal type narrow (per the convention's annotation anti-pattern).
+const updateTaskProgressFixture = {
   task: taskRowFixture,
-}
+} satisfies Awaited<ReturnType<TasksService['updateTaskProgress']>>
 // handleTaskFailure real return is `{task, retried} | {error}`. Mock
 // the success-no-retry branch.
-const handleTaskFailureFixture: Awaited<ReturnType<TasksRetryService['handleTaskFailure']>> = {
+const handleTaskFailureFixture = {
   task: taskRowFixture,
   retried: false,
-}
+} satisfies Awaited<ReturnType<TasksRetryService['handleTaskFailure']>>
 // getZapsForTask real return is `{zaps, hasMore} | {error}`. PR #190 fixed
 // the shape; this pin enforces it stays correct.
-const getZapsForTaskFixture: Awaited<ReturnType<TasksZapsService['getZapsForTask']>> = {
+const getZapsForTaskFixture = {
   zaps: [],
   hasMore: false,
-}
+} satisfies Awaited<ReturnType<TasksZapsService['getZapsForTask']>>
 
+// Sibling mocks pinned via `mock<typeof svc[fnName]>(...)` per the
+// contract-test mocks convention's dynamic-return pattern. Even though
+// only assignNextTask + updateTaskProgress + handleTaskFailure +
+// getZapsForTask are called by the agent routes under test, the others
+// must be present in the mock namespace (mock.module REPLACES, not
+// merges — exports omitted here are undefined for any module that
+// resolves tasks.js after this file loads). Pinning each return shape
+// makes a service signature drift surface here at construction time
+// instead of as undefined-method errors elsewhere.
+const listTasksEmpty = {
+  tasks: [],
+  total: 0,
+  limit: 50,
+  offset: 0,
+} satisfies Awaited<ReturnType<TasksService['listTasks']>>
+const reassignStaleEmpty = {
+  reassigned: 0,
+  rebalanced: 0,
+  failedOverrun: 0,
+  failedMaxRetries: 0,
+  errored: 0,
+} satisfies Awaited<ReturnType<TasksRetryService['reassignStaleTasks']>>
 mock.module('../../src/services/tasks.js', () => ({
-  assignNextTask: mock(() => Promise.resolve(mockCamelCaseTask)),
-  updateTaskProgress: mock(() => Promise.resolve(updateTaskProgressFixture)),
-  handleTaskFailure: mock(() => Promise.resolve(handleTaskFailureFixture)),
-  generateTasksForAttack: mock(() => Promise.resolve({ tasks: [], count: 0 })),
-  reassignStaleTasks: mock(() => Promise.resolve([])),
-  getTaskById: mock(() => Promise.resolve(null)),
-  listTasks: mock(() => Promise.resolve([])),
-  getZapsForTask: mock(() => Promise.resolve(getZapsForTaskFixture)),
+  assignNextTask: mock<TasksService['assignNextTask']>(async () => mockCamelCaseTask),
+  updateTaskProgress: mock<TasksService['updateTaskProgress']>(
+    async () => updateTaskProgressFixture
+  ),
+  handleTaskFailure: mock<TasksRetryService['handleTaskFailure']>(
+    async () => handleTaskFailureFixture
+  ),
+  generateTasksForAttack: mock<TasksService['generateTasksForAttack']>(async () => ({
+    tasks: [],
+    count: 0,
+  })),
+  reassignStaleTasks: mock<TasksRetryService['reassignStaleTasks']>(async () => reassignStaleEmpty),
+  getTaskById: mock<TasksService['getTaskById']>(async () => null),
+  listTasks: mock<TasksService['listTasks']>(async () => listTasksEmpty),
+  getZapsForTask: mock<TasksZapsService['getZapsForTask']>(async () => getZapsForTaskFixture),
   // Re-export real impls so sibling tests see the genuine functions.
   AGENT_TASK_ACTIVE_STATUSES: realAgentTaskActiveStatuses,
   projectAgentTaskRows: realProjectAgentTaskRows,
@@ -1442,6 +1476,32 @@ describe('Agent API: errored-agent rejection across work endpoints', () => {
 // restored the original `{ zaps, hasMore }` schema. This test pins
 // the contract against the real service mock so the wire shape and
 // the spec can never silently diverge again.
+
+describe('Agent API: POST /tasks/:id/report — wire shape', () => {
+  it('returns bare { acknowledged: true } body on the non-failure path', async () => {
+    // Arrange — default updateTaskProgress mock already returns the
+    // {task} success branch; route is supposed to emit the bare
+    // taskReportAckSchema body (no `retried` field).
+    const token = agentToken(TEST_AGENT_TOKEN)
+    const res = await app.request(`${AGENT_BASE}/tasks/42/report`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ status: 'running' }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body['acknowledged']).toBe(true)
+    // Negative-shape assertion: the bug PR #190 originally shipped had
+    // `retried: false` on the non-failure path, breaking consumers with
+    // `disallowUnknownFields`. The retried key MUST only appear on the
+    // failure-retry branch — pin its absence on the bare-success path.
+    expect(body['retried']).toBeUndefined()
+  })
+})
 
 describe('Agent API: GET /tasks/:id/zaps — wire shape', () => {
   it('returns { zaps, hasMore } body matching getZapsForTask runtime shape', async () => {

--- a/packages/backend/tests/unit/agent-api-contract.test.ts
+++ b/packages/backend/tests/unit/agent-api-contract.test.ts
@@ -205,14 +205,16 @@ const getZapsForTaskFixture = {
 } satisfies Awaited<ReturnType<TasksZapsService['getZapsForTask']>>
 
 // Sibling mocks pinned via `mock<typeof svc[fnName]>(...)` per the
-// contract-test mocks convention's dynamic-return pattern. Even though
-// only assignNextTask + updateTaskProgress + handleTaskFailure +
-// getZapsForTask are called by the agent routes under test, the others
-// must be present in the mock namespace (mock.module REPLACES, not
-// merges — exports omitted here are undefined for any module that
-// resolves tasks.js after this file loads). Pinning each return shape
-// makes a service signature drift surface here at construction time
-// instead of as undefined-method errors elsewhere.
+// contract-test mocks convention's dynamic-return pattern. Bun's
+// `mock.module` MERGES — non-mocked exports pass through to the real
+// module (per GOTCHAS.md "Shared module cache"). But the real
+// `services/tasks.js` pulls in DB / queue modules that this test's
+// mock graph can't load cleanly, so any export the route module
+// touches needs an explicit mock here to keep the merged namespace
+// import-safe. Only assignNextTask + updateTaskProgress +
+// handleTaskFailure + getZapsForTask are actually called from the
+// agent routes under test; the others are kept-and-pinned to harden
+// the namespace and to surface signature drift at construction time.
 const listTasksEmpty = {
   tasks: [],
   total: 0,

--- a/packages/backend/tests/unit/control-routes-rbac.test.ts
+++ b/packages/backend/tests/unit/control-routes-rbac.test.ts
@@ -30,9 +30,9 @@ if (!IS_ISOLATED) {
   //
   // The state arrays carry only the fields tests actually set; the
   // `make*` builders below expand each partial to a full Drizzle row
-  // so the typed factory bodies (per D4 of the contract-test-mocks
-  // convention) can satisfy `typeof svc` without losing test-fixture
-  // ergonomics.
+  // so the typed factory bodies (dynamic-return pattern from the
+  // contract-test-mocks-mirror-service-not-schema convention) can
+  // satisfy `typeof svc` without losing test-fixture ergonomics.
 
   interface MockMembership {
     userId: number
@@ -40,8 +40,8 @@ if (!IS_ISOLATED) {
     roles: string[]
   }
 
-  // Import service types so the typed-factory pattern (D4) can
-  // constrain mock factories against the real service signatures.
+  // Import service types so the typed-factory pattern can constrain
+  // mock factories against the real service signatures.
   type CampaignsService = typeof import('../../src/services/campaigns.js')
   type AgentsService = typeof import('../../src/services/agents.js')
   type FullCampaign = NonNullable<Awaited<ReturnType<CampaignsService['getCampaignById']>>>
@@ -104,9 +104,8 @@ if (!IS_ISOLATED) {
       authTokenFormat: 'plaintext',
       capabilities: {},
       hardwareProfile: {},
-      hashcatVersion: null,
+      crackerVersion: null,
       lastSeenAt: null,
-      lastErrorReportedAt: null,
       createdAt: new Date(),
       updatedAt: new Date(),
     }
@@ -154,8 +153,9 @@ if (!IS_ISOLATED) {
     campaign: makeCampaign({ id: 1, projectId: 1, status: 'running', name: 'Default' }),
   }
 
-  // Typed factory bodies — per D4 of the contract-test-mocks convention,
-  // type each factory function via `typeof svc` so the signature is
+  // Typed factory bodies — dynamic-return pattern from the
+  // contract-test-mocks-mirror-service-not-schema convention.
+  // Type each factory via `typeof svc[fnName]` so the signature is
   // constrained at definition time. A signature drift in the service
   // surfaces as a type-check failure here rather than as a runtime
   // wire-shape regression.

--- a/packages/backend/tests/unit/control-routes-rbac.test.ts
+++ b/packages/backend/tests/unit/control-routes-rbac.test.ts
@@ -27,6 +27,12 @@ if (!IS_ISOLATED) {
   })
 } else {
   // ─── Test state ───────────────────────────────────────────────────
+  //
+  // The state arrays carry only the fields tests actually set; the
+  // `make*` builders below expand each partial to a full Drizzle row
+  // so the typed factory bodies (per D4 of the contract-test-mocks
+  // convention) can satisfy `typeof svc` without losing test-fixture
+  // ergonomics.
 
   interface MockMembership {
     userId: number
@@ -34,11 +40,77 @@ if (!IS_ISOLATED) {
     roles: string[]
   }
 
+  // Import service types so the typed-factory pattern (D4) can
+  // constrain mock factories against the real service signatures.
+  type CampaignsService = typeof import('../../src/services/campaigns.js')
+  type AgentsService = typeof import('../../src/services/agents.js')
+  type FullCampaign = NonNullable<Awaited<ReturnType<CampaignsService['getCampaignById']>>>
+  type FullAttack = NonNullable<Awaited<ReturnType<CampaignsService['getAttackById']>>>
+  type FullAgent = NonNullable<Awaited<ReturnType<AgentsService['getAgentById']>>>
+
+  type CampaignPartial = Pick<FullCampaign, 'id' | 'projectId' | 'status' | 'name'>
+  type AttackPartial = Pick<FullAttack, 'id' | 'campaignId' | 'projectId'>
+  type AgentPartial = Pick<FullAgent, 'id' | 'projectId' | 'status' | 'name'>
+
   let mockMemberships: MockMembership[] = []
   let mockProjects: Array<{ id: number; name: string }> = []
-  let mockCampaigns: Array<{ id: number; projectId: number; status: string; name: string }> = []
-  let mockAgents: Array<{ id: number; projectId: number; status: string; name: string }> = []
-  let mockAttacks: Array<{ id: number; campaignId: number; projectId: number }> = []
+  let mockCampaigns: CampaignPartial[] = []
+  let mockAgents: AgentPartial[] = []
+  let mockAttacks: AttackPartial[] = []
+
+  // Builders expand the partial fixtures into full Drizzle rows so the
+  // mock factories below satisfy `typeof svc`. Each builder fills the
+  // optional/defaulted columns with realistic NULLs / empty-object
+  // defaults so the route handler downstream sees a representative row.
+  function makeCampaign(p: CampaignPartial): FullCampaign {
+    return {
+      ...p,
+      description: null,
+      hashListId: 1,
+      priority: 5,
+      progress: {},
+      metadata: {},
+      createdBy: null,
+      startedAt: null,
+      completedAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }
+  }
+
+  function makeAttack(p: AttackPartial): FullAttack {
+    return {
+      ...p,
+      mode: 0,
+      hashTypeId: null,
+      wordlistId: null,
+      rulelistId: null,
+      masklistId: null,
+      advancedConfiguration: {},
+      keyspace: null,
+      status: 'pending',
+      dependencies: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }
+  }
+
+  function makeAgent(p: AgentPartial): FullAgent {
+    return {
+      ...p,
+      operatingSystemId: null,
+      authToken: null,
+      authTokenHash: null,
+      authTokenFormat: 'plaintext',
+      capabilities: {},
+      hardwareProfile: {},
+      hashcatVersion: null,
+      lastSeenAt: null,
+      lastErrorReportedAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }
+  }
 
   function findMembership(userId: number, projectId: number) {
     return mockMemberships.find((m) => m.userId === userId && m.projectId === projectId) ?? null
@@ -74,46 +146,93 @@ if (!IS_ISOLATED) {
         })),
   }))
 
-  let mockTransitionResult: { campaign: object } | { error: string; code?: string } = {
-    campaign: {},
+  // `transitionCampaign` returns `{campaign: <row>} | {error, code?}`.
+  // Default to a "campaign present" shape so the happy path tests pass;
+  // individual tests override via `mockTransitionResult = {error: ...}`
+  // when they need to exercise a failure branch.
+  let mockTransitionResult: Awaited<ReturnType<CampaignsService['transitionCampaign']>> = {
+    campaign: makeCampaign({ id: 1, projectId: 1, status: 'running', name: 'Default' }),
   }
 
-  mock.module('../../src/services/campaigns.js', () => ({
-    getCampaignById: async (id: number) => mockCampaigns.find((c) => c.id === id) ?? null,
-    listCampaigns: async ({ projectId }: { projectId?: number }) => ({
-      campaigns: mockCampaigns.filter((c) => c.projectId === projectId),
-      total: mockCampaigns.filter((c) => c.projectId === projectId).length,
+  // Typed factory bodies — per D4 of the contract-test-mocks convention,
+  // type each factory function via `typeof svc` so the signature is
+  // constrained at definition time. A signature drift in the service
+  // surfaces as a type-check failure here rather than as a runtime
+  // wire-shape regression.
+  const getCampaignByIdMock: CampaignsService['getCampaignById'] = async (id) => {
+    const partial = mockCampaigns.find((c) => c.id === id)
+    return partial ? makeCampaign(partial) : null
+  }
+  const listCampaignsMock: CampaignsService['listCampaigns'] = async ({ projectId }) => {
+    const matched = mockCampaigns.filter((c) => c.projectId === projectId).map(makeCampaign)
+    return {
+      campaigns: matched,
+      total: matched.length,
       limit: 50,
       offset: 0,
-    }),
-    createCampaign: async (data: { projectId: number; name: string }) => ({
-      id: 999,
-      projectId: data.projectId,
-      name: data.name,
-      status: 'draft',
-    }),
-    updateCampaign: async (id: number) => ({ id }),
-    transitionCampaign: async () => mockTransitionResult,
-    listAttacks: async () => [],
-    listAttacksPaginated: async (campaignId: number) => ({
-      items: mockAttacks.filter((a) => a.campaignId === campaignId),
-      total: mockAttacks.filter((a) => a.campaignId === campaignId).length,
-    }),
-    getAttackById: async (id: number) => mockAttacks.find((a) => a.id === id) ?? null,
-    createAttack: async (data: { campaignId: number; projectId: number }) => ({ id: 888, ...data }),
-    updateAttack: async (id: number) => ({ id }),
-    deleteAttack: async () => undefined,
+    }
+  }
+  const createCampaignMock: CampaignsService['createCampaign'] = async (data) =>
+    makeCampaign({ id: 999, projectId: data.projectId, name: data.name, status: 'draft' })
+  // Discriminated-union return (`{kind: 'updated', campaign} | {kind:
+  // 'not_found'} | {kind: 'not_draft', status}`). Default to the
+  // happy `updated` branch; individual tests can override via
+  // mockImplementationOnce when they need to exercise the other kinds.
+  const updateCampaignMock: CampaignsService['updateCampaign'] = async (id, projectId) => ({
+    kind: 'updated',
+    campaign: makeCampaign({ id, projectId, status: 'draft', name: 'Updated' }),
+  })
+  const transitionCampaignMock: CampaignsService['transitionCampaign'] = async () =>
+    mockTransitionResult
+  const listAttacksMock: CampaignsService['listAttacks'] = async () => []
+  const listAttacksPaginatedMock: CampaignsService['listAttacksPaginated'] = async (campaignId) => {
+    const matched = mockAttacks.filter((a) => a.campaignId === campaignId).map(makeAttack)
+    return { items: matched, total: matched.length }
+  }
+  const getAttackByIdMock: CampaignsService['getAttackById'] = async (id) => {
+    const partial = mockAttacks.find((a) => a.id === id)
+    return partial ? makeAttack(partial) : null
+  }
+  const createAttackMock: CampaignsService['createAttack'] = async (data) =>
+    makeAttack({ id: 888, campaignId: data.campaignId, projectId: data.projectId })
+  const updateAttackMock: CampaignsService['updateAttack'] = async (id) =>
+    makeAttack({ id, campaignId: 1, projectId: 1 })
+  const deleteAttackMock: CampaignsService['deleteAttack'] = async () => null
+
+  mock.module('../../src/services/campaigns.js', () => ({
+    getCampaignById: getCampaignByIdMock,
+    listCampaigns: listCampaignsMock,
+    createCampaign: createCampaignMock,
+    updateCampaign: updateCampaignMock,
+    transitionCampaign: transitionCampaignMock,
+    listAttacks: listAttacksMock,
+    listAttacksPaginated: listAttacksPaginatedMock,
+    getAttackById: getAttackByIdMock,
+    createAttack: createAttackMock,
+    updateAttack: updateAttackMock,
+    deleteAttack: deleteAttackMock,
   }))
 
-  mock.module('../../src/services/agents.js', () => ({
-    listAgents: async ({ projectId }: { projectId?: number }) => ({
-      agents: mockAgents.filter((a) => a.projectId === projectId),
-      total: mockAgents.filter((a) => a.projectId === projectId).length,
+  const listAgentsMock: AgentsService['listAgents'] = async ({ projectId }) => {
+    const matched = mockAgents.filter((a) => a.projectId === projectId).map(makeAgent)
+    return {
+      agents: matched,
+      total: matched.length,
       limit: 50,
       offset: 0,
-    }),
-    getAgentById: async (id: number) => mockAgents.find((a) => a.id === id) ?? null,
-    updateAgent: async (id: number) => ({ id }),
+    }
+  }
+  const getAgentByIdMock: AgentsService['getAgentById'] = async (id) => {
+    const partial = mockAgents.find((a) => a.id === id)
+    return partial ? makeAgent(partial) : null
+  }
+  const updateAgentMock: AgentsService['updateAgent'] = async (id) =>
+    makeAgent({ id, projectId: 1, status: 'offline', name: 'Updated' })
+
+  mock.module('../../src/services/agents.js', () => ({
+    listAgents: listAgentsMock,
+    getAgentById: getAgentByIdMock,
+    updateAgent: updateAgentMock,
   }))
 
   mock.module('../../src/db/index.js', () => ({

--- a/packages/backend/tests/unit/control-routes-rbac.test.ts
+++ b/packages/backend/tests/unit/control-routes-rbac.test.ts
@@ -312,6 +312,14 @@ if (!IS_ISOLATED) {
         { id: 60, campaignId: 200, projectId: 2 },
       ]
       activeUserId = 1
+      // Reset the transitionCampaign mock to the happy {campaign}
+      // branch. Failure-branch tests later in this file mutate this
+      // shared variable in place; without the reset, the override
+      // leaks into any subsequent test that runs after them and
+      // depends on the happy default.
+      mockTransitionResult = {
+        campaign: makeCampaign({ id: 1, projectId: 1, status: 'running', name: 'Default' }),
+      }
     })
 
     describe('campaigns', () => {

--- a/packages/backend/tests/unit/crackers-routes.test.ts
+++ b/packages/backend/tests/unit/crackers-routes.test.ts
@@ -91,22 +91,25 @@ mock.module('../../src/services/auth.js', () => ({
 //
 // We mock the service so route-level behavior (validation, error mapping,
 // auth gates) is exercised without standing up a real DB. Service
-// behavior is covered in crackers.test.ts.
+// behavior is covered in crackers.test.ts. Per the
+// contract-test-mocks-mirror-service-not-schema convention, the mock
+// factories are typed via `typeof svc` so a signature drift in the
+// service surfaces here as a type-check failure.
 
-const mockListCrackerBinaries = mock(async () => [])
-const mockCreateCrackerBinary = mock(
-  async (data: { engine: string; version: string; platform: string }) => ({
-    id: 42,
-    engine: data.engine,
-    version: data.version,
-    platform: data.platform,
-    fileRef: {},
-    isActive: true,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  })
-)
-const mockGetCrackerBinaryById = mock(async (id: number) =>
+type CrackersService = typeof import('../../src/services/crackers.js')
+
+const mockListCrackerBinaries: CrackersService['listCrackerBinaries'] = mock(async () => [])
+const mockCreateCrackerBinary: CrackersService['createCrackerBinary'] = mock(async (data) => ({
+  id: 42,
+  engine: data.engine,
+  version: data.version,
+  platform: data.platform,
+  fileRef: {},
+  isActive: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+}))
+const mockGetCrackerBinaryById: CrackersService['getCrackerBinaryById'] = mock(async (id) =>
   id === 42
     ? {
         id: 42,
@@ -120,9 +123,11 @@ const mockGetCrackerBinaryById = mock(async (id: number) =>
       }
     : null
 )
-const mockGetLatestCracker = mock(async () => null)
-const mockGetCrackerDownloadUrl = mock(async () => null)
-const mockDeleteCrackerBinary = mock(async () => 'deleted' as const)
+const mockGetLatestCracker: CrackersService['getLatestCracker'] = mock(async () => null)
+const mockGetCrackerDownloadUrl: CrackersService['getCrackerDownloadUrl'] = mock(async () => null)
+const mockDeleteCrackerBinary: CrackersService['deleteCrackerBinary'] = mock(
+  async () => 'deleted' as const
+)
 
 class MockMismatch extends Error {
   constructor(

--- a/packages/backend/tests/unit/dashboard-agents-routes.test.ts
+++ b/packages/backend/tests/unit/dashboard-agents-routes.test.ts
@@ -80,8 +80,16 @@ type AgentsService = typeof import('../../src/services/agents.js')
 type TasksService = typeof import('../../src/services/tasks.js')
 type AgentRow = NonNullable<Awaited<ReturnType<AgentsService['getAgentById']>>>
 
+// Defaults come first so `??` falls through to safe values; the
+// trailing-spread footgun is avoided by enumerating every field
+// explicitly. Callers can still set any field via `p` (including
+// id/projectId from the Pick) and the `??` fallback covers absent
+// keys. Setting a field to `undefined` explicitly still hits the
+// default — that's the intended invariant.
 function makeAgent(p: Partial<AgentRow> & Pick<AgentRow, 'id' | 'projectId'>): AgentRow {
   return {
+    id: p.id,
+    projectId: p.projectId,
     name: p.name ?? `Agent ${p.id}`,
     status: p.status ?? 'online',
     operatingSystemId: p.operatingSystemId ?? null,
@@ -94,7 +102,6 @@ function makeAgent(p: Partial<AgentRow> & Pick<AgentRow, 'id' | 'projectId'>): A
     lastSeenAt: p.lastSeenAt ?? new Date(),
     createdAt: p.createdAt ?? new Date(),
     updatedAt: p.updatedAt ?? new Date(),
-    ...p,
   }
 }
 

--- a/packages/backend/tests/unit/dashboard-agents-routes.test.ts
+++ b/packages/backend/tests/unit/dashboard-agents-routes.test.ts
@@ -68,69 +68,59 @@ mock.module('../../src/services/auth.js', () => ({
 }))
 
 // ─── Mock the Agents Service Layer ───────────────────────────────────
+//
+// Per the contract-test-mocks-mirror-service-not-schema convention:
+// type the mock factories via `typeof svc` and derive the row shape
+// from the real service so a signature drift surfaces as a type-check
+// failure. A `makeAgent` builder fills the partial fixtures used by
+// tests with the full Drizzle row (operatingSystemId, authTokenHash,
+// authTokenFormat) so the mocks satisfy the real return type.
 
-const mockGetAgentById = mock(async (id: number) => {
-  if (id === 100) {
-    // Same-project agent.
-    return {
-      id: 100,
-      name: 'Rig Alpha',
-      status: 'online',
-      lastSeenAt: new Date(),
-      projectId: 1,
-      capabilities: null,
-      hardwareProfile: null,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      authToken: 'tok',
-      crackerVersion: null,
-    }
+type AgentsService = typeof import('../../src/services/agents.js')
+type TasksService = typeof import('../../src/services/tasks.js')
+type AgentRow = NonNullable<Awaited<ReturnType<AgentsService['getAgentById']>>>
+
+function makeAgent(p: Partial<AgentRow> & Pick<AgentRow, 'id' | 'projectId'>): AgentRow {
+  return {
+    name: p.name ?? `Agent ${p.id}`,
+    status: p.status ?? 'online',
+    operatingSystemId: p.operatingSystemId ?? null,
+    authToken: p.authToken ?? 'tok',
+    authTokenHash: p.authTokenHash ?? null,
+    authTokenFormat: p.authTokenFormat ?? 'plaintext',
+    capabilities: p.capabilities ?? {},
+    hardwareProfile: p.hardwareProfile ?? {},
+    crackerVersion: p.crackerVersion ?? null,
+    lastSeenAt: p.lastSeenAt ?? new Date(),
+    createdAt: p.createdAt ?? new Date(),
+    updatedAt: p.updatedAt ?? new Date(),
+    ...p,
   }
-  if (id === 200) {
-    // Foreign-project agent — same numeric id space, different project.
-    return {
-      id: 200,
-      name: 'Rig Beta',
-      status: 'online',
-      lastSeenAt: new Date(),
-      projectId: 999,
-      capabilities: null,
-      hardwareProfile: null,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      authToken: 'tok',
-      crackerVersion: null,
-    }
+}
+
+const mockGetAgentById: AgentsService['getAgentById'] = mock(async (id: number) => {
+  if (id === 100) return makeAgent({ id: 100, projectId: 1, name: 'Rig Alpha' })
+  if (id === 200) return makeAgent({ id: 200, projectId: 999, name: 'Rig Beta' })
+  return null
+})
+
+const mockUpdateAgent: AgentsService['updateAgent'] = mock(async (id, patch, projectId) => {
+  // Honors the atomic UPDATE WHERE projectId contract: id=100 lives
+  // in project 1, id=200 lives in project 999 (foreign). A mismatch
+  // collapses to null exactly the way the real query would after the
+  // 0 rows-affected.
+  if (id === 100 && projectId === 1) {
+    return makeAgent({
+      id: 100,
+      projectId: 1,
+      name: patch.name ?? 'Rig Alpha',
+      status: patch.status ?? 'online',
+    })
   }
   return null
 })
 
-const mockUpdateAgent = mock(
-  async (id: number, patch: { name?: string; status?: string }, projectId: number) => {
-    // Honors the atomic UPDATE WHERE projectId contract: id=100 lives
-    // in project 1, id=200 lives in project 999 (foreign). A mismatch
-    // collapses to null exactly the way the real query would after the
-    // 0 rows-affected.
-    if (id === 100 && projectId === 1) {
-      return {
-        id: 100,
-        name: patch.name ?? 'Rig Alpha',
-        status: patch.status ?? 'online',
-        lastSeenAt: new Date(),
-        projectId: 1,
-        capabilities: null,
-        hardwareProfile: null,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        authToken: 'tok',
-        crackerVersion: null,
-      }
-    }
-    return null
-  }
-)
-
-const mockRotateAgentToken = mock(async (agentId: number, projectId: number) => {
+const mockRotateAgentToken: AgentsService['rotateAgentToken'] = mock(async (agentId, projectId) => {
   // Mirrors the real service: same-project rotation succeeds and
   // returns the raw token once; cross-project hands back null so the
   // route maps to 404.
@@ -142,27 +132,42 @@ const mockRotateAgentToken = mock(async (agentId: number, projectId: number) => 
 
 mock.module('../../src/services/agents.js', () => ({
   getAgentById: mockGetAgentById,
-  getAgentErrors: mock(async () => []),
-  getBenchmarksForAgent: mock(async () => []),
-  listAgents: mock(async () => ({ agents: [], total: 0, limit: 50, offset: 0 })),
+  getAgentErrors: mock(
+    async () => [] satisfies Awaited<ReturnType<AgentsService['getAgentErrors']>>
+  ),
+  getBenchmarksForAgent: mock(
+    async () => [] satisfies Awaited<ReturnType<AgentsService['getBenchmarksForAgent']>>
+  ),
+  listAgents: mock(
+    async () =>
+      ({
+        agents: [],
+        total: 0,
+        limit: 50,
+        offset: 0,
+      }) satisfies Awaited<ReturnType<AgentsService['listAgents']>>
+  ),
   rotateAgentToken: mockRotateAgentToken,
   updateAgent: mockUpdateAgent,
 }))
 
 mock.module('../../src/services/tasks.js', () => ({
-  listTasksByAgent: mock(async () => [
-    {
-      id: 1,
-      campaignId: 1,
-      campaignName: 'Test Campaign',
-      attackId: 1,
-      attackMode: 0,
-      status: 'running',
-      progress: {},
-      startedAt: null,
-      assignedAt: null,
-    },
-  ]),
+  listTasksByAgent: mock(
+    async () =>
+      [
+        {
+          id: 1,
+          campaignId: 1,
+          campaignName: 'Test Campaign',
+          attackId: 1,
+          attackMode: 0,
+          status: 'running',
+          progress: {},
+          startedAt: null,
+          assignedAt: null,
+        },
+      ] satisfies Awaited<ReturnType<TasksService['listTasksByAgent']>>
+  ),
 }))
 
 // ─── Mock DB / Storage / Redis (route handlers don't reach these, but

--- a/packages/backend/tests/unit/dashboard-campaigns-routes.test.ts
+++ b/packages/backend/tests/unit/dashboard-campaigns-routes.test.ts
@@ -94,27 +94,21 @@ if (!IS_ISOLATED) {
   // Per the contract-test-mocks-mirror-service-not-schema convention:
   // local type aliases derive from the real service return types so a
   // signature drift in the service surfaces here as a type-check
-  // failure rather than as a wire-shape regression. The mocks below
-  // keep their existing Promise<X> return annotations; the annotations
-  // now bind to the real-service-derived types instead of independent
-  // local interfaces.
+  // failure rather than as a wire-shape regression. Every dynamic-return
+  // mock below is typed via `mock<CampaignsService['fnName']>(...)` per
+  // the convention's dynamic-return pattern; the type aliases (CampaignRow,
+  // UpdateCampaignResult, etc.) exist for the row builder and per-test
+  // assertions that need to name the shape directly.
   type CampaignsService = typeof import('../../src/services/campaigns.js')
   type CampaignRow = NonNullable<Awaited<ReturnType<CampaignsService['getCampaignById']>>>
-  type UpdateCampaignResult = Awaited<ReturnType<CampaignsService['updateCampaign']>>
-  type DeleteCampaignResult = Awaited<ReturnType<CampaignsService['deleteCampaign']>>
-  type ListCampaignsResult = Awaited<ReturnType<CampaignsService['listCampaigns']>>
-  // CreateWithAttacksResult and TransitionResult are used implicitly by
-  // the `mock<typeof svc>()` declarations below — they don't need
-  // standalone type aliases here.
+  type CreateWithAttacksResult = Awaited<ReturnType<CampaignsService['createCampaignWithAttacks']>>
 
-  const mockListCampaigns = mock(
-    async (_filters: Record<string, unknown>): Promise<ListCampaignsResult> => ({
-      campaigns: [],
-      total: 0,
-      limit: 50,
-      offset: 0,
-    })
-  )
+  const mockListCampaigns = mock<CampaignsService['listCampaigns']>(async () => ({
+    campaigns: [],
+    total: 0,
+    limit: 50,
+    offset: 0,
+  }))
 
   const makeCampaign = (overrides: Partial<CampaignRow> = {}): CampaignRow => ({
     id: 100,
@@ -134,27 +128,23 @@ if (!IS_ISOLATED) {
     ...overrides,
   })
 
-  const mockGetCampaignById = mock(async (id: number): Promise<CampaignRow | null> => {
+  const mockGetCampaignById = mock<CampaignsService['getCampaignById']>(async (id) => {
     if (id === 100) return makeCampaign()
     if (id === 101) return makeCampaign({ id: 101, status: 'running' })
     if (id === 200) return makeCampaign({ id: 200, projectId: 999 })
     return null
   })
 
-  const mockDeleteCampaign = mock(async (id: number): Promise<DeleteCampaignResult> => {
+  const mockDeleteCampaign = mock<CampaignsService['deleteCampaign']>(async (id) => {
     if (id === 100) return { kind: 'deleted', id: 100, projectId: 1 }
     if (id === 101) return { kind: 'not_draft', status: 'running' }
     return { kind: 'not_found' }
   })
 
-  const mockUpdateCampaign = mock(
-    async (
-      id: number,
-      _projectId: number,
-      data: Record<string, unknown>
-    ): Promise<UpdateCampaignResult> => {
+  const mockUpdateCampaign = mock<CampaignsService['updateCampaign']>(
+    async (id, _projectId, data) => {
       if (id === 100) {
-        return { kind: 'updated', campaign: makeCampaign({ ...data }) }
+        return { kind: 'updated', campaign: makeCampaign({ ...(data as Partial<CampaignRow>) }) }
       }
       if (id === 101) return { kind: 'not_draft', status: 'running' }
       return { kind: 'not_found' }
@@ -169,9 +159,6 @@ if (!IS_ISOLATED) {
     failed: 1,
   }))
 
-  // TransitionResult is derived above from the real service signature.
-  // The factory below uses the derived type instead of the prior
-  // hand-maintained local union.
   const mockTransitionCampaign = mock<CampaignsService['transitionCampaign']>(async () => ({
     campaign: makeCampaign(),
   }))
@@ -206,21 +193,17 @@ if (!IS_ISOLATED) {
     ): Promise<ResourceCheckResult> => ({ valid: true })
   )
 
-  // CreateWithAttacksResult is derived above from the real service.
-
-  const mockCreateCampaign = mock(
-    async (data: { name: string; projectId: number; hashListId: number }) =>
-      makeCampaign({ name: data.name, projectId: data.projectId, hashListId: data.hashListId })
+  const mockCreateCampaign = mock<CampaignsService['createCampaign']>(async (data) =>
+    makeCampaign({ name: data.name, projectId: data.projectId, hashListId: data.hashListId })
   )
 
-  const mockCreateCampaignWithAttacks = mock(
-    async (_input: {
-      attacks: ReadonlyArray<{ dependencyIndices?: number[] | undefined }>
-    }): Promise<CreateWithAttacksResult> => ({
-      kind: 'created',
-      campaign: makeCampaign(),
-      attacks: [],
-    })
+  const mockCreateCampaignWithAttacks = mock<CampaignsService['createCampaignWithAttacks']>(
+    async () =>
+      ({
+        kind: 'created',
+        campaign: makeCampaign(),
+        attacks: [],
+      }) satisfies CreateWithAttacksResult
   )
 
   const mockCreateAttack = mock(async () => ({ id: 555 }))

--- a/packages/backend/tests/unit/dashboard-campaigns-routes.test.ts
+++ b/packages/backend/tests/unit/dashboard-campaigns-routes.test.ts
@@ -90,27 +90,31 @@ if (!IS_ISOLATED) {
   }))
 
   // ─── Mock the Campaigns Service Layer ───────────────────────────────
+  //
+  // Per the contract-test-mocks-mirror-service-not-schema convention:
+  // local type aliases derive from the real service return types so a
+  // signature drift in the service surfaces here as a type-check
+  // failure rather than as a wire-shape regression. The mocks below
+  // keep their existing Promise<X> return annotations; the annotations
+  // now bind to the real-service-derived types instead of independent
+  // local interfaces.
+  type CampaignsService = typeof import('../../src/services/campaigns.js')
+  type CampaignRow = NonNullable<Awaited<ReturnType<CampaignsService['getCampaignById']>>>
+  type UpdateCampaignResult = Awaited<ReturnType<CampaignsService['updateCampaign']>>
+  type DeleteCampaignResult = Awaited<ReturnType<CampaignsService['deleteCampaign']>>
+  type ListCampaignsResult = Awaited<ReturnType<CampaignsService['listCampaigns']>>
+  // CreateWithAttacksResult and TransitionResult are used implicitly by
+  // the `mock<typeof svc>()` declarations below — they don't need
+  // standalone type aliases here.
 
   const mockListCampaigns = mock(
-    async (_filters: Record<string, unknown>) =>
-      ({ campaigns: [], total: 0, limit: 50, offset: 0 }) as const
+    async (_filters: Record<string, unknown>): Promise<ListCampaignsResult> => ({
+      campaigns: [],
+      total: 0,
+      limit: 50,
+      offset: 0,
+    })
   )
-
-  interface CampaignRow {
-    id: number
-    projectId: number
-    status: string
-    name: string
-    hashListId: number
-    priority: number
-    description: string | null
-    progress: Record<string, unknown> | null
-    createdAt: Date
-    startedAt: Date | null
-    completedAt: Date | null
-    updatedAt: Date
-    createdBy: number | null
-  }
 
   const makeCampaign = (overrides: Partial<CampaignRow> = {}): CampaignRow => ({
     id: 100,
@@ -121,6 +125,7 @@ if (!IS_ISOLATED) {
     priority: 5,
     description: null,
     progress: {},
+    metadata: {},
     createdAt: new Date('2026-01-01'),
     startedAt: null,
     completedAt: null,
@@ -136,24 +141,11 @@ if (!IS_ISOLATED) {
     return null
   })
 
-  const mockDeleteCampaign = mock(
-    async (
-      id: number
-    ): Promise<
-      | { kind: 'deleted'; id: number; projectId: number }
-      | { kind: 'not_found' }
-      | { kind: 'not_draft'; status: string }
-    > => {
-      if (id === 100) return { kind: 'deleted', id: 100, projectId: 1 }
-      if (id === 101) return { kind: 'not_draft', status: 'running' }
-      return { kind: 'not_found' }
-    }
-  )
-
-  type UpdateCampaignResult =
-    | { kind: 'updated'; campaign: CampaignRow }
-    | { kind: 'not_found' }
-    | { kind: 'not_draft'; status: string }
+  const mockDeleteCampaign = mock(async (id: number): Promise<DeleteCampaignResult> => {
+    if (id === 100) return { kind: 'deleted', id: 100, projectId: 1 }
+    if (id === 101) return { kind: 'not_draft', status: 'running' }
+    return { kind: 'not_found' }
+  })
 
   const mockUpdateCampaign = mock(
     async (
@@ -177,20 +169,12 @@ if (!IS_ISOLATED) {
     failed: 1,
   }))
 
-  type TransitionErrorCode =
-    | 'QUEUE_UNAVAILABLE'
-    | 'INVALID_TRANSITION'
-    | 'NOT_FOUND'
-    | 'RESOURCE_MISSING'
-    | 'RESOURCE_VALIDATION_FAILED'
-    | 'STALE_STATE'
-    | 'TASK_GENERATION_FAILED'
-  type TransitionResult =
-    | { campaign: { id: number; status: string } | null }
-    | { error: string; code?: TransitionErrorCode }
-  const mockTransitionCampaign = mock<(id: number, target: string) => Promise<TransitionResult>>(
-    async () => ({ campaign: null })
-  )
+  // TransitionResult is derived above from the real service signature.
+  // The factory below uses the derived type instead of the prior
+  // hand-maintained local union.
+  const mockTransitionCampaign = mock<CampaignsService['transitionCampaign']>(async () => ({
+    campaign: makeCampaign(),
+  }))
 
   const mockListActiveAgentsByCampaign = mock(async (_id: number) => [
     {
@@ -222,14 +206,7 @@ if (!IS_ISOLATED) {
     ): Promise<ResourceCheckResult> => ({ valid: true })
   )
 
-  type CreateWithAttacksResult =
-    | {
-        kind: 'created'
-        campaign: CampaignRow
-        attacks: Array<{ id: number; dependencies: number[] | null }>
-      }
-    | { kind: 'dag_invalid'; error: string }
-    | { kind: 'resource_missing'; missing: string[] }
+  // CreateWithAttacksResult is derived above from the real service.
 
   const mockCreateCampaign = mock(
     async (data: { name: string; projectId: number; hashListId: number }) =>

--- a/packages/backend/tests/unit/dashboard-resources-routes.test.ts
+++ b/packages/backend/tests/unit/dashboard-resources-routes.test.ts
@@ -184,7 +184,11 @@ if (!IS_ISOLATED) {
     getHashListById: mockGetHashListById,
     listHashLists: inertList,
     listHashListsPaginated: mock(async () => ({ items: [], total: 0 })),
-    getHashItems: mock(async () => ({ items: [], total: 0 })),
+    // Real getHashItems returns `{items, total, limit, offset} | null`.
+    // Mock shape pinned to match; the prior `{items, total}` stub
+    // missed the limit/offset fields the route passes through to the
+    // wire (and the null branch the route maps to 404).
+    getHashItems: mock(async () => ({ items: [], total: 0, limit: 50, offset: 0 })),
     getHashListStats: mock(async () => ({
       totalCount: 0,
       crackedCount: 0,
@@ -200,7 +204,14 @@ if (!IS_ISOLATED) {
     uploadResourceFile: mock(async () => ({ key: 'k', size: 0 })),
     deleteResource: mock(async () => true),
     getResourcePresignedUrl: mock(async () => 'https://example/test'),
-    getAgentDownloadUrl: mock(async () => 'https://example/test'),
+    // Real getAgentDownloadUrl returns `{url, expiresIn} | null`. No
+    // dashboard route consumes this service from this test file's
+    // surface, but `routes/agent/index.ts` imports the function at
+    // module-load time so the export must exist in the mocked module
+    // (bun's mock.module replaces the namespace; missing exports break
+    // import resolution for transitive consumers). Pinned to the real
+    // shape per the contract-test-mocks convention.
+    getAgentDownloadUrl: mock(async () => ({ url: 'https://example/test', expiresIn: 600 })),
     // String helper used by results routes.
     escapeLike: (s: string) => s,
     // Chunked upload

--- a/packages/backend/tests/unit/dashboard-resources-routes.test.ts
+++ b/packages/backend/tests/unit/dashboard-resources-routes.test.ts
@@ -185,10 +185,18 @@ if (!IS_ISOLATED) {
     listHashLists: inertList,
     listHashListsPaginated: mock(async () => ({ items: [], total: 0 })),
     // Real getHashItems returns `{items, total, limit, offset} | null`.
-    // Mock shape pinned to match; the prior `{items, total}` stub
-    // missed the limit/offset fields the route passes through to the
-    // wire (and the null branch the route maps to 404).
-    getHashItems: mock(async () => ({ items: [], total: 0, limit: 50, offset: 0 })),
+    // Mock shape pinned via `satisfies` so the mirror-service-not-schema
+    // convention's static-fixture pattern fails type-check (in any tool
+    // that includes test files) if the service shape drifts. The prior
+    // `{items, total}` stub missed the limit/offset fields the route
+    // passes through to the wire (and the null branch the route maps
+    // to 404).
+    getHashItems: mock(
+      async () =>
+        ({ items: [], total: 0, limit: 50, offset: 0 }) satisfies NonNullable<
+          Awaited<ReturnType<typeof import('../../src/services/resources.js').getHashItems>>
+        >
+    ),
     getHashListStats: mock(async () => ({
       totalCount: 0,
       crackedCount: 0,
@@ -207,11 +215,20 @@ if (!IS_ISOLATED) {
     // Real getAgentDownloadUrl returns `{url, expiresIn} | null`. No
     // dashboard route consumes this service from this test file's
     // surface, but `routes/agent/index.ts` imports the function at
-    // module-load time so the export must exist in the mocked module
-    // (bun's mock.module replaces the namespace; missing exports break
-    // import resolution for transitive consumers). Pinned to the real
-    // shape per the contract-test-mocks convention.
-    getAgentDownloadUrl: mock(async () => ({ url: 'https://example/test', expiresIn: 600 })),
+    // module-load time. Bun's `mock.module` MERGES — non-mocked
+    // exports pass through to the real module (per GOTCHAS.md "Shared
+    // module cache"). However, the real `services/resources.ts` pulls
+    // in DB / S3 modules that this test's mock graph doesn't provide,
+    // so the real export can't load cleanly; providing an explicit
+    // mock here keeps the merged namespace import-safe for transitive
+    // consumers. Pinned via `satisfies` per the convention's static-
+    // fixture pattern.
+    getAgentDownloadUrl: mock(
+      async () =>
+        ({ url: 'https://example/test', expiresIn: 600 }) satisfies NonNullable<
+          Awaited<ReturnType<typeof import('../../src/services/resources.js').getAgentDownloadUrl>>
+        >
+    ),
     // String helper used by results routes.
     escapeLike: (s: string) => s,
     // Chunked upload

--- a/packages/backend/tests/unit/dashboard-tasks-routes.test.ts
+++ b/packages/backend/tests/unit/dashboard-tasks-routes.test.ts
@@ -79,8 +79,13 @@ const mockListTasks = mock(async (filters: { projectId: number }) => ({
 
 const mockGetTaskById = mock(async (id: number, projectId: number) => {
   // Task 100 lives in project 1; task 200 lives in project 999 (foreign).
+  // Real `getTaskById` returns the tasks DB row (no `projectId` column —
+  // that's joined from campaigns at the service-layer query). The mock
+  // previously included a ghost `projectId` field that would leak to
+  // the wire if any future route refactor passed the result through to
+  // c.json() verbatim. Stripped per the contract-test-mocks convention.
   if (id === 100 && projectId === 1) {
-    return { id: 100, campaignId: 7, status: 'pending', projectId: 1 }
+    return { id: 100, campaignId: 7, status: 'pending' }
   }
   return null
 })

--- a/packages/backend/tests/unit/dashboard-tasks-routes.test.ts
+++ b/packages/backend/tests/unit/dashboard-tasks-routes.test.ts
@@ -68,25 +68,49 @@ mock.module('../../src/services/auth.js', () => ({
 // ─── Mock Tasks Service Layer ────────────────────────────────────────
 //
 // The mocks capture the `projectId` argument so the tests can assert
-// the route correctly forwarded the session-scoped project.
+// the route correctly forwarded the session-scoped project. Both
+// factories are typed via `mock<TasksService['fnName']>(...)` per the
+// contract-test-mocks-mirror-service-not-schema convention's
+// dynamic-return pattern — signature drift in `tasks.ts` surfaces here
+// as a type-check failure instead of a wire-shape regression.
+type TasksService = typeof import('../../src/services/tasks.js')
+type TaskRow = NonNullable<Awaited<ReturnType<TasksService['getTaskById']>>>
 
-const mockListTasks = mock(async (filters: { projectId: number }) => ({
-  tasks: filters.projectId === 1 ? [{ id: 42, campaignId: 7, status: 'pending' }] : [],
+// Minimal task row built from the real Drizzle shape so the mock
+// satisfies `typeof svc`. Fields the route doesn't read get safe
+// defaults; the route only inspects id/campaignId/status today.
+const taskRowFixture = {
+  id: 42,
+  attackId: 0,
+  campaignId: 7,
+  agentId: null,
+  status: 'pending',
+  workRange: {},
+  progress: {},
+  resultStats: {},
+  requiredCapabilities: {},
+  assignedAt: null,
+  startedAt: null,
+  completedAt: null,
+  failureReason: null,
+  retryCount: 0,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+} satisfies TaskRow
+
+const mockListTasks = mock<TasksService['listTasks']>(async (filters) => ({
+  tasks: filters.projectId === 1 ? [{ ...taskRowFixture, id: 42 }] : [],
   total: filters.projectId === 1 ? 1 : 0,
   limit: 50,
   offset: 0,
 }))
 
-const mockGetTaskById = mock(async (id: number, projectId: number) => {
-  // Task 100 lives in project 1; task 200 lives in project 999 (foreign).
-  // Real `getTaskById` returns the tasks DB row (no `projectId` column —
-  // that's joined from campaigns at the service-layer query). The mock
-  // previously included a ghost `projectId` field that would leak to
-  // the wire if any future route refactor passed the result through to
-  // c.json() verbatim. Stripped per the contract-test-mocks convention.
-  if (id === 100 && projectId === 1) {
-    return { id: 100, campaignId: 7, status: 'pending' }
-  }
+// Real `getTaskById` returns the tasks DB row (no `projectId` column —
+// that's joined from campaigns at the service-layer query). The mock's
+// shape is now pinned to the real return type via `mock<typeof svc>`,
+// so any future addition of a ghost field would fail type-check here.
+const mockGetTaskById = mock<TasksService['getTaskById']>(async (id, projectId) => {
+  if (id === 100 && projectId === 1) return { ...taskRowFixture, id: 100 }
   return null
 })
 
@@ -147,8 +171,14 @@ describe('Dashboard tasks routes: project isolation (S-H1)', () => {
       headers: { cookie: ADMIN_COOKIE },
     })
     expect(res.status).toBe(200)
-    const body = (await res.json()) as { task?: { id?: number } }
-    expect(body.task?.id).toBe(100)
+    const body = (await res.json()) as { task?: Record<string, unknown> }
+    expect(body.task?.['id']).toBe(100)
+    // Negative-shape assertion (convention's technique 3): the real
+    // service return has no `projectId` column (it's joined from
+    // campaigns server-side). A regression that re-introduces a ghost
+    // projectId on the wire would leak the JOIN concern and confuse
+    // dashboard consumers; pin its absence.
+    expect(body.task?.['projectId']).toBeUndefined()
   })
 
   it('GET /:id returns 404 for task in foreign project (service returns null)', async () => {


### PR DESCRIPTION
## Summary

Applies the `contract-test-mocks-mirror-service-not-schema` convention across every audited contract/route test file. Test-only changes; no production code, no wire-contract impact.

**All 6 units shipped (U0-U5).** All test files in the audit scope now have their service mocks pinned via `typeof svc` or `satisfies Awaited<ReturnType<typeof svc>>` so future service-surface drift surfaces as type-check failure rather than silent test/route divergence.

## What Changed

### U0 - Convention doc (`7a1be9a`)
Lands `docs/solutions/conventions/contract-test-mocks-mirror-service-not-schema.md` -- the authority source for the rest of the rollout. Codifies the lesson from PR #190's three wire-contract regressions; prescribes `satisfies Awaited<ReturnType<typeof svc>>` for static-fixture mocks and `const fnMock: typeof svc` for dynamic-return mocks; documents the anti-patterns (no `fixtureSatisfying<T>` helper, no explicit type annotations).

### U1 - `control-routes-rbac.test.ts` (`8ceb8f1`)
Highest-risk file (control API surface, planned CLI/TUI codegen consumers). 9 RED shape corrections:

- State arrays (`mockCampaigns`, `mockAgents`, `mockAttacks`) now carry partial fields tests actually set; new `make{Campaign,Attack,Agent}` builders expand them to full Drizzle rows.
- Each mock factory declared as `const fnMock: typeof svc = ...` -- signature drift in the service surfaces as type-check failure here.
- `updateCampaign` mock returns the real `{kind: 'updated', campaign}` discriminated union (was `{id}` stub that didn't match any branch of the union).
- `transitionCampaign` mock typed against its real return.

21 tests pass under `CONTROL_RBAC_TEST_ISOLATED=1`.

### U2 - `agent-api-contract.test.ts` (`1ccbaa2`)
Closes the PR #190 loop. 2 RED + ~10 satisfies pins:

- `processHeartbeat` fixture pinned to full real return (`{agent, hasHighPriorityTasks, taskFailureSummary?}`).
- `updateTaskProgress` + `handleTaskFailure` fixtures pinned to the success (`{task, ...}`) branch of their discriminated-union returns. Prior shapes (`{acknowledged:true}`, `{retried:false}`) weren't in either union.
- `getZapsForTask` fixture pinned to `{zaps, hasMore}` -- the convention's namesake regression.
- Shared `TaskRow` extracted from `updateTaskProgress`'s success variant so both task-mutation fixtures derive from one source.

50 tests pass.

### U3 - `dashboard-resources-routes.test.ts` + `dashboard-tasks-routes.test.ts` (`3fa9e68`)
Three RED fixes:

- `getHashItems`: shape corrected to `{items, total, limit, offset} | null`.
- `getAgentDownloadUrl`: shape corrected to `{url, expiresIn} | null`. Kept in the mock because `routes/agent/index.ts` imports it transitively into the module graph.
- `getTaskById`: stripped ghost `projectId` field that doesn't exist on the real Drizzle return.

17 + 4 tests pass.

### U4 - `dashboard-campaigns-routes.test.ts` (`b4ff258`)
Replaced 6 local interfaces (`CampaignRow`, `UpdateCampaignResult`, `DeleteCampaignResult`, `ListCampaignsResult`, etc.) with `typeof import` derivations from `services/campaigns.js`. Added `metadata: {}` to `makeCampaign` (real Drizzle row has it; local interface didn't). `mockTransitionCampaign = mock<CampaignsService['transitionCampaign']>(...)`.

101 tests pass.

### U5 - `dashboard-agents-routes.test.ts` + `crackers-routes.test.ts` (`a06579d`)
Final YELLOW-batch pinning:

- `dashboard-agents-routes.test.ts`: `getAgentById`/`updateAgent`/`rotateAgentToken` typed via `const fnMock: typeof svc = mock(...)`. New `makeAgent` builder expands partial fixtures to full Drizzle rows (added `operatingSystemId`, `authTokenHash`, `authTokenFormat` fields the prior inline mocks omitted). Inline `getAgentErrors`/`getBenchmarksForAgent`/`listAgents`/`listTasksByAgent` factories use `satisfies Awaited<ReturnType<typeof svc>>`.
- `crackers-routes.test.ts`: all service mocks typed via `CrackersService['fnName']`. Service shapes already matched real returns per the audit; the pin enforces it stays that way.

12 + 14 tests pass.

### Lockfile sync (`d062678`)
Regenerated `bun.lock` to align `@aws-sdk/client-s3` and `@aws-sdk/s3-request-presigner` at 3.1054.0 (dependabot bumped `package.json` but not the lockfile). Resolved the CI-only TS2379 in `src/config/storage.ts:130`.

## Test plan

- [x] `just check` green
- [x] `just ci-check` green: 613 backend tests pass + 5 e2e
- [x] All six units verified with their isolated test invocations
- [x] CI green on the PR
