### PR TITLE
fix(deps): bump oxfmt/oxlint lockfile; close already-fixed #227

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -149,11 +149,11 @@ version = "0.22.1"
 backend = "npm:markdownlint-cli2"
 
 [[tools.oxfmt]]
-version = "0.54.0"
+version = "0.55.0"
 backend = "npm:oxfmt"
 
 [[tools.oxlint]]
-version = "1.69.0"
+version = "1.70.0"
 backend = "npm:oxlint"
 
 [[tools."pipx:mdformat"]]


### PR DESCRIPTION
## Summary

Small dependency lockfile bump for the local toolchain:

- `oxfmt` -> 0.55.0
- `oxlint` -> 1.70.0

## Why this also closes #227

While investigating #227 (SPA deep-link / page-refresh on sub-routes redirecting to the dashboard), I confirmed the bug was **already fixed and regression-tested** when PR #226 (commit `624a8be`) merged to `main`. The issue was simply never closed.

The fix and its coverage are all present on `main`:

- **`ProtectedRoute` hydration gate** (`packages/frontend/src/components/features/protected-route.tsx`) waits on `hasFetchedProjects` before deciding "no project -> redirect", so a cold load of a sub-route no longer discards the requested route.
- **Unit tests** (`packages/frontend/tests/components/protected-route.test.tsx`, `tests/stores/auth.test.ts`) cover cold-load loading, deep-link preservation, no-project, and failed-fetch (no-hang) paths. Verified green locally (11/11).
- **E2E regression spec** (`packages/frontend/e2e/zz-deep-link.spec.ts`) explicitly labeled "Regression for issue #227"; asserts deep-link + refresh hold on sub-routes. Passed in CI (`e2e-tests`) on the #226 merge.
- **Spec doc** (`docs/issues/227-spa-deep-link-refresh-redirect-spec.md`).

No further code change was needed for #227. This PR carries the pending lockfile bump and uses it to close the dangling ticket.

### Note (not part of #227)

The gate fully resolves the filed repro (single-project / server-preselected operator). A multi-project user with no server preselection who deep-links to a sub-route would still route through `/select-project` and land on `/` after picking, which is distinct from the reported bug and arguably correct (no project chosen yet).

Closes #227

## Test plan

- [x] Carrier change is lockfile-only (`mise.lock`, 2 lines).
- [x] #227 fix verified present on `main`; unit tests green locally; e2e regression passed in CI on #226.
- [ ] CI `ci-check` + `e2e-tests` green on this PR.
