### PR TITLE
feat(e2e): Linux Playwright visual-baseline workflow + dashboard spec hardening (#201)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,15 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   e2e-tests:
-    runs-on: ubuntu-latest
+    # Pinned to a dated image, NOT ubuntu-latest: this job validates the
+    # committed Playwright visual baseline (packages/frontend/e2e/*-snapshots),
+    # whose pixels depend on the runner's system font stack (freetype,
+    # fontconfig). ubuntu-latest is a rolling alias; an alias migration would
+    # change the font stack and make the frozen baseline self-diff with no code
+    # to blame. Keep this in lockstep with regenerate-visual-baselines.yml —
+    # bump both together and regenerate the baseline when changing the image.
+    # See docs/solutions/conventions/playwright-visual-baselines.md.
+    runs-on: ubuntu-24.04
     needs: ci-check
     steps:
       - name: Checkout code

--- a/.github/workflows/regenerate-visual-baselines.yml
+++ b/.github/workflows/regenerate-visual-baselines.yml
@@ -1,0 +1,88 @@
+name: Regenerate visual baselines
+
+# Generates the canonical Linux Playwright visual baseline(s) on a GitHub
+# runner — the ONLY environment whose font stack the committed PNGs must
+# match (macOS/Windows local renders differ and must never be committed).
+#
+# Two triggers, one job:
+#   - pull_request (label-gated): bootstrap / on-branch regeneration. A
+#     same-repo PR runs the workflow version from the PR head branch, so this
+#     works before the workflow ever reaches main. Add the `regen-baselines`
+#     label to a PR to fire it; remove the label once the PNG is committed.
+#   - workflow_dispatch: steady-state intentional updates, available once this
+#     workflow is on the default branch.
+#
+# The job NEVER commits. It uploads the generated snapshot directory as an
+# artifact; a human downloads it (`gh run download -n visual-baselines`) and
+# commits the PNG alongside the unskip. See
+# docs/solutions/conventions/playwright-visual-baselines.md.
+'on':
+  workflow_dispatch:
+  pull_request:
+    types: [labeled]
+
+# A label-driven push storm should not pile up runner slots; cancel a
+# superseded run. workflow_dispatch falls back to run_id (no cross-run cancel).
+concurrency:
+  group: regen-baselines-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+# Read-only: the job generates and uploads an artifact; it never pushes.
+permissions:
+  contents: read
+
+jobs:
+  regenerate:
+    # Only run on explicit dispatch or when the gate label is present.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'regen-baselines')
+    # MUST match the e2e-tests job image in ci.yml — generation and validation
+    # render against the same system font stack. Bump both together.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          install: true
+          cache: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: just install
+      - run: just build
+
+      # Pinned-Playwright install (never `bunx playwright install`) — same
+      # rationale as the e2e-tests job in ci.yml.
+      - name: Install Playwright browsers
+        run: mise x -- bun --filter @hashhive/frontend test:e2e:install
+
+      # Ephemeral unskip — CI workspace only, NEVER committed. `--update-snapshots`
+      # does not run a `test.skip` test, so the visual baseline test must be
+      # active for generation. Assert exactly one skipped marker so a future
+      # second skip in the file can't silently change what gets generated.
+      - name: Ephemeral unskip of visual baseline test
+        run: |
+          set -euo pipefail
+          SPEC=packages/frontend/e2e/zz-dashboard.spec.ts
+          count=$(grep -cF "test.skip('dashboard visual baseline" "$SPEC" || true)
+          if [ "$count" -ne 1 ]; then
+            echo "::error::Expected exactly 1 skipped visual baseline marker, found $count in $SPEC" >&2
+            exit 1
+          fi
+          sed -i "s/test\.skip('dashboard visual baseline/test('dashboard visual baseline/" "$SPEC"
+          if grep -qF "test.skip('dashboard visual baseline" "$SPEC"; then
+            echo "::error::Ephemeral unskip failed — marker still present in $SPEC" >&2
+            exit 1
+          fi
+
+      - name: Generate dashboard visual baseline
+        run: mise x -- bun --filter @hashhive/frontend test:e2e:update:dashboard
+
+      - name: Upload generated baseline(s)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: visual-baselines
+          path: packages/frontend/e2e/zz-dashboard.spec.ts-snapshots/
+          if-no-files-found: error

--- a/docs/solutions/conventions/playwright-visual-baselines.md
+++ b/docs/solutions/conventions/playwright-visual-baselines.md
@@ -65,7 +65,11 @@ the PNG as an artifact — it never commits.
 1. **Trigger generation.**
    - On a branch / for a brand-new baseline: open the PR and add the
      `regen-baselines` label (a same-repo PR runs the workflow from the PR head
-     branch, so this works before the workflow is on `main`).
+     branch, so this works before the workflow is on `main`). Applying the label
+     runs the PR head's code on a runner — only label a PR (especially a fork PR)
+     after reviewing its code. The workflow uses `pull_request` (read-only token,
+     no secrets), so the blast radius is the ephemeral runner, but the label is
+     an intentional opt-in, not a rubber stamp.
    - For steady-state updates once the workflow is on `main`: run it via
      `workflow_dispatch` (`gh workflow run regenerate-visual-baselines.yml`).
 2. **Download the artifact:** `gh run download <run-id> -n visual-baselines`

--- a/docs/solutions/conventions/playwright-visual-baselines.md
+++ b/docs/solutions/conventions/playwright-visual-baselines.md
@@ -1,0 +1,117 @@
+---
+module: packages/frontend/e2e, .github/workflows
+date: 2026-06-23
+status: active
+problem_type: convention
+component: e2e-testing
+severity: medium
+applies_when:
+  - "Adding or updating a Playwright visual-regression baseline (toHaveScreenshot)"
+  - "A visual baseline test diffs in CI with no intentional UI change"
+  - "Changing the CI runner image for a job that validates a committed baseline"
+  - "Reviewing a PR that commits a *-snapshots PNG"
+tags:
+  - playwright
+  - visual-regression
+  - e2e
+  - ci
+  - snapshots
+  - github-actions
+  - fonts
+---
+
+# Playwright visual baselines
+
+How HashHive generates, commits, and maintains Playwright screenshot baselines
+(`toHaveScreenshot`). The first baseline is the dashboard at 1440×900
+(`packages/frontend/e2e/zz-dashboard.spec.ts`); this convention governs every
+one added after it.
+
+## Linux CI is the only canonical platform
+
+A screenshot baseline is a frozen PNG compared pixel-for-pixel against future
+runs. Font metrics, subpixel antialiasing, and emoji rasterisation differ
+between operating systems, so a baseline is only valid on the platform that
+generated it.
+
+- **Baselines are generated on a GitHub Linux runner and committed with
+  Playwright's `-chromium-linux` platform suffix** (e.g.
+  `dashboard-1440x900-chromium-linux.png`).
+- **Never commit a baseline generated on macOS or Windows.** A local macOS run
+  *will* report a platform/pixel mismatch — that message is expected behaviour,
+  not a regression. Do not run `--update-snapshots` locally to silence it.
+
+## Pin the runner image — never `ubuntu-latest`
+
+The committed PNG is frozen, but `ubuntu-latest` is a rolling alias GitHub
+migrates across major OS versions (20.04 → 22.04 → 24.04). Each migration
+updates freetype, fontconfig, and the system font stack — the exact inputs the
+baseline depends on (the app ships no bundled web fonts; all text rendering uses
+runner-provided system fonts). An alias migration would make every baseline
+self-diff on an unrelated PR with no code to blame.
+
+- Both the **generation** workflow (`.github/workflows/regenerate-visual-baselines.yml`)
+  and the **validation** job (`e2e-tests` in `.github/workflows/ci.yml`) pin the
+  **same dated image** (`ubuntu-24.04`). Keep them in lockstep.
+- When GitHub deprecates the pinned image, bump *both* jobs together and
+  regenerate the baseline in the same PR.
+
+## How to generate or update a baseline (intentionally)
+
+Generation runs on CI because only the GitHub runner matches the validating
+environment. The `regenerate-visual-baselines.yml` workflow does it and uploads
+the PNG as an artifact — it never commits.
+
+1. **Trigger generation.**
+   - On a branch / for a brand-new baseline: open the PR and add the
+     `regen-baselines` label (a same-repo PR runs the workflow from the PR head
+     branch, so this works before the workflow is on `main`).
+   - For steady-state updates once the workflow is on `main`: run it via
+     `workflow_dispatch` (`gh workflow run regenerate-visual-baselines.yml`).
+2. **Download the artifact:** `gh run download <run-id> -n visual-baselines`
+   into `packages/frontend/e2e/<spec>-snapshots/`. Sanity-check the PNG is
+   non-trivial (> 50 KB) and carries the `-chromium-linux` suffix.
+3. **Commit the PNG and the unskip together** in one commit, so the first CI run
+   of the unskipped test already has the baseline present (no red window). The
+   generation workflow ephemerally unskips the test in the CI workspace only
+   (`--update-snapshots` does not run a `test.skip` test) — that change is never
+   committed; you commit the real unskip.
+4. **Remove the `regen-baselines` label** so generation does not re-fire on
+   every subsequent push.
+5. **Verify CI twice:** the validation run passes (R3), and a no-op re-run also
+   passes (the baseline matches itself). The re-run is the real determinism
+   gate — see below.
+
+## Tolerance and determinism
+
+- **Tolerance is `maxDiffPixelRatio: 0.02`** (~2% of pixel area). Raise it only
+  with written justification in the PR. Prefer stabilising or masking
+  non-deterministic regions over inflating tolerance.
+- **Stabilise non-deterministic state at its source, then mask the remainder.**
+  Masking cannot fix a *conditional mount* — a region that sometimes doesn't
+  exist can't be masked, and its appearance reflows the layout. The dashboard
+  baseline drives the page to the `Live` (open) connection state before
+  capturing, which unmounts the conditional `FreshnessLine` ("Last updated X
+  ago", a 1 Hz wall-clock ticker) and fixes the connection-indicator label
+  width. The `output[aria-label]` mask is then belt-and-suspenders over residual
+  status pixels. **Masked regions render as magenta boxes in the committed PNG —
+  expected, not corruption.**
+
+  > Connection-state stabilisation approach (dashboard baseline): **wait for the
+  > `Live` state** (`output[aria-label="Live"]`). The e2e backend connects
+  > reliably, so the WebSocket reaches `open` within the test timeout. If a
+  > future surface cannot reliably connect, fall back to forcing
+  > `ConnectionIndicator`'s documented `status` prop via a test hook.
+- **Capture Motion-driven UI under `prefers-reduced-motion: reduce`.**
+  `animations: 'disabled'` only fast-forwards CSS animations/transitions — it
+  does not freeze `motion/react` (JS/rAF/WAAPI) motion. `emulateMedia({
+  reducedMotion: 'reduce' })` resolves it to a deterministic end state.
+- **Scope `retries: 0` to visual tests** (the e2e config defaults to `retries:
+  2` in CI) so a no-op re-run is a strict idempotency check rather than a
+  3-attempts-allowed one.
+
+## Design-change updates
+
+When the UI changes intentionally, regenerate the baseline on Linux (steps
+above) and include a before/after screenshot in the PR description so reviewers
+can confirm the new baseline is the intended appearance.

--- a/packages/frontend/e2e/zz-dashboard.spec.ts
+++ b/packages/frontend/e2e/zz-dashboard.spec.ts
@@ -94,22 +94,45 @@ test.describe.serial('Dashboard delight pass (issue #162)', () => {
   })
 
   // Visual baseline: skipped until the Linux baseline PNG is committed.
-  // See issue #201 for the procedure (generate on Linux with
-  // --update-snapshots, commit the PNG, then unskip this test). Local macOS
-  // runs WILL diff on font rendering and must not update the baseline.
-  test.skip('dashboard visual baseline at 1440x900', async ({ page }) => {
-    // Wait for the page to settle: all four cards present, crack-rate region
-    // mounted. Sparklines will be empty on cold load (1 sample) — by design.
-    await expect(page.locator('[data-testid="stat-card"]')).toHaveCount(4)
-    await expect(page.getByRole('region', { name: /crack rate trend/i })).toBeVisible()
+  // The baseline is CI-Linux-canonical (pinned ubuntu-24.04). Generate it via
+  // the `regenerate-visual-baselines.yml` workflow (label a PR with
+  // `regen-baselines`, or `workflow_dispatch` once it's on main), download the
+  // artifact, commit the PNG, and unskip this test in the same commit. Local
+  // macOS runs WILL diff on font rendering and must NOT update the baseline —
+  // that mismatch message is expected, not a regression. Full procedure:
+  // docs/solutions/conventions/playwright-visual-baselines.md.
+  //
+  // Determinism (why this differs from a plain toHaveScreenshot):
+  //  - We wait for the `Live` (open) connection state before capturing. That
+  //    unmounts the conditional FreshnessLine ("Last updated X ago", a 1Hz
+  //    wall-clock ticker rendered as <p data-testid="dashboard-last-updated">),
+  //    which would otherwise reflow the bento grid and is NOT covered by the
+  //    output[aria-label] mask. It also fixes the indicator label width.
+  //  - `prefers-reduced-motion: reduce` resolves motion/react to its end state
+  //    (animations:'disabled' only fast-forwards CSS, not JS/rAF motion).
+  //  - The mask is belt-and-suspenders over any residual WS-status pixels;
+  //    masked regions render as magenta boxes in the committed PNG (expected).
+  //  - retries:0 (configured on this nested describe) makes the no-op re-run a
+  //    strict idempotency check; the file default is retries:2 in CI.
+  test.describe('visual baseline', () => {
+    test.describe.configure({ retries: 0 })
 
-    // Allow a brief settle so motion-cross-fade and any layout reflow finish.
-    await page.waitForTimeout(500)
+    test.skip('dashboard visual baseline at 1440x900', async ({ page }) => {
+      await page.emulateMedia({ reducedMotion: 'reduce' })
 
-    await expect(page).toHaveScreenshot('dashboard-1440x900.png', {
-      maxDiffPixelRatio: 0.02,
-      fullPage: false,
-      animations: 'disabled',
+      // Drive to a single deterministic connection state: on `open` the
+      // indicators read "Live" and FreshnessLine does not mount.
+      await expect(page.locator('output[aria-label="Live"]').first()).toBeVisible()
+
+      await expect(page.locator('[data-testid="stat-card"]')).toHaveCount(4)
+      await expect(page.getByRole('region', { name: /crack rate trend/i })).toBeVisible()
+
+      await expect(page).toHaveScreenshot('dashboard-1440x900.png', {
+        maxDiffPixelRatio: 0.02,
+        fullPage: false,
+        animations: 'disabled',
+        mask: [page.locator('output[aria-label]')],
+      })
     })
   })
 

--- a/packages/frontend/e2e/zz-dashboard.spec.ts
+++ b/packages/frontend/e2e/zz-dashboard.spec.ts
@@ -118,14 +118,34 @@ test.describe.serial('Dashboard delight pass (issue #162)', () => {
     test.describe.configure({ retries: 0 })
 
     test.skip('dashboard visual baseline at 1440x900', async ({ page }) => {
+      // emulateMedia must be followed by reload: motion/react reads matchMedia
+      // at mount, so already-mounted components from beforeEach won't honor a
+      // late reduced-motion switch. Mirror the sibling reduced-motion test.
       await page.emulateMedia({ reducedMotion: 'reduce' })
+      await page.reload()
+      if (page.url().includes('/select-project')) {
+        await page.click('button:has-text("Test Project")')
+        await page.waitForURL('/', { timeout: 10_000 })
+      }
 
       // Drive to a single deterministic connection state: on `open` the
-      // indicators read "Live" and FreshnessLine does not mount.
-      await expect(page.locator('output[aria-label="Live"]').first()).toBeVisible()
+      // indicators read "Live" and FreshnessLine does not mount. A generous
+      // timeout absorbs a slow CI WebSocket handshake (connecting ->
+      // authenticating -> open) — important because retries:0 gives the first
+      // run no recovery budget.
+      await expect(page.locator('output[aria-label="Live"]').first()).toBeVisible({
+        timeout: 20_000,
+      })
 
       await expect(page.locator('[data-testid="stat-card"]')).toHaveCount(4)
       await expect(page.getByRole('region', { name: /crack rate trend/i })).toBeVisible()
+
+      // Data-quiescence gate: the stat-card wrappers mount immediately, so a
+      // count assertion alone can fire while react-query is still loading and
+      // StatCard / CrackRateTrendChart render Skeletons (animate-pulse). Wait
+      // for all skeletons to clear so the baseline captures the loaded layout,
+      // never a frozen skeleton frame.
+      await expect(page.locator('.animate-pulse')).toHaveCount(0)
 
       await expect(page).toHaveScreenshot('dashboard-1440x900.png', {
         maxDiffPixelRatio: 0.02,

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -12,6 +12,7 @@
     "test": "bun test --preload ./tests/setup.ts tests/",
     "test:e2e": "playwright test",
     "test:e2e:install": "playwright install --with-deps chromium",
+    "test:e2e:update:dashboard": "playwright test --update-snapshots zz-dashboard.spec.ts",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## What & why

Closes the technical debt in #201: the dashboard Playwright visual-regression test has shipped as `test.skip` since #198 because no canonical baseline PNG existed, so it provided zero protection against rendered-appearance regressions (color drift, spacing shifts, missing accent stripes, `text-5xl` -> `text-2xl` fallbacks).

This PR adds the **mechanism** to generate, validate, and maintain that baseline reliably across machines. The baseline PNG itself is committed as a follow-up step **within this PR** (see "Remaining step" below) because a Linux-canonical baseline can only be generated on a GitHub runner, not on a macOS dev machine.

## What's in this PR

- **`regenerate-visual-baselines.yml`** — a dual-trigger workflow that generates the baseline on a pinned `ubuntu-24.04` runner and uploads it as an artifact (it never commits):
  - `pull_request` (gated by the `regen-baselines` label) for on-branch/bootstrap generation — a same-repo PR runs the workflow from the PR head, so it works before the workflow reaches `main`.
  - `workflow_dispatch` for steady-state intentional updates once it's on `main`.
- **`ci.yml`** — pins the validating `e2e-tests` job to `ubuntu-24.04` (matching the generator). `ubuntu-latest` is a rolling alias; an image migration changes the system font stack and would make a frozen baseline self-diff with no code to blame. The two jobs are kept in lockstep with cross-referencing comments.
- **Hardened visual baseline spec** (`zz-dashboard.spec.ts`, still skipped) for deterministic capture:
  - Waits for the `Live` (open) connection state before capture. This unmounts the conditional `FreshnessLine` ("Last updated X ago", a 1 Hz wall-clock ticker) — which a static mask cannot handle because its mount reflows the layout — and stabilizes the connection-indicator label width.
  - Captures under `prefers-reduced-motion: reduce`, with a `reload()` so `motion/react` (which reads the media query at mount) actually honors it. `animations: 'disabled'` only covers CSS.
  - A data-quiescence gate (no `animate-pulse` skeletons) so the baseline never freezes a react-query loading frame.
  - Masks the connection indicators as belt-and-suspenders (masked regions render as magenta boxes in the committed PNG — expected).
  - `retries: 0` scoped to the visual test so a no-op re-run is a strict idempotency check (the suite default is `retries: 2` in continuous integration), plus a 20s timeout on the wait-for-Live assertion to absorb a slow WebSocket (WS) handshake.
- **`docs/solutions/conventions/playwright-visual-baselines.md`** — documents the canonical workflow: Linux-only baselines, the dated-image pin, the generate/update procedure, tolerance policy (`maxDiffPixelRatio: 0.02`), and the determinism rules above.

## Remaining step (completes #201 in this PR)

The baseline PNG and the unskip land in one follow-up commit here:

1. Add the `regen-baselines` label to this PR to trigger generation (review the branch's code first — a labeled run executes it on a runner).
2. `gh run download <run-id> -n visual-baselines` into `packages/frontend/e2e/zz-dashboard.spec.ts-snapshots/`.
3. Commit the PNG **and** the `test.skip` -> `test` unskip together (so the first run of the unskipped test has the baseline present), then remove the label.

## Test plan

- [x] `just check` green (format, lint, type-check, build).
- [x] `playwright test zz-dashboard.spec.ts --list` collects cleanly (nested describe + `retries: 0` inside the serial block; sed unskip marker unique).
- [ ] Labeled run on this PR produces a `> 50 KB` `*-chromium-linux.png` artifact.
- [ ] After committing the PNG + unskip: `e2e-tests` passes the visual comparison, and a no-op re-run also passes (the determinism gate).
- [ ] Local macOS run reports the expected platform mismatch (not a silent pass).

## Notes

Application/page code is unchanged — this is test-infrastructure, CI, and documentation only.

AI assistance: planned and drafted with Claude Code (Opus); every line reviewed and owned by the author per `AI_POLICY.md`. The plan was run through an automated document review and the diff through an automated multi-persona code review; findings were applied in-branch.
