### PR TITLE
feat: composite cursor pagination for the agent zaps endpoint (#182)

### DIFF
--- a/docs/solutions/test-failures/openldap-testcontainer-bootstrap-race.md
+++ b/docs/solutions/test-failures/openldap-testcontainer-bootstrap-race.md
@@ -1,0 +1,67 @@
+---
+title: "OpenLDAP testcontainer: seeding races the entrypoint's bootstrap slapd, so the memberof overlay never backpatches"
+date: 2026-07-12
+category: docs/solutions/test-failures
+module: packages/backend
+problem_type: test_failure
+component: testing_framework
+symptoms:
+  - "LDAP container test lane fails deterministically in CI: 'ldap-container: memberOf on uid=admin-user,... never settled to include cn=hh-admins-memberof,... after 15 attempts', then 'failed to boot and seed a working directory after 6 attempts'"
+  - "Passes intermittently locally and in isolation, so it reads like flaky Docker contention rather than a real bug"
+  - "The memberof overlay config is correct, and a manual ldapadd against a fully-booted container backpatches memberOf synchronously every time"
+root_cause: race_condition
+resolution_type: code_fix
+severity: high
+tags: [testcontainers, openldap, osixia, memberof, ldap, wait-strategy, ci, real-db-lane]
+---
+
+# OpenLDAP testcontainer: seeding races the entrypoint's bootstrap slapd
+
+## Problem
+
+An `osixia/openldap` container booted via testcontainers with `Wait.forListeningPorts()` reports "ready" while the image is still bootstrapping, so seeding fixtures over LDAP races the entrypoint's own config load. The `memberof` overlay never backpatches `memberOf` onto the seeded users, and the readiness poll times out — deterministically on CI, intermittently locally.
+
+## Symptoms
+
+- `ldap-container: memberOf on uid=admin-user,... never settled ... after 15 attempts` → `failed to boot and seed a working directory after 6 attempts`.
+- Two container-backed LDAP tests fail together; both pass when run in isolation or on a re-run.
+- Reads like host Docker contention (and it can be masked by it), so the first instinct — bump timeouts / add boot retries — is wrong.
+
+## What Didn't Work
+
+- **Increasing the memberof settle-poll count and the whole-container boot-retry budget** (6 boots × 15 settle polls). The overlay never fires within the race window, so more retries just fail slower.
+- **Blaming the overlay config.** Inspecting `cn=config` (`olcMemberOfGroupOC` / `olcMemberOfMemberAD`) showed it already matched what the helper seeds (`groupOfUniqueNames` / `uniqueMember`); a manual `ldapadd` against a fully-booted container backpatched `memberOf` on the first try.
+- **Attributing it to local Docker contention.** The failure is deterministic on a clean CI runner, so contention was a red herring that delayed finding the real race.
+
+## Solution
+
+The root cause: `osixia/openldap`'s entrypoint runs a **transient bootstrap `slapd`** on port 389 while it loads schemas and default LDIF into `cn=config`, then stops it and hands off to the real, long-running foreground `slapd`. `Wait.forListeningPorts()` can report the container ready **during that bootstrap window**, so `seedFixtures` writes into a database the entrypoint is concurrently loading (single-writer mdb), and the group's `uniqueMember` add lands in a state the overlay never backpatches.
+
+Wait for the foreground `slapd`'s startup log line in addition to the port. The `slapd starting` line is emitted **once**, only after the bootstrap sequence has fully completed:
+
+```typescript
+// Before — reports ready mid-bootstrap:
+.withWaitStrategy(Wait.forListeningPorts())
+
+// After — waits for the real foreground slapd:
+.withWaitStrategy(
+  Wait.forAll([
+    Wait.forListeningPorts(),
+    Wait.forLogMessage(/slapd starting/),
+  ]).withStartupTimeout(120_000),
+)
+```
+
+Result: `memberOf` settles on the **first** boot attempt, and the two container-backed tests drop from ~19–53s (retry/poll-heavy) to ~2–4s combined.
+
+## Why This Works
+
+The bug is a readiness lie, not an overlay failure. Port-listening is necessary but not sufficient for an image whose entrypoint listens on that same port during a preparatory phase. Gating on a log line the image emits only at final hand-off removes the race at its source, so no seed operation can run against the half-initialized `cn=config`. The pre-existing boot-retries and settle-poll remain as cheap defense-in-depth against ordinary host contention, but they are no longer load-bearing.
+
+## Prevention
+
+- **For any container whose image does multi-phase startup (a bootstrap DB load, an init sidecar, schema seeding), never rely on `Wait.forListeningPorts()` alone.** Combine it with `Wait.forLogMessage(<final-ready line>)` via `Wait.forAll([...])`. Port-open is a floor, not a ready signal.
+- **When a container test is "flaky" but the service config checks out, suspect a readiness race before contention.** Determinism on CI (vs. intermittency locally) is the tell: a clean runner exposes the race that a busy local host sometimes hides.
+- **Prefer a deterministic readiness gate over retry budgets.** Retries that "converge" are masking a race; the fix belongs at the wait strategy, and success should be observable as "settles on boot attempt 1", not "passes after N retries".
+
+See the shared helper `packages/backend/tests/db/support/ldap-container.ts` for the applied fix.

--- a/packages/backend/src/lib/pg-limits.ts
+++ b/packages/backend/src/lib/pg-limits.ts
@@ -1,0 +1,12 @@
+/**
+ * PostgreSQL column-type limits, shared so validation boundaries agree on
+ * one source of truth rather than redeclaring the literal per file.
+ */
+
+/**
+ * Maximum value of a PostgreSQL `integer` / `serial` (int4) column. Used to
+ * bound agent-supplied ids at the validator boundary so an out-of-range
+ * value is a clean 400 instead of reaching the column and surfacing as an
+ * opaque error. If an id column is ever widened to `bigint`, update here.
+ */
+export const MAX_PG_INT4 = 2_147_483_647

--- a/packages/backend/src/routes/agent/index.ts
+++ b/packages/backend/src/routes/agent/index.ts
@@ -75,6 +75,7 @@ import {
 } from '../../services/tasks.js'
 import { getStopTaskIdsForAgent } from '../../services/tasks/preemption.js'
 import { getResourcesForTask } from '../../services/tasks/task-resources.js'
+import { decodeZapCursor } from '../../services/tasks/zap-cursor.js'
 import { registerEnrollRoute } from './enroll.js'
 import { agentInternalError, type AgentInternalErrorCode } from './helpers.js'
 
@@ -201,16 +202,20 @@ const taskReportRequestSchema = z
   .openapi('TaskReport')
 
 // Mirrors `getZapsForTask`'s runtime return shape (see
-// `services/tasks/zaps.ts`) and the pre-deletion `agent-api.yaml`
-// `ZapResponse` schema. `zaps` is the list of already-cracked hash
-// values for the task's hash list; `hasMore` signals truncation beyond
-// the requested `limit`. The agent's documented contract — do not
-// rename either key or generated Go clients will silently drop cracked
-// hashes and the agent will re-run already-cracked work.
+// `services/tasks/zaps.ts`). `zaps` is the list of already-cracked hash
+// values for the task's hash list. `nextCursor` is an opaque
+// continuation token: the agent echoes it back as the `cursor` query
+// param to fetch the next page, and it is ALWAYS present — a base64url
+// string when more rows remain, and explicit `null` (never an absent
+// key) when the set is exhausted, so a client terminates cleanly on
+// `nextCursor === null`. This replaced the prior `hasMore: boolean`,
+// which carried no cursor material forward and could not survive rows
+// sharing a `crackedAt` timestamp (#182). The agent's documented
+// contract — do not rename either key or generated Go clients break.
 const zapResponseSchema = z
   .object({
     zaps: z.array(z.string()),
-    hasMore: z.boolean(),
+    nextCursor: z.string().nullable(),
   })
   .openapi('ZapResponse')
 
@@ -333,11 +338,39 @@ const resourceParamSchema = z.object({
   id: z.coerce.number().int().positive().max(MAX_PG_INT4).openapi({ example: 1 }),
 })
 
+// `cursor` is the opaque, agent-controlled continuation token from a
+// prior response's `nextCursor`. It is decoded and validated HERE, at
+// the request boundary, not in the service: `decodeZapCursor` throws on
+// any malformed / wrong-shape / out-of-range token, and reporting that
+// as a Zod issue routes it through `agentOpenApiHonoOptions.defaultHook`
+// to a clean 400 `VALIDATION_ERROR`. Decoding in the service instead
+// would surface a bad cursor as the route's 404 (`{ error }` path) or a
+// 500 — both wrong per the contract ("malformed cursor returns 400, not
+// a 500"). Absent cursor (omitted OR empty string) → `undefined` → start
+// from the beginning; an empty `?cursor=` is a client serializing a
+// nil/absent token, not a malformed one, so it restarts rather than 400s.
+//
+// `.max(MAX_ZAP_CURSOR_LEN)` bounds the raw token BEFORE base64url-decode
+// + JSON.parse so a hostile agent can't force decode/parse work on a
+// multi-megabyte query value — every other input in this route file is
+// explicitly bounded, and a real cursor is well under 100 chars.
+const MAX_ZAP_CURSOR_LEN = 512
 const zapQuerySchema = z.object({
-  since: z.iso
-    .datetime()
+  cursor: z
+    .string()
+    .max(MAX_ZAP_CURSOR_LEN)
     .optional()
-    .transform((v) => (v ? new Date(v) : undefined)),
+    .transform((token, ctx) => {
+      if (token === undefined || token === '') {
+        return undefined
+      }
+      try {
+        return decodeZapCursor(token)
+      } catch {
+        ctx.addIssue({ code: 'custom', message: 'Invalid cursor' })
+        return z.NEVER
+      }
+    }),
   limit: z.coerce.number().int().min(1).max(10_000).default(10_000),
 })
 
@@ -530,7 +563,7 @@ const zapsRoute = createRoute({
   tags: ['Tasks'],
   summary: 'Retrieve cracked hash values for a task',
   description:
-    "Returns hash values that have been cracked from the same hash list as the given task. Agents use this to build a 'zap list' so they can skip already-cracked hashes during processing.",
+    "Returns hash values that have been cracked from the same hash list as the given task. Agents use this to build a 'zap list' so they can skip already-cracked hashes during processing. Pagination is an opaque composite cursor: pass the `cursor` from a prior response's `nextCursor` to continue; omit it to start from the beginning; stop when `nextCursor` is `null`. BREAKING CHANGE (#182): the former `since` timestamp query param was removed in favor of `cursor`/`nextCursor`, which paginate correctly even when more cracked rows share one `crackedAt` timestamp than fit in `limit` — a case `since` could not handle without skipping or replaying rows.",
   security: [{ AgentBearer: [] }],
   request: {
     params: taskIdParamSchema,
@@ -551,10 +584,10 @@ const zapsRoute = createRoute({
 agentRoutes.openapi(zapsRoute, async (c) => {
   const { agentId, projectId } = c.get('agent')
   const { taskId } = c.req.valid('param')
-  const { since, limit } = c.req.valid('query')
+  const { cursor, limit } = c.req.valid('query')
 
   try {
-    const result = await getZapsForTask(taskId, agentId, projectId, { since, limit })
+    const result = await getZapsForTask(taskId, agentId, projectId, { cursor, limit })
 
     if ('error' in result) {
       return c.json({ error: { code: 'TASK_NOT_FOUND', message: result.error } }, 404)

--- a/packages/backend/src/routes/agent/index.ts
+++ b/packages/backend/src/routes/agent/index.ts
@@ -47,6 +47,7 @@ import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
 import type { AppEnv } from '../../types.js'
 
 import { logger } from '../../config/logger.js'
+import { MAX_PG_INT4 } from '../../lib/pg-limits.js'
 import { requireAgentToken, requireAgentTokenForHeartbeatRecovery } from '../../middleware/auth.js'
 import {
   AGENT_RESPONSE_REFS,
@@ -75,7 +76,7 @@ import {
 } from '../../services/tasks.js'
 import { getStopTaskIdsForAgent } from '../../services/tasks/preemption.js'
 import { getResourcesForTask } from '../../services/tasks/task-resources.js'
-import { decodeZapCursor } from '../../services/tasks/zap-cursor.js'
+import { decodeZapCursor, ZapCursorError } from '../../services/tasks/zap-cursor.js'
 import { registerEnrollRoute } from './enroll.js'
 import { agentInternalError, type AgentInternalErrorCode } from './helpers.js'
 
@@ -215,7 +216,11 @@ const taskReportRequestSchema = z
 const zapResponseSchema = z
   .object({
     zaps: z.array(z.string()),
-    nextCursor: z.string().nullable(),
+    nextCursor: z.string().nullable().openapi({
+      description:
+        'Opaque continuation token, or `null` at exhaustion. Pass it back verbatim as the `cursor` query param to fetch the next page; treat it as opaque (do not parse). Always present — terminate when it is `null`.',
+      example: 'eyJjIjoxNzUyMDAwMDAwMDAwLCJpIjo0Mn0',
+    }),
   })
   .openapi('ZapResponse')
 
@@ -314,8 +319,9 @@ const downloadUrlResponseSchema = z
 // guard). The `.max(MAX_PG_INT4)` upper bound keeps absurd inputs
 // like `/tasks/1e15/report` from reaching the service layer (and the
 // downstream PostgreSQL `serial` / int4 column) where they would
-// surface as an opaque 500 instead of a clean 400.
-const MAX_PG_INT4 = 2_147_483_647
+// surface as an opaque 500 instead of a clean 400. `MAX_PG_INT4` is
+// shared from `lib/pg-limits.js` so the cursor codec and this route
+// agree on one source of truth for the int4 ceiling.
 const taskIdParamSchema = z.object({
   taskId: z.coerce.number().int().positive().max(MAX_PG_INT4).openapi({ example: 42 }),
 })
@@ -352,23 +358,35 @@ const resourceParamSchema = z.object({
 //
 // `.max(MAX_ZAP_CURSOR_LEN)` bounds the raw token BEFORE base64url-decode
 // + JSON.parse so a hostile agent can't force decode/parse work on a
-// multi-megabyte query value — every other input in this route file is
-// explicitly bounded, and a real cursor is well under 100 chars.
+// multi-megabyte query value — the cursor is the one variable-length input
+// on this hot polling path, and a real token is well under 100 chars.
 const MAX_ZAP_CURSOR_LEN = 512
 const zapQuerySchema = z.object({
   cursor: z
     .string()
     .max(MAX_ZAP_CURSOR_LEN)
     .optional()
+    .openapi({
+      description:
+        'Opaque continuation token from a prior response’s `nextCursor`. Echo it back verbatim to fetch the next page; do not parse or construct it. Omit (or send empty) to start from the beginning.',
+      example: 'eyJjIjoxNzUyMDAwMDAwMDAwLCJpIjo0Mn0',
+    })
     .transform((token, ctx) => {
       if (token === undefined || token === '') {
         return undefined
       }
       try {
         return decodeZapCursor(token)
-      } catch {
-        ctx.addIssue({ code: 'custom', message: 'Invalid cursor' })
-        return z.NEVER
+      } catch (err) {
+        // Only a malformed token (ZapCursorError) is a client 400. Anything
+        // else thrown from the decode path is an unexpected server fault —
+        // rethrow it so the route's catch logs it and returns a 500, rather
+        // than silently mislabeling a server bug as agent-supplied bad input.
+        if (err instanceof ZapCursorError) {
+          ctx.addIssue({ code: 'custom', message: 'Invalid cursor' })
+          return z.NEVER
+        }
+        throw err
       }
     }),
   limit: z.coerce.number().int().min(1).max(10_000).default(10_000),

--- a/packages/backend/src/routes/agent/index.ts
+++ b/packages/backend/src/routes/agent/index.ts
@@ -77,6 +77,7 @@ import {
 import { getStopTaskIdsForAgent } from '../../services/tasks/preemption.js'
 import { getResourcesForTask } from '../../services/tasks/task-resources.js'
 import { decodeZapCursor, ZapCursorError } from '../../services/tasks/zap-cursor.js'
+import { MAX_ZAPS_LIMIT } from '../../services/tasks/zaps.js'
 import { registerEnrollRoute } from './enroll.js'
 import { agentInternalError, type AgentInternalErrorCode } from './helpers.js'
 
@@ -389,7 +390,7 @@ const zapQuerySchema = z.object({
         throw err
       }
     }),
-  limit: z.coerce.number().int().min(1).max(10_000).default(10_000),
+  limit: z.coerce.number().int().min(1).max(MAX_ZAPS_LIMIT).default(MAX_ZAPS_LIMIT),
 })
 
 // ─── POST /heartbeat — agent heartbeat ──────────────────────────────

--- a/packages/backend/src/services/tasks/zap-cursor.ts
+++ b/packages/backend/src/services/tasks/zap-cursor.ts
@@ -27,18 +27,26 @@
  * exactly against the column, matching how `services/results/export.ts`
  * and `routes/dashboard/results.ts` keyset-paginate this same column.
  */
-import { z } from '@hono/zod-openapi'
+import { z } from 'zod'
+
+import { MAX_PG_INT4 } from '../../lib/pg-limits.js'
 
 /**
  * Server-private composite cursor shape. Mirrors the internal
  * `CrackedCursor` in `services/results/export.ts` but is kept local to
  * the zaps feature — it is not an agent-facing wire shape (the agent
  * only ever sees the opaque base64url token).
+ *
+ * Accepted limitation (not a bug): `crackedAt` is an application-computed
+ * wall-clock value, so concurrent first-time INSERTs can commit in an order
+ * that diverges from timestamp order — a row with an earlier `crackedAt`
+ * that commits after a later one an agent already paged past would be missed
+ * on that walk. Benign for a zap hint list (the agent re-cracks an
+ * already-cracked hash — wasted cycles, never data loss) and inherent to
+ * keyset pagination over an externally-timestamped column (the sibling
+ * `results/export.ts` shares it).
  */
 export type ZapCursor = { readonly crackedAt: Date; readonly id: number }
-
-/** Upper bound for the `id` field — matches the PostgreSQL int4 / `serial` ceiling. */
-const MAX_PG_INT4 = 2_147_483_647
 
 /**
  * Upper bound for the epoch-millis `c` field — JavaScript `Date`'s valid

--- a/packages/backend/src/services/tasks/zap-cursor.ts
+++ b/packages/backend/src/services/tasks/zap-cursor.ts
@@ -1,0 +1,103 @@
+/**
+ * Opaque pagination cursor for the Agent API zaps endpoint
+ * (`GET /api/v1/agent/tasks/{taskId}/zaps`).
+ *
+ * The agent treats the cursor as opaque: the server mints it in a
+ * response's `nextCursor` and the agent echoes it back verbatim as the
+ * `cursor` query param on the next call. Because the agent never parses
+ * or constructs the token, the entire `>` vs `>=` / advance-the-cursor
+ * bug class disappears — the server round-trips its own encoding and can
+ * evolve it freely.
+ *
+ * Wire form: base64url of a compact JSON object `{ "c": <epochMillis>,
+ * "i": <id> }` keyed on the composite `(crackedAt, id)` sort key the
+ * zaps query orders by. base64url (not standard base64) keeps the token
+ * query-safe with no `+`/`/`/`=` escaping.
+ *
+ * Precision (ms-aligned-writes invariant): `c` carries `crackedAt` as
+ * epoch-MILLISECONDS, matching the millisecond precision the app can
+ * observe. Although `hash_items.cracked_at` is a Postgres `timestamptz`
+ * (microsecond-capable), EVERY write path sets it from a JavaScript
+ * `Date` (`new Date()` in services/tasks.ts + hash-items/propagation.ts,
+ * the JS-`Date`-fed `EXCLUDED.cracked_at` upserts in the queue workers,
+ * and `new Date(...)` in scripts/migrate-data.ts) — there is no
+ * `defaultNow()`/`now()` DB-side write. So the column only ever holds
+ * millisecond-aligned values and `new Date(millis).getTime() === millis`
+ * round-trips losslessly. Decode → `Date` → Drizzle `gt`/`eq` compares
+ * exactly against the column, matching how `services/results/export.ts`
+ * and `routes/dashboard/results.ts` keyset-paginate this same column.
+ */
+import { z } from '@hono/zod-openapi'
+
+/**
+ * Server-private composite cursor shape. Mirrors the internal
+ * `CrackedCursor` in `services/results/export.ts` but is kept local to
+ * the zaps feature — it is not an agent-facing wire shape (the agent
+ * only ever sees the opaque base64url token).
+ */
+export type ZapCursor = { readonly crackedAt: Date; readonly id: number }
+
+/** Upper bound for the `id` field — matches the PostgreSQL int4 / `serial` ceiling. */
+const MAX_PG_INT4 = 2_147_483_647
+
+/**
+ * Upper bound for the epoch-millis `c` field — JavaScript `Date`'s valid
+ * range ceiling (±8.64e15 ms from the epoch). Without this bound a
+ * schema-valid-but-huge `c` passes `int().nonnegative()`, decodes to an
+ * `Invalid Date`, and only surfaces when the bad `Date` reaches Drizzle's
+ * comparator downstream — where it throws into the route's generic catch
+ * and leaks a 500 instead of the 400 the contract promises for a
+ * malformed cursor. Rejecting it at decode keeps every structurally
+ * invalid token on the 400 path.
+ */
+const MAX_EPOCH_MILLIS = 8_640_000_000_000_000
+
+/** Decoded token payload, validated defensively — the cursor is agent-controlled input. */
+const cursorPayloadSchema = z
+  .object({
+    c: z.number().int().nonnegative().max(MAX_EPOCH_MILLIS),
+    i: z.number().int().positive().max(MAX_PG_INT4),
+  })
+  .strict()
+
+/**
+ * Thrown when a cursor token cannot be decoded to a valid {@link ZapCursor}.
+ * Carries a fixed, non-leaky message; the route maps it to the Agent API
+ * validation-error envelope (400). Internal parse-exception text is never
+ * surfaced to the agent.
+ */
+export class ZapCursorError extends Error {
+  constructor() {
+    super('Invalid cursor')
+    this.name = 'ZapCursorError'
+  }
+}
+
+/** Encode a composite cursor to an opaque base64url token. */
+export function encodeZapCursor(cursor: ZapCursor): string {
+  const payload = JSON.stringify({ c: cursor.crackedAt.getTime(), i: cursor.id })
+  return Buffer.from(payload, 'utf8').toString('base64url')
+}
+
+/**
+ * Decode an opaque token back to a composite cursor. Rejects — by throwing
+ * {@link ZapCursorError} — a token that is not valid base64url, does not
+ * decode to JSON, does not match the expected shape, or carries an
+ * out-of-range `id` or `crackedAt`. Never trusts the token.
+ */
+export function decodeZapCursor(token: string): ZapCursor {
+  let payload: unknown
+  try {
+    const json = Buffer.from(token, 'base64url').toString('utf8')
+    payload = JSON.parse(json)
+  } catch {
+    throw new ZapCursorError()
+  }
+
+  const parsed = cursorPayloadSchema.safeParse(payload)
+  if (!parsed.success) {
+    throw new ZapCursorError()
+  }
+
+  return { crackedAt: new Date(parsed.data.c), id: parsed.data.i }
+}

--- a/packages/backend/src/services/tasks/zaps.ts
+++ b/packages/backend/src/services/tasks/zaps.ts
@@ -44,12 +44,14 @@ const MAX_ZAPS_LIMIT = 10_000
  * `services/results/export.ts` / `routes/dashboard/results.ts`, inverted
  * to ASC (`gt`, not `lt`).
  */
+export type GetZapsForTaskResult = { zaps: string[]; nextCursor: string | null } | { error: string }
+
 export async function getZapsForTask(
   taskId: number,
   agentId: number,
   projectId: number,
   opts: { cursor?: ZapCursor | undefined; limit?: number | undefined } = {}
-): Promise<{ zaps: string[]; nextCursor: string | null } | { error: string }> {
+): Promise<GetZapsForTaskResult> {
   // Clamp caller-supplied limit so an agent can't force an unbounded
   // in-memory read (the route is on a hot polling path; an agent
   // requesting `limit=10_000_000` would pull millions of rows + map
@@ -104,6 +106,10 @@ export async function getZapsForTask(
   // bound (`Index Cond`) on `hash_items_hash_list_cracked_idx`, leaving
   // the OR as a cheap tie-break Filter. Same result set, seek instead of
   // scan.
+  //
+  // DO NOT REMOVE the `gte` as "redundant" — it is a query-plan optimization
+  // (verified with EXPLAIN), not dead code. Deleting it silently degrades
+  // this hot path to a full-range rescan; every correctness test stays green.
   if (opts.cursor) {
     conditions.push(
       gte(hashItems.crackedAt, opts.cursor.crackedAt),
@@ -133,12 +139,22 @@ export async function getZapsForTask(
   const page = hasMore ? rows.slice(0, fetchLimit) : rows
   const zaps = page.map((r) => r.hashValue)
 
-  // Mint the continuation token from the last returned row. `crackedAt`
-  // is non-null on every row (the `isNotNull` filter above guarantees
-  // it), so the assertion mirrors `results/export.ts`'s `last.crackedAt!`.
-  const lastRow = page.at(-1)
-  const nextCursor =
-    hasMore && lastRow ? encodeZapCursor({ crackedAt: lastRow.crackedAt!, id: lastRow.id }) : null
+  // Mint the continuation token from the last returned row when more remain.
+  // `fetchLimit >= 1` (clamped above), so `hasMore` implies a non-empty page;
+  // if that invariant is ever broken, throw LOUD rather than silently
+  // returning `nextCursor: null` — a false "exhausted" signal would make the
+  // agent stop polling and skip cracked hashes with no error to trace. The
+  // throw routes through the route's catch to a logged 500 + TASK_ZAP_ERROR.
+  let nextCursor: string | null = null
+  if (hasMore) {
+    const lastRow = page.at(-1)
+    if (!lastRow) {
+      throw new Error('zap pagination invariant violated: hasMore=true with an empty page')
+    }
+    // `crackedAt` is non-null on every row (the `isNotNull` filter above
+    // guarantees it), so the assertion mirrors `results/export.ts`.
+    nextCursor = encodeZapCursor({ crackedAt: lastRow.crackedAt!, id: lastRow.id })
+  }
 
   return { zaps, nextCursor }
 }

--- a/packages/backend/src/services/tasks/zaps.ts
+++ b/packages/backend/src/services/tasks/zaps.ts
@@ -11,9 +11,10 @@
  * import path.
  */
 import { campaigns, hashItems, tasks } from '@hashhive/shared'
-import { and, eq, gt, isNotNull } from 'drizzle-orm'
+import { and, eq, gt, gte, isNotNull, or, type SQL } from 'drizzle-orm'
 
 import { db } from '../../db/index.js'
+import { encodeZapCursor, type ZapCursor } from './zap-cursor.js'
 
 /**
  * Hard ceiling on the number of zap rows returned per request.
@@ -29,13 +30,26 @@ const MAX_ZAPS_LIMIT = 10_000
  * task's hash list — so the calling agent can skip them. Project-scoped
  * via the campaigns join so a leaked task id from another project
  * resolves to "task not found", not a cross-project read.
+ *
+ * Pagination is an opaque composite cursor over `(crackedAt, id)`. The
+ * agent passes back the prior response's `nextCursor` as `opts.cursor`
+ * (decoded to `{ crackedAt, id }` at the route boundary); the filter
+ * `(crackedAt > c.crackedAt) OR (crackedAt = c.crackedAt AND id > c.id)`
+ * resumes strictly after that row, matching the `ORDER BY (crackedAt,
+ * id)`. This walks every cracked row exactly once even when more than
+ * `limit` rows share one `crackedAt` — the single-timestamp `since`
+ * cursor could not (it skipped or replayed tied rows). `nextCursor` is
+ * the encoded cursor of the last returned row when more remain, or
+ * `null` at exhaustion. Mirrors the keyset pattern in
+ * `services/results/export.ts` / `routes/dashboard/results.ts`, inverted
+ * to ASC (`gt`, not `lt`).
  */
 export async function getZapsForTask(
   taskId: number,
   agentId: number,
   projectId: number,
-  opts: { since?: Date | undefined; limit?: number | undefined } = {}
-): Promise<{ zaps: string[]; hasMore: boolean } | { error: string }> {
+  opts: { cursor?: ZapCursor | undefined; limit?: number | undefined } = {}
+): Promise<{ zaps: string[]; nextCursor: string | null } | { error: string }> {
   // Clamp caller-supplied limit so an agent can't force an unbounded
   // in-memory read (the route is on a hot polling path; an agent
   // requesting `limit=10_000_000` would pull millions of rows + map
@@ -61,32 +75,70 @@ export async function getZapsForTask(
   }
 
   if (!taskRow.hashListId) {
-    return { zaps: [], hasMore: false }
+    return { zaps: [], nextCursor: null }
   }
 
-  // Build conditions for cracked hash items
-  const conditions = [eq(hashItems.hashListId, taskRow.hashListId), isNotNull(hashItems.crackedAt)]
+  // Build conditions for cracked hash items. Typed to allow the
+  // `or(...)` (which is `SQL | undefined`) without a non-null assertion —
+  // `and(...conditions)` filters undefined itself, matching the pattern
+  // in `services/results/export.ts`.
+  const conditions: Array<SQL | undefined> = [
+    eq(hashItems.hashListId, taskRow.hashListId),
+    isNotNull(hashItems.crackedAt),
+  ]
 
-  if (opts.since) {
-    conditions.push(gt(hashItems.crackedAt, opts.since))
+  // Composite-cursor resume predicate. Drizzle's operator set is
+  // single-column, so the row-value comparison
+  // `(crackedAt, id) > (cursor.crackedAt, cursor.id)` is written as the
+  // boolean expansion. NOTE: ASC ordering here means `gt`, not the `lt`
+  // the DESC export paths use — mirroring them without flipping the
+  // comparator is the classic bug this endpoint's tied-timestamp DB test
+  // guards against.
+  //
+  // The leading `gte(crackedAt, cursor.crackedAt)` is LOGICALLY REDUNDANT
+  // with the OR below (every row the OR admits also satisfies the `gte`),
+  // but it is load-bearing for performance on this hot polling path: the
+  // OR alone is not pushed into the index and forces a row-by-row Filter
+  // that rescans the whole cracked-row range each page, so per-page cost
+  // grows as the agent walks deeper. The `gte` restores the index range
+  // bound (`Index Cond`) on `hash_items_hash_list_cracked_idx`, leaving
+  // the OR as a cheap tie-break Filter. Same result set, seek instead of
+  // scan.
+  if (opts.cursor) {
+    conditions.push(
+      gte(hashItems.crackedAt, opts.cursor.crackedAt),
+      or(
+        gt(hashItems.crackedAt, opts.cursor.crackedAt),
+        and(eq(hashItems.crackedAt, opts.cursor.crackedAt), gt(hashItems.id, opts.cursor.id))
+      )
+    )
   }
 
-  // Fetch limit+1 to detect hasMore. Ordering uses `(crackedAt, id)`
-  // so rows that share a `crackedAt` timestamp resolve to the same
-  // order across calls; without the `id` tiebreaker the planner picks
-  // physical-storage order, which is non-deterministic. Resilient
-  // pagination across tied timestamps still needs a composite cursor
-  // on the wire (`since` is a single Date today) -- tracked in #182,
-  // which has to ship with a coordinated agent-client + OpenAPI update.
+  // Fetch limit+1 to detect whether more rows remain. Ordering uses
+  // `(crackedAt, id)` so rows that share a `crackedAt` timestamp resolve
+  // to the same order across calls; the `id` tiebreaker is load-bearing
+  // for the composite cursor above.
   const rows = await db
-    .select({ hashValue: hashItems.hashValue })
+    .select({
+      hashValue: hashItems.hashValue,
+      id: hashItems.id,
+      crackedAt: hashItems.crackedAt,
+    })
     .from(hashItems)
     .where(and(...conditions))
     .orderBy(hashItems.crackedAt, hashItems.id)
     .limit(fetchLimit + 1)
 
   const hasMore = rows.length > fetchLimit
-  const zaps = (hasMore ? rows.slice(0, fetchLimit) : rows).map((r) => r.hashValue)
+  const page = hasMore ? rows.slice(0, fetchLimit) : rows
+  const zaps = page.map((r) => r.hashValue)
 
-  return { zaps, hasMore }
+  // Mint the continuation token from the last returned row. `crackedAt`
+  // is non-null on every row (the `isNotNull` filter above guarantees
+  // it), so the assertion mirrors `results/export.ts`'s `last.crackedAt!`.
+  const lastRow = page.at(-1)
+  const nextCursor =
+    hasMore && lastRow ? encodeZapCursor({ crackedAt: lastRow.crackedAt!, id: lastRow.id }) : null
+
+  return { zaps, nextCursor }
 }

--- a/packages/backend/src/services/tasks/zaps.ts
+++ b/packages/backend/src/services/tasks/zaps.ts
@@ -22,8 +22,12 @@ import { encodeZapCursor, type ZapCursor } from './zap-cursor.js'
  * clamped up. This is the *only* bound between an agent's polling
  * query and the SQL planner, so a malformed or hostile agent can't
  * force a large in-memory read.
+ *
+ * Exported so the agent route's `zapQuerySchema` bounds `limit` against
+ * the same value — one source of truth, so the route's boundary reject
+ * and the service's clamp can't drift apart.
  */
-const MAX_ZAPS_LIMIT = 10_000
+export const MAX_ZAPS_LIMIT = 10_000
 
 /**
  * Returns "zaps" — hashes already cracked by any campaign sharing this

--- a/packages/backend/tests/db/zaps-pagination.db.test.ts
+++ b/packages/backend/tests/db/zaps-pagination.db.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Real-DB tests for U5: the zaps endpoint composite cursor
+ * (docs/plans/2026-07-12-001-feat-zaps-composite-cursor-plan.md).
+ *
+ * These prove the property the whole change exists for, against a real
+ * Postgres — SQL comparison semantics over tied `crackedAt` timestamps
+ * cannot be proven with mocks:
+ *
+ * 1. Exactly-once walk: an agent that starts with no cursor and repeatedly
+ *    calls back with the returned `nextCursor` reads every cracked hash
+ *    value exactly once, terminating when `nextCursor` is null — even when
+ *    MORE than `limit` rows share ONE `crackedAt` timestamp (the case the
+ *    old single-timestamp `since` cursor skipped or replayed).
+ * 2. Tied cluster straddling a page boundary loses/repeats nothing.
+ * 3. Exhaustion returns `nextCursor: null`.
+ * 4. Empty / no-cracked-rows hash list → `{ zaps: [], nextCursor: null }`.
+ * 5. Immutability characterization (KTD4): moving a row's `crackedAt`
+ *    FORWARD (the monotonic re-crack mutation) can cause a benign REPLAY
+ *    but never a SKIP — every cracked hash remains reachable.
+ *
+ * Timestamps are seeded MILLISECOND-ALIGNED (`new Date(fixedMillis)`),
+ * matching how every write path in the app actually writes `crackedAt`
+ * (KTD3's ms-aligned-writes invariant). Do NOT rebuild these on sub-ms
+ * values — that is not a state the write paths can produce.
+ *
+ * Runs under `just test-db` (preload: tests/preload-db.ts). Uses the
+ * shared drizzle client from `../../src/db/index.js`.
+ *
+ * NOTE: Do NOT call client.end() — the pooled client is a process-wide
+ * singleton shared by every file in the lane.
+ * NOTE: Do NOT self-skip — the test-db lane always has Postgres available.
+ */
+import { agents, attacks, campaigns, hashItems, hashLists, projects, tasks } from '@hashhive/shared'
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
+import { and, eq } from 'drizzle-orm'
+
+import { db } from '../../src/db/index.js'
+import { decodeZapCursor, type ZapCursor } from '../../src/services/tasks/zap-cursor.js'
+import { getZapsForTask } from '../../src/services/tasks/zaps.js'
+
+const SLUG = 'zaps-pagination-proj'
+
+let projectId: number
+let hashListId: number
+let agentId: number
+let taskId: number
+// A second, empty hash list reached through its own campaign/task (scenario 4).
+let emptyAgentId: number
+let emptyTaskId: number
+
+async function cleanup(): Promise<void> {
+  await db.delete(projects).where(eq(projects.slug, SLUG))
+}
+
+/**
+ * Drive a full paginated walk through getZapsForTask, echoing back the
+ * decoded `nextCursor` exactly as an agent would, and return the ordered
+ * list of every zap value seen across all calls.
+ */
+async function walkAll(
+  targetTaskId: number,
+  targetAgentId: number,
+  limit: number
+): Promise<string[]> {
+  const seen: string[] = []
+  let cursor: ZapCursor | undefined
+  // Bound the loop defensively so a pagination bug can't spin forever.
+  for (let guard = 0; guard < 1000; guard++) {
+    const result = await getZapsForTask(targetTaskId, targetAgentId, projectId, { cursor, limit })
+    if ('error' in result) {
+      throw new Error(`unexpected error walking zaps: ${result.error}`)
+    }
+    seen.push(...result.zaps)
+    if (result.nextCursor === null) {
+      return seen
+    }
+    cursor = decodeZapCursor(result.nextCursor)
+  }
+  throw new Error('walkAll did not terminate — possible pagination loop')
+}
+
+/**
+ * Seed a campaign → attack → agent → task chain pointing at `listId`,
+ * assigned to a fresh agent (getZapsForTask checks `tasks.agentId` with
+ * no status/lease gate, so an agent set at insert is sufficient). Returns
+ * the agent and task ids the zaps lookup needs. `projectId` is read from
+ * module scope (the shared project seeded in beforeAll).
+ */
+async function createTaskFixture(
+  listId: number,
+  prefix: string
+): Promise<{ agentId: number; taskId: number }> {
+  const [camp] = await db
+    .insert(campaigns)
+    .values({
+      name: `${prefix}-camp`,
+      projectId,
+      hashListId: listId,
+      priority: 1,
+      status: 'running',
+      hashcatMode: 0,
+    })
+    .returning({ id: campaigns.id })
+  const [atk] = await db
+    .insert(attacks)
+    .values({ campaignId: camp!.id, projectId, mode: 0 })
+    .returning({ id: attacks.id })
+  const [agnt] = await db
+    .insert(agents)
+    .values({ name: `${prefix}-agent`, projectId, capabilities: { gpu: false }, status: 'online' })
+    .returning({ id: agents.id })
+  const [task] = await db
+    .insert(tasks)
+    .values({
+      attackId: atk!.id,
+      campaignId: camp!.id,
+      agentId: agnt!.id,
+      status: 'running',
+      workRange: { start: 0, end: 1_000_000, total: 1_000_000 },
+      requiredCapabilities: { gpu: false },
+    })
+    .returning({ id: tasks.id })
+  return { agentId: agnt!.id, taskId: task!.id }
+}
+
+beforeAll(async () => {
+  await cleanup()
+
+  const [proj] = await db
+    .insert(projects)
+    .values({ name: SLUG, slug: SLUG })
+    .returning({ id: projects.id })
+  projectId = proj!.id
+
+  const [list] = await db
+    .insert(hashLists)
+    .values({ projectId, name: 'list-zap-pag', status: 'ready' })
+    .returning({ id: hashLists.id })
+  hashListId = list!.id
+  ;({ agentId, taskId } = await createTaskFixture(hashListId, 'zap-pag'))
+
+  // Second campaign/task with an EMPTY hash list (no cracked rows) for scenario 4.
+  const [emptyList] = await db
+    .insert(hashLists)
+    .values({ projectId, name: 'list-zap-empty', status: 'ready' })
+    .returning({ id: hashLists.id })
+  ;({ agentId: emptyAgentId, taskId: emptyTaskId } = await createTaskFixture(
+    emptyList!.id,
+    'zap-empty'
+  ))
+})
+
+afterAll(async () => {
+  await cleanup()
+})
+
+// Fixed, millisecond-aligned timestamps (KTD3). T_TIED is shared by a
+// cluster larger than the walk's `limit`, so it must straddle a page
+// boundary; T_BEFORE/T_AFTER bracket the cluster.
+const T_BEFORE = new Date(1_752_000_000_000)
+const T_TIED = new Date(1_752_000_000_500)
+const T_AFTER = new Date(1_752_000_001_000)
+
+describe('getZapsForTask — composite cursor pagination', () => {
+  it('walks every cracked hash exactly once across a tied-timestamp cluster larger than limit', async () => {
+    // Arrange: 2 rows before the tie, 5 rows sharing ONE crackedAt, 2 after.
+    // With limit=3 the 5-row tied cluster cannot fit in one page — it must
+    // split across page boundaries without losing or repeating a tied row.
+    const before = ['zp-before-1', 'zp-before-2']
+    const tied = ['zp-tie-1', 'zp-tie-2', 'zp-tie-3', 'zp-tie-4', 'zp-tie-5']
+    const after = ['zp-after-1', 'zp-after-2']
+    const expected = [...before, ...tied, ...after]
+
+    await db.insert(hashItems).values([
+      ...before.map((hashValue) => ({
+        hashListId,
+        hashValue,
+        plaintext: 'pw',
+        crackedAt: T_BEFORE,
+      })),
+      ...tied.map((hashValue) => ({ hashListId, hashValue, plaintext: 'pw', crackedAt: T_TIED })),
+      ...after.map((hashValue) => ({
+        hashListId,
+        hashValue,
+        plaintext: 'pw',
+        crackedAt: T_AFTER,
+      })),
+    ])
+
+    // Act: full walk with a limit smaller than the tied cluster.
+    const seen = await walkAll(taskId, agentId, 3)
+
+    // Assert: exactly-once — the multiset of returned values equals the
+    // seeded set, with no duplicates and no omissions.
+    expect(seen.length).toBe(expected.length)
+    expect([...seen].sort()).toEqual([...expected].sort())
+    expect(new Set(seen).size).toBe(seen.length) // no duplicates
+  })
+
+  it('returns nextCursor: null on the final page, and empty for a cursor past the end', async () => {
+    // The final page of a full walk terminates with nextCursor === null
+    // (the service never emits a cursor pointing AT the last row).
+    let cursor: ZapCursor | undefined
+    let pages = 0
+    let finalCursor: string | null = 'sentinel'
+    for (let guard = 0; guard < 1000; guard++) {
+      const result = await getZapsForTask(taskId, agentId, projectId, { cursor, limit: 3 })
+      if ('error' in result) throw new Error(result.error)
+      pages++
+      finalCursor = result.nextCursor
+      if (result.nextCursor === null) break
+      cursor = decodeZapCursor(result.nextCursor)
+    }
+    expect(pages).toBeGreaterThan(1) // multi-page walk actually happened
+    expect(finalCursor).toBeNull() // clean termination
+
+    // A cursor positioned strictly past every row (max timestamp + max id)
+    // yields an empty page with a null cursor — the past-the-end contract.
+    const pastEnd: ZapCursor = { crackedAt: T_AFTER, id: 2_147_483_647 }
+    const tail = await getZapsForTask(taskId, agentId, projectId, { cursor: pastEnd, limit: 3 })
+    if ('error' in tail) throw new Error(tail.error)
+    expect(tail.zaps).toEqual([])
+    expect(tail.nextCursor).toBeNull()
+  })
+
+  it('returns { zaps: [], nextCursor: null } for a hash list with no cracked rows', async () => {
+    const result = await getZapsForTask(emptyTaskId, emptyAgentId, projectId, { limit: 3 })
+    if ('error' in result) throw new Error(result.error)
+    expect(result.zaps).toEqual([])
+    expect(result.nextCursor).toBeNull()
+  })
+
+  it('moving a row crackedAt forward causes a benign replay, never a skip (KTD4)', async () => {
+    // Fresh isolated hash list so the earlier seeded rows don't interfere.
+    const [list2] = await db
+      .insert(hashLists)
+      .values({ projectId, name: 'list-zap-immut', status: 'ready' })
+      .returning({ id: hashLists.id })
+    const list2Id = list2!.id
+    const immut = await createTaskFixture(list2Id, 'zap-immut')
+
+    const all = ['im-1', 'im-2', 'im-3', 'im-4']
+    await db.insert(hashItems).values(
+      all.map((hashValue, idx) => ({
+        hashListId: list2Id,
+        hashValue,
+        plaintext: 'pw',
+        // Distinct ascending timestamps so ordering is unambiguous.
+        crackedAt: new Date(1_752_100_000_000 + idx * 1000),
+      }))
+    )
+
+    // First page (limit 2) — pages past im-1, im-2. Capture the cursor.
+    const page1 = await getZapsForTask(immut.taskId, immut.agentId, projectId, { limit: 2 })
+    if ('error' in page1) throw new Error(page1.error)
+    expect(page1.zaps).toEqual(['im-1', 'im-2'])
+    expect(page1.nextCursor).not.toBeNull()
+
+    // Re-crack im-1 (already paged past) by moving its crackedAt FORWARD,
+    // beyond every other row — the monotonic-forward mutation of KTD4.
+    await db
+      .update(hashItems)
+      .set({ crackedAt: new Date(1_752_100_099_000) })
+      .where(and(eq(hashItems.hashListId, list2Id), eq(hashItems.hashValue, 'im-1')))
+
+    // Continue the walk from the captured cursor (page1) to exhaustion.
+    const continued: string[] = []
+    let cursor: ZapCursor | undefined = decodeZapCursor(page1.nextCursor!)
+    for (let guard = 0; guard < 1000; guard++) {
+      const r = await getZapsForTask(immut.taskId, immut.agentId, projectId, { cursor, limit: 2 })
+      if ('error' in r) throw new Error(r.error)
+      continued.push(...r.zaps)
+      if (r.nextCursor === null) break
+      cursor = decodeZapCursor(r.nextCursor)
+    }
+
+    const seenAcrossWalk = [...page1.zaps, ...continued]
+
+    // No SKIP: every original hash appears at least once across the walk.
+    for (const hashValue of all) {
+      expect(seenAcrossWalk).toContain(hashValue)
+    }
+    // Benign REPLAY: im-1 was paged past, moved forward, and reappears —
+    // exactly the accepted, documented duplicate (never a skip).
+    expect(seenAcrossWalk.filter((h) => h === 'im-1').length).toBe(2)
+  })
+})

--- a/packages/backend/tests/db/zaps-pagination.db.test.ts
+++ b/packages/backend/tests/db/zaps-pagination.db.test.ts
@@ -230,6 +230,53 @@ describe('getZapsForTask — composite cursor pagination', () => {
     expect(result.nextCursor).toBeNull()
   })
 
+  it('returns exactly-limit rows in a single page with nextCursor: null (boundary)', async () => {
+    // Exactly `limit` cracked rows must come back in one call with no
+    // continuation token — pins the strict `>` in `rows.length > fetchLimit`.
+    const [list] = await db
+      .insert(hashLists)
+      .values({ projectId, name: 'list-zap-exact', status: 'ready' })
+      .returning({ id: hashLists.id })
+    const fx = await createTaskFixture(list!.id, 'zap-exact')
+    await db.insert(hashItems).values(
+      ['ex-1', 'ex-2', 'ex-3'].map((hashValue, idx) => ({
+        hashListId: list!.id,
+        hashValue,
+        plaintext: 'pw',
+        crackedAt: new Date(1_752_200_000_000 + idx * 1000),
+      }))
+    )
+
+    const result = await getZapsForTask(fx.taskId, fx.agentId, projectId, { limit: 3 })
+    if ('error' in result) throw new Error(result.error)
+    expect(result.zaps).toEqual(['ex-1', 'ex-2', 'ex-3'])
+    expect(result.nextCursor).toBeNull()
+  })
+
+  it('clamps a below-range limit up to 1 rather than returning zero rows', async () => {
+    // The service independently clamps `Math.max(limit, 1)`; a limit of 0
+    // must still return the first row (and a cursor since more remain), not
+    // an empty page.
+    const [list] = await db
+      .insert(hashLists)
+      .values({ projectId, name: 'list-zap-clamp', status: 'ready' })
+      .returning({ id: hashLists.id })
+    const fx = await createTaskFixture(list!.id, 'zap-clamp')
+    await db.insert(hashItems).values(
+      ['cl-1', 'cl-2', 'cl-3'].map((hashValue, idx) => ({
+        hashListId: list!.id,
+        hashValue,
+        plaintext: 'pw',
+        crackedAt: new Date(1_752_300_000_000 + idx * 1000),
+      }))
+    )
+
+    const result = await getZapsForTask(fx.taskId, fx.agentId, projectId, { limit: 0 })
+    if ('error' in result) throw new Error(result.error)
+    expect(result.zaps).toEqual(['cl-1'])
+    expect(result.nextCursor).not.toBeNull()
+  })
+
   it('moving a row crackedAt forward causes a benign replay, never a skip (KTD4)', async () => {
     // Fresh isolated hash list so the earlier seeded rows don't interfere.
     const [list2] = await db

--- a/packages/backend/tests/integration/agent-config-route.test.ts
+++ b/packages/backend/tests/integration/agent-config-route.test.ts
@@ -172,7 +172,12 @@ if (!IS_ISOLATED) {
     })),
     getTaskById: mock(async () => null),
     listTasks: mock(async () => ({ tasks: [], total: 0, limit: 50, offset: 0 })),
-    getZapsForTask: mock(async () => ({ zaps: [], hasMore: false })),
+    // Pinned via `mock<ReturnType>` per the contract-test-mocks convention so
+    // a future service wire-shape change (#182 replaced `hasMore` with
+    // `nextCursor`) compile-fails here instead of drifting silently.
+    getZapsForTask: mock<(typeof import('../../src/services/tasks.js'))['getZapsForTask']>(
+      async () => ({ zaps: [], nextCursor: null })
+    ),
     AGENT_TASK_ACTIVE_STATUSES: ['pending', 'assigned', 'running'] as const,
     projectAgentTaskRows: mock(),
     buildCapabilityPredicate: mock(() => ({ sql: 'TRUE' })),

--- a/packages/backend/tests/unit/agent-api-contract.test.ts
+++ b/packages/backend/tests/unit/agent-api-contract.test.ts
@@ -198,11 +198,13 @@ const handleTaskFailureFixture = {
   task: taskRowFixture,
   retried: false,
 } satisfies Awaited<ReturnType<TasksRetryService['handleTaskFailure']>>
-// getZapsForTask real return is `{zaps, hasMore} | {error}`. PR #190 fixed
-// the shape; this pin enforces it stays correct.
+// getZapsForTask real return is `{zaps, nextCursor} | {error}` (#182
+// replaced `hasMore` with the opaque composite cursor). This pin — via
+// `satisfies Awaited<ReturnType<...>>` — enforces the mock mirrors the
+// service, so a service-shape change breaks this at compile time.
 const getZapsForTaskFixture = {
   zaps: [],
-  hasMore: false,
+  nextCursor: null,
 } satisfies Awaited<ReturnType<TasksZapsService['getZapsForTask']>>
 // getResourcesForTask real return is `{resources} | {error} | {notReady}`
 // (#108 U6; `notReady` added by the referenced-but-unresolved-resource
@@ -1610,13 +1612,14 @@ describe('Agent API: errored-agent rejection across work endpoints', () => {
   )
 })
 
-// ─── ZapResponse wire shape regression test (post-U6 fix) ───────────
+// ─── ZapResponse wire shape regression test ─────────────────────────
 //
 // U6 initially declared ZapResponse as `{ taskId, hashes }` while
-// `getZapsForTask` actually returns `{ zaps, hasMore }`. The fix
-// restored the original `{ zaps, hasMore }` schema. This test pins
-// the contract against the real service mock so the wire shape and
-// the spec can never silently diverge again.
+// `getZapsForTask` actually returns the zaps envelope. #182 changed
+// that envelope from `{ zaps, hasMore }` to `{ zaps, nextCursor }`
+// (opaque composite cursor). This test pins the current contract
+// against the real service mock so the wire shape and the spec can
+// never silently diverge again.
 
 describe('Agent API: POST /tasks/:id/report — wire shape', () => {
   it('returns bare { acknowledged: true } body on the non-failure path', async () => {
@@ -1645,15 +1648,17 @@ describe('Agent API: POST /tasks/:id/report — wire shape', () => {
 })
 
 describe('Agent API: GET /tasks/:id/zaps — wire shape', () => {
-  it('returns { zaps, hasMore } body matching getZapsForTask runtime shape', async () => {
-    // Arrange — override the default mock with a non-empty payload so
-    // the field-shape assertion has actual data to verify.
+  it('returns { zaps, nextCursor } body matching getZapsForTask runtime shape', async () => {
+    // Arrange — override the default mock with a non-empty payload and a
+    // continuation token so the field-shape assertion has real data.
     const tasksMod = await import('../../src/services/tasks.js')
     ;(
       tasksMod.getZapsForTask as unknown as {
         mockImplementationOnce: (fn: () => unknown) => void
       }
-    ).mockImplementationOnce(() => Promise.resolve({ zaps: ['hash1', 'hash2'], hasMore: false }))
+    ).mockImplementationOnce(() =>
+      Promise.resolve({ zaps: ['hash1', 'hash2'], nextCursor: 'opaque-token' })
+    )
 
     const token = agentToken(TEST_AGENT_TOKEN)
     const res = await app.request(`${AGENT_BASE}/tasks/42/zaps`, {
@@ -1664,14 +1669,107 @@ describe('Agent API: GET /tasks/:id/zaps — wire shape', () => {
     expect(res.status).toBe(200)
     const body = (await res.json()) as Record<string, unknown>
     expect(body).toHaveProperty('zaps')
-    expect(body).toHaveProperty('hasMore')
+    expect(body).toHaveProperty('nextCursor')
     expect(Array.isArray(body['zaps'])).toBe(true)
-    expect(body['hasMore']).toBe(false)
+    expect(body['nextCursor']).toBe('opaque-token')
+    // `hasMore` was removed in #182 — pin its absence so a regression
+    // can't re-add the redundant key alongside `nextCursor`.
+    expect(body['hasMore']).toBeUndefined()
     // Negative-shape assertions catch a regression that would re-add
     // the wrong keys (`taskId`/`hashes`) and silently break agent
     // codegen consumers parsing this response.
     expect(body['taskId']).toBeUndefined()
     expect(body['hashes']).toBeUndefined()
+  })
+
+  it('emits nextCursor: null (explicit key) at exhaustion', async () => {
+    const tasksMod = await import('../../src/services/tasks.js')
+    ;(
+      tasksMod.getZapsForTask as unknown as {
+        mockImplementationOnce: (fn: () => unknown) => void
+      }
+    ).mockImplementationOnce(() => Promise.resolve({ zaps: ['only-hash'], nextCursor: null }))
+
+    const token = agentToken(TEST_AGENT_TOKEN)
+    const res = await app.request(`${AGENT_BASE}/tasks/42/zaps`, {
+      method: 'GET',
+      headers: { authorization: `Bearer ${token}` },
+    })
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Record<string, unknown>
+    // Exhaustion is an explicit null, never an absent key — a client can
+    // terminate on `nextCursor === null` without also handling absence.
+    expect(body).toHaveProperty('nextCursor')
+    expect(body['nextCursor']).toBeNull()
+  })
+})
+
+// ─── GET /tasks/:id/zaps — malformed cursor is 400, never 500/404 ────
+//
+// The `cursor` param is agent-controlled input decoded at the query
+// boundary (zapQuerySchema). A malformed / out-of-range token must fail
+// validation and return the agent VALIDATION_ERROR envelope (400) via
+// defaultHook — never a 500 (Invalid Date reaching the DB) and never a
+// 404 (the service's not-found path). Validation runs before the handler,
+// so the mocked getZapsForTask is never reached on these paths.
+
+function encodeCursorToken(payload: unknown): string {
+  return Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url')
+}
+
+describe('Agent API: GET /tasks/:id/zaps — malformed cursor', () => {
+  const cases: ReadonlyArray<{ name: string; cursor: string }> = [
+    { name: 'non-base64url garbage', cursor: '!!!not-a-cursor!!!' },
+    {
+      name: 'out-of-range id (beyond int4)',
+      cursor: encodeCursorToken({ c: 1_752_000_000_000, i: 2_147_483_648 }),
+    },
+    // The load-bearing case: a structurally valid but out-of-Date-range c
+    // would otherwise decode to an Invalid Date, reach Drizzle, and leak a
+    // 500. Bounding c at decode keeps it on the 400 path.
+    {
+      name: 'out-of-range c (beyond JS Date range)',
+      cursor: encodeCursorToken({ c: 8_640_000_000_000_001, i: 1 }),
+    },
+  ]
+
+  for (const { name, cursor } of cases) {
+    it(`returns 400 VALIDATION_ERROR for ${name}`, async () => {
+      const token = agentToken(TEST_AGENT_TOKEN)
+      const res = await app.request(
+        `${AGENT_BASE}/tasks/42/zaps?cursor=${encodeURIComponent(cursor)}`,
+        { method: 'GET', headers: { authorization: `Bearer ${token}` } }
+      )
+
+      expect(res.status).toBe(400)
+      const body = (await res.json()) as { error?: { code?: string } }
+      expect(body.error?.code).toBe('VALIDATION_ERROR')
+    })
+  }
+
+  it('accepts a well-formed cursor and reaches the service (200)', async () => {
+    // A valid token passes validation and hits the default mock → 200.
+    const validCursor = encodeCursorToken({ c: 1_752_000_000_123, i: 7 })
+    const token = agentToken(TEST_AGENT_TOKEN)
+    const res = await app.request(
+      `${AGENT_BASE}/tasks/42/zaps?cursor=${encodeURIComponent(validCursor)}`,
+      { method: 'GET', headers: { authorization: `Bearer ${token}` } }
+    )
+
+    expect(res.status).toBe(200)
+  })
+
+  it('treats an empty cursor (?cursor=) as absent → 200, not 400', async () => {
+    // A client serializing a nil/absent token as an empty string must
+    // restart the walk from the beginning, not get stuck on a 400.
+    const token = agentToken(TEST_AGENT_TOKEN)
+    const res = await app.request(`${AGENT_BASE}/tasks/42/zaps?cursor=`, {
+      method: 'GET',
+      headers: { authorization: `Bearer ${token}` },
+    })
+
+    expect(res.status).toBe(200)
   })
 })
 

--- a/packages/backend/tests/unit/agent-api-contract.test.ts
+++ b/packages/backend/tests/unit/agent-api-contract.test.ts
@@ -1773,6 +1773,38 @@ describe('Agent API: GET /tasks/:id/zaps — malformed cursor', () => {
   })
 })
 
+describe('Agent API: GET /tasks/:id/zaps — limit validation', () => {
+  const badLimits: ReadonlyArray<{ name: string; value: string }> = [
+    { name: 'zero (below min)', value: '0' },
+    { name: 'above the 10000 ceiling', value: '10001' },
+    { name: 'non-numeric', value: 'abc' },
+  ]
+
+  for (const { name, value } of badLimits) {
+    it(`rejects limit=${value} (${name}) with 400 VALIDATION_ERROR`, async () => {
+      const token = agentToken(TEST_AGENT_TOKEN)
+      const res = await app.request(`${AGENT_BASE}/tasks/42/zaps?limit=${value}`, {
+        method: 'GET',
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(res.status).toBe(400)
+      const body = (await res.json()) as { error?: { code?: string } }
+      expect(body.error?.code).toBe('VALIDATION_ERROR')
+    })
+  }
+
+  it('accepts limit at the 10000 ceiling → 200', async () => {
+    const token = agentToken(TEST_AGENT_TOKEN)
+    const res = await app.request(`${AGENT_BASE}/tasks/42/zaps?limit=10000`, {
+      method: 'GET',
+      headers: { authorization: `Bearer ${token}` },
+    })
+
+    expect(res.status).toBe(200)
+  })
+})
+
 // ─── GET /tasks/:id/resources — wire shape (#108 U6) ────────────────
 //
 // Pins the response envelope (`{ resources: [...] }`, not a bare array)

--- a/packages/backend/tests/unit/zap-cursor.test.ts
+++ b/packages/backend/tests/unit/zap-cursor.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Unit tests for the Agent API zaps opaque pagination cursor codec
+ * (U1 of docs/plans/2026-07-12-001-feat-zaps-composite-cursor-plan.md).
+ *
+ * The codec is pure and side-effect-free, so these tests fully pin its
+ * contract: lossless millisecond round-trip, base64url wire form, and
+ * defensive decode (never trust the agent-controlled token).
+ */
+import { describe, expect, it } from 'bun:test'
+
+import {
+  decodeZapCursor,
+  encodeZapCursor,
+  ZapCursorError,
+  type ZapCursor,
+} from '../../src/services/tasks/zap-cursor.js'
+
+describe('zap-cursor codec', () => {
+  it('round-trips a cursor losslessly at millisecond precision', () => {
+    // Arrange
+    const cursor: ZapCursor = { crackedAt: new Date(1_752_000_000_123), id: 42 }
+
+    // Act
+    const decoded = decodeZapCursor(encodeZapCursor(cursor))
+
+    // Assert
+    expect(decoded.id).toBe(42)
+    expect(decoded.crackedAt.getTime()).toBe(cursor.crackedAt.getTime())
+  })
+
+  it('produces a URL-safe base64url token with no +, /, or = characters', () => {
+    // Arrange
+    const cursor: ZapCursor = { crackedAt: new Date(1_752_000_000_999), id: 2_147_483_647 }
+
+    // Act
+    const token = encodeZapCursor(cursor)
+
+    // Assert
+    expect(token).not.toMatch(/[+/=]/)
+  })
+
+  it('rejects a token that is not valid base64url / decodable JSON', () => {
+    // "!!!" is not valid base64url; even if permissively decoded it is not JSON.
+    expect(() => decodeZapCursor('!!!not-base64!!!')).toThrow(ZapCursorError)
+  })
+
+  it('rejects valid base64url that does not decode to JSON', () => {
+    const notJson = Buffer.from('this is not json', 'utf8').toString('base64url')
+    expect(() => decodeZapCursor(notJson)).toThrow(ZapCursorError)
+  })
+
+  it('rejects JSON of the wrong shape (missing c)', () => {
+    const badShape = Buffer.from(JSON.stringify({ i: 1 }), 'utf8').toString('base64url')
+    expect(() => decodeZapCursor(badShape)).toThrow(ZapCursorError)
+  })
+
+  it('rejects JSON of the wrong shape (missing i)', () => {
+    const badShape = Buffer.from(JSON.stringify({ c: 1_752_000_000_000 }), 'utf8').toString(
+      'base64url'
+    )
+    expect(() => decodeZapCursor(badShape)).toThrow(ZapCursorError)
+  })
+
+  it('rejects extra unexpected keys (strict shape)', () => {
+    const extra = Buffer.from(
+      JSON.stringify({ c: 1_752_000_000_000, i: 1, evil: true }),
+      'utf8'
+    ).toString('base64url')
+    expect(() => decodeZapCursor(extra)).toThrow(ZapCursorError)
+  })
+
+  it('rejects a non-integer id', () => {
+    const bad = Buffer.from(JSON.stringify({ c: 1_752_000_000_000, i: 1.5 }), 'utf8').toString(
+      'base64url'
+    )
+    expect(() => decodeZapCursor(bad)).toThrow(ZapCursorError)
+  })
+
+  it('rejects id = 0, negative id, and id beyond int4', () => {
+    for (const i of [0, -1, 2_147_483_648]) {
+      const bad = Buffer.from(JSON.stringify({ c: 1_752_000_000_000, i }), 'utf8').toString(
+        'base64url'
+      )
+      expect(() => decodeZapCursor(bad)).toThrow(ZapCursorError)
+    }
+  })
+
+  it('rejects a negative or non-finite crackedAt (c)', () => {
+    for (const c of [-1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const bad = Buffer.from(JSON.stringify({ c, i: 1 }), 'utf8').toString('base64url')
+      expect(() => decodeZapCursor(bad)).toThrow(ZapCursorError)
+    }
+  })
+
+  it('rejects c beyond the JS Date range (guards the 500-not-400 gap)', () => {
+    // A structurally valid but out-of-Date-range c must fail decode rather
+    // than becoming an Invalid Date that only surfaces as a 500 downstream.
+    const bad = Buffer.from(JSON.stringify({ c: 8_640_000_000_000_001, i: 1 }), 'utf8').toString(
+      'base64url'
+    )
+    expect(() => decodeZapCursor(bad)).toThrow(ZapCursorError)
+  })
+})

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -901,7 +901,7 @@ export const taskResourceEntrySchema = z.object({
 /**
  * Response body for `GET /tasks/{taskId}/resources`. Wrapped in a
  * `resources` key (rather than a bare array) to match every other
- * agent-surface response's envelope shape (e.g. `{ zaps, hasMore }`)
+ * agent-surface response's envelope shape (e.g. `{ zaps, nextCursor }`)
  * and to leave room for additive top-level fields later without a
  * breaking wire change.
  */


### PR DESCRIPTION
## Summary

Closes #182. Replaces the unsound `since: Date` pagination on the Agent API zaps endpoint (`GET /api/v1/agent/tasks/{taskId}/zaps`) with an opaque, server-round-tripped **composite cursor** over `(crackedAt, id)`.

| | |
|---|---|
| **Impact** | 9 files (zaps feature) - roughly half production code, half tests |
| **Change size** | ~870 additions / ~51 deletions |
| **Risk** | Low-Medium - one deliberate, owner-authorized breaking change (details below) |
| **Review effort** | ~30-45 min |
| **New tests** | 11 codec unit tests + 6 real-DB tests + route contract/limit tests |

The old contract returned `{ zaps, hasMore }` - cracked hash **values** only, with no cursor material to advance with - and paginated off a single-millisecond `since` timestamp. When more cracked rows shared one `crackedAt` than fit in `limit`, advancing `since` past the largest returned timestamp **skipped** the tied remainder, while advancing with `>=` **replayed** already-seen rows. Both are wrong.

Now the server mints a base64url `nextCursor` token that the agent echoes back verbatim as `cursor`. The agent never parses or constructs it, so the entire `>` vs `>=` / advance-the-cursor bug class disappears. An agent walks every cracked hash exactly once across calls, terminating when `nextCursor === null`.

---

## Breaking change (owner-authorized)

This deliberately breaks the Agent API - a documented exception to the "never break the agent surface" rule, approved under repo-owner product authority because the system is pre-deployment and the hashcat worker agents are being regenerated from the OpenAPI (Open Application Programming Interface) spec:

- **Removed** the `since` query param and the `hasMore` response field.
- **Added** the optional opaque `cursor` query param and the `nextCursor` response field.
- Response is now `{ zaps, nextCursor }`, where `nextCursor` is **always present** - a token when more rows remain, explicit `null` at exhaustion (never an absent key).
- The break is stated in the route `description`, so the regenerated `openapi.json` makes it explicit rather than leaving it to a diff.

**Rollout:** the backend change and the regenerated agent client land together - the agents are rebuilt off the spec, not upgraded in place, so there is no mixed-version window.

---

## What changed

**Production code**
- `services/tasks/zap-cursor.ts` (new) - the opaque cursor codec: base64url of `{ "c": <epochMillis>, "i": <id> }`, with strict, defensive decode (bounds on both fields).
- `services/tasks/zaps.ts` - composite `(crackedAt, id)` keyset filter, `nextCursor` minting, fail-loud pagination invariant, exported `MAX_ZAPS_LIMIT`.
- `routes/agent/index.ts` - route contract: drop `since`/`hasMore`, add `cursor`/`nextCursor`, boundary-400 cursor decode, documented breaking change, shared limit constant.
- `lib/pg-limits.ts` (new) - shared `MAX_PG_INT4` so validation boundaries agree on one source of truth.
- `shared/src/schemas/index.ts` - one illustrative doc-comment refreshed to the new envelope.

**Tests**
- `tests/unit/zap-cursor.test.ts` (new) - 11 codec cases: round-trip, base64url form, and every malformed/out-of-range decode path.
- `tests/db/zaps-pagination.db.test.ts` (new) - 6 real-Postgres cases (see Test coverage).
- `tests/unit/agent-api-contract.test.ts` - wire shape, exhaustion, malformed-cursor 400s, limit validation.
- `tests/integration/agent-config-route.test.ts` - updated the stale `getZapsForTask` mock to the new shape, pinned via `mock<ReturnType>`.

**Unrelated (pre-existing on the branch):** `docs/solutions/test-failures/openldap-testcontainer-bootstrap-race.md` is a documentation commit that predates this work and rode along on the branch.

---

## How it works

- **Opaque codec:** the cursor is agent-controlled input decoded defensively at the request boundary - bad base64, non-JSON, wrong shape, or out-of-range `c`/`id` all yield a clean **400** `VALIDATION_ERROR`, never a 500 or a silent full-table scan. Bounding `c` to the JavaScript `Date` range is load-bearing: an unbounded value would decode to an `Invalid Date` and leak a 500 downstream.
- **Precision:** the cursor carries `crackedAt` as epoch-milliseconds and round-trips through a native `Date`, matching the existing keyset-pagination pattern in `services/results/export.ts` and `routes/dashboard/results.ts`. This is correct because every `crackedAt` write in the codebase goes through a JavaScript `Date` (millisecond precision), so the `timestamptz` column never holds sub-millisecond values.
- **Composite filter:** `gte(crackedAt, c.crackedAt) AND (crackedAt > c.crackedAt OR (crackedAt = c.crackedAt AND id > c.id))`, matching `ORDER BY (crackedAt, id)`. The leading `gte` is logically redundant with the `OR` but restores the index range-scan on the hot polling path (the `OR` alone degrades to a row-by-row filter) - verified with `EXPLAIN`.
- **Immutability:** the one `crackedAt` mutation path (re-crack upsert) only ever moves the value **forward**, so it can cause a rare, benign **replay** but never a **skip** - characterized by a test.

```mermaid
sequenceDiagram
    participant A as Agent
    participant R as Route (zapQuerySchema)
    participant S as getZapsForTask
    participant DB as Postgres
    A->>R: GET /tasks/{id}/zaps (no cursor)
    R->>S: { cursor: undefined, limit }
    S->>DB: ORDER BY (crackedAt, id) LIMIT limit+1
    DB-->>S: rows
    S-->>R: { zaps, nextCursor: "eyJj..." }
    R-->>A: 200
    A->>R: GET .../zaps?cursor=eyJj...
    Note over R: decode → {crackedAt,id}; malformed → 400
    R->>S: { cursor, limit }
    S->>DB: AND (crackedAt > c OR (crackedAt = c AND id > c.id))
    S-->>R: { zaps, nextCursor: null }
    R-->>A: 200 → agent stops
```

---

## Risk assessment

| Factor | Level | Detail |
|--------|-------|--------|
| Size | Low | ~870 lines, roughly half tests; single bounded feature |
| Complexity | Low-Medium | Cursor/keyset logic, but mirrors the proven `export.ts` pattern |
| Contract | **Medium** | Deliberate Agent API break - mitigated by pre-deployment + coordinated agent regen |
| Test coverage | Low risk | Real-DB exactly-once proof + exhaustive codec/boundary tests |
| Security | Low | Agent-controlled cursor is strictly validated → 400; cross-tenant reads traced and ruled out (scoping runs before the cursor predicate); token is unsigned but only repositions within the caller's own already-scoped result set |
| Dependencies | None | No new runtime dependencies |

---

## Test coverage

All three lanes green locally (`just ci-check`: backend 1072, `test:db` 390, frontend e2e 15).

- [x] **Codec unit** - lossless ms round-trip, base64url form, and every defensive-decode path (bad base64/JSON/shape, strict extra-key rejection, out-of-range `id` and `c`).
- [x] **Route contract** - `{ zaps, nextCursor }` wire shape, explicit `null` at exhaustion, malformed cursor → 400 (bad base64 / out-of-range `id` / out-of-range `c`), empty `?cursor=` treated as absent → 200, and limit validation (0 / 10001 / non-numeric → 400, 10000 accepted).
- [x] **Real-DB** (`test:db` lane) - exactly-once walk across a **tied-timestamp cluster larger than `limit`** (the property mocks can't prove), clean exhaustion / past-the-end, empty hash list, exactly-`limit` single-page boundary, below-range limit clamp, and the replay-not-skip immutability characterization.

---

## Review checklist

### Code quality
- [x] No code duplication (shared `MAX_PG_INT4` / `MAX_ZAPS_LIMIT` constants)
- [x] Errors handled explicitly; cursor decode narrowed to `ZapCursorError` (unexpected faults → logged 500, not a mislabeled 400)
- [x] Fail-loud pagination invariant instead of a silent false-"exhausted" signal
- [x] Immutable patterns; no mutation of shared state

### Agent API contract
- [x] `createRoute` definition is the spec; `openapi.json` regenerates with `cursor`/`nextCursor` and no `since`/`hasMore`
- [x] Breaking change documented in the route `description`
- [x] `nextCursor` modeled as `.nullable()` (always present), `cursor` carries opacity docs + example for codegen

### Security
- [x] Agent-controlled cursor validated at the boundary; malformed → 400 envelope
- [x] SQL is parameterized via Drizzle; no injection surface
- [x] Length + range bounds on the token before any decode/parse work
- [x] Cross-tenant safety: scoping (project + agent) runs before the cursor predicate

### Testing
- [x] New behavior covered by tests; DB test proves the exactly-once property against real SQL semantics
- [x] Contract-test mocks mirror the service `ReturnType` (pinned via `satisfies` / `mock<...>`)
- [x] Edge and error paths tested (ties, exhaustion, boundaries, malformed input)

---

## Review history

This PR has already been through several review passes before request:
- A structured multi-persona plan/code review (correctness, security, api-contract, performance, project-standards) - one P1 (stale mock) and several hardening items applied.
- A comprehensive PR-toolkit review (code, type-design, silent-failure, comments, tests) - the silent-failure and coverage findings landed as commit `2b36d31`.
- Automated review feedback (Copilot, CodeRabbit) resolved: the limit constant was centralized (`37e5787`); the remaining nitpicks were already addressed or are documented deferrals.

Commits: `6c746bb` (feature) -> `2b36d31` (review hardening) -> `37e5787` (limit centralization).

---

Tooling: implemented with AI assistance (Claude Code). Every line was reviewed and is owned by the author.
