### PR TITLE
docs: refresh docs/solutions for route-as-spec + drifted refs

### DIFF
--- a/docs/solutions/conventions/barrel-plus-subdir-service-split.md
+++ b/docs/solutions/conventions/barrel-plus-subdir-service-split.md
@@ -30,7 +30,7 @@ related_components:
 Two refactors in `packages/backend/src/services` independently hit the same constraints and converged on the same shape:
 
 - **U7** split `services/agents.ts` by extracting `services/agents/heartbeat.ts` while keeping `services/agents.ts` in place as both the slimmed primary file and the barrel.
-- **U9** split `services/tasks.ts` (1286 LOC, over the 800-line file budget from `~/.claude/rules/coding-style.md`) into `services/tasks/retry.ts`, `services/tasks/zaps.ts`, `services/tasks/agent-projection.ts`, plus a small `services/tasks/_internals.ts` for shared helpers -- and kept the parent at `services/tasks.ts` (now 751 LOC).
+- **U9** split `services/tasks.ts` (1286 LOC, over the 800-line file budget from `~/.claude/rules/coding-style.md`) into `services/tasks/retry.ts`, `services/tasks/zaps.ts`, `services/tasks/agent-projection.ts`, plus a small `services/tasks/_internals.ts` for shared helpers -- and kept the parent at `services/tasks.ts` (751 LOC right after the split; the pattern has since accreted more submodules and the parent has grown past the budget again as new task logic landed -- a later split is warranted).
 
 Both refactors had to preserve a fragile set of caller assumptions: seven test files mock the parent path with `mock.module('../../src/services/tasks.js', ...)`, `services/agents/heartbeat.ts` does `await import('../tasks.js')` to break a circular dep, and call sites across `routes/` and other services import the parent directly. Renaming the parent to `services/tasks/index.ts` would have silently no-op'd the mock registrations and forced churn across dozens of files. The convention below is what survives those constraints.
 
@@ -146,17 +146,19 @@ Atomic commits on `refactor/tasks-service-split` (PR #181):
 - `fb77ee4` -- extract zap endpoint to `services/tasks/zaps.ts`
 - `ea1029e` -- alphabetize re-export statements by source file
 
-Final tree:
+Tree right after the U9 split (`_internals` + three extracted submodules, parent as barrel at tail):
 
 ```text
 packages/backend/src/services/
-├── tasks.ts                              # 751 LOC, barrel at tail
+├── tasks.ts                              # barrel at tail
 └── tasks/
-    ├── _internals.ts                     # jsonSafeBigint, ~30 LOC
-    ├── agent-projection.ts               # listTasksByAgent + projectAgentTaskRows, ~99 LOC
-    ├── retry.ts                          # handleTaskFailure + reassignStaleTasks + MAX_RETRIES, ~420 LOC
-    └── zaps.ts                           # getZapsForTask, ~71 LOC
+    ├── _internals.ts                     # jsonSafeBigint
+    ├── agent-projection.ts               # listTasksByAgent + projectAgentTaskRows
+    ├── retry.ts                          # handleTaskFailure + reassignStaleTasks + MAX_RETRIES
+    └── zaps.ts                           # getZapsForTask
 ```
+
+The pattern kept accreting the same way as more task logic landed: `services/tasks/` has since gained `preemption.ts`, `task-events.ts`, `task-resources.ts`, and `zap-cursor.ts`. Each extraction followed the identical barrel-plus-subdir shape without touching caller imports -- the point of the convention.
 
 Caller code unchanged across the refactor:
 

--- a/docs/solutions/conventions/barrel-plus-subdir-service-split.md
+++ b/docs/solutions/conventions/barrel-plus-subdir-service-split.md
@@ -30,7 +30,7 @@ related_components:
 Two refactors in `packages/backend/src/services` independently hit the same constraints and converged on the same shape:
 
 - **U7** split `services/agents.ts` by extracting `services/agents/heartbeat.ts` while keeping `services/agents.ts` in place as both the slimmed primary file and the barrel.
-- **U9** split `services/tasks.ts` (1286 LOC, over the 800-line file budget from `~/.claude/rules/coding-style.md`) into `services/tasks/retry.ts`, `services/tasks/zaps.ts`, `services/tasks/agent-projection.ts`, plus a small `services/tasks/_internals.ts` for shared helpers -- and kept the parent at `services/tasks.ts` (751 LOC right after the split; the pattern has since accreted more submodules and the parent has grown past the budget again as new task logic landed -- a later split is warranted).
+- **U9** split `services/tasks.ts` (1286 LOC, over the project's 800-line file-size budget) into `services/tasks/retry.ts`, `services/tasks/zaps.ts`, `services/tasks/agent-projection.ts`, plus a small `services/tasks/_internals.ts` for shared helpers -- and kept the parent at `services/tasks.ts` (751 LOC right after the split; the pattern has since accreted more submodules and the parent has grown past the budget again as new task logic landed -- a later split is warranted).
 
 Both refactors had to preserve a fragile set of caller assumptions: seven test files mock the parent path with `mock.module('../../src/services/tasks.js', ...)`, `services/agents/heartbeat.ts` does `await import('../tasks.js')` to break a circular dep, and call sites across `routes/` and other services import the parent directly. Renaming the parent to `services/tasks/index.ts` would have silently no-op'd the mock registrations and forced churn across dozens of files. The convention below is what survives those constraints.
 
@@ -119,7 +119,7 @@ The U7 agents split is the first instance of this pattern in the codebase -- it 
 
 - **Barrel surface stability for `mock.module`.** Bun's `mock.module(path, ...)` binds by literal path. If the parent moves to `services/tasks/index.ts`, the seven test files registering `mock.module('../../src/services/tasks.js', ...)` resolve to a new module identity that the production code no longer imports -- the mocks silently no-op and tests pass by accident. The barrel keeps the literal path live.
 - **Stable lazy-import resolution for circular-dep workarounds.** `services/agents/heartbeat.ts` uses `await import('../tasks.js')` to break a cycle with `services/tasks.ts`. Moving the parent breaks the dynamic-import path string.
-- **File-size budget.** The 800-line/file rule from `~/.claude/rules/coding-style.md` is non-negotiable. Submodules are how large services stay under budget without breaking the public surface.
+- **File-size budget.** The project's 800-line/file budget is non-negotiable. Submodules are how large services stay under budget without breaking the public surface.
 - **Avoids the ESM cycle trap.** A sibling submodule that imports through the parent barrel forms a hard cycle: parent re-exports from submodule, submodule imports from parent. `_internals.ts` is the escape valve -- it sits below both the parent and the submodules in the dependency graph.
 
 ## When to Apply
@@ -183,5 +183,5 @@ mock.module('../../src/services/tasks.js', () => ({
 ## Related
 
 - `docs/solutions/conventions/bun-test-mock-module-import-order.md` -- why `mock.module` path identity matters and how Bun resolves it. This convention exists in part to preserve the path identity that doc depends on.
-- `~/.claude/rules/coding-style.md` -- the 800-line file budget that drives when this pattern applies.
+- The project's 800-line file-size budget -- drives when this pattern applies.
 - `GOTCHAS.md` -- Service Layer entry covers the lazy `await import(...)` cycle workaround that this convention preserves.

--- a/docs/solutions/conventions/bun-test-mock-module-import-order.md
+++ b/docs/solutions/conventions/bun-test-mock-module-import-order.md
@@ -27,7 +27,7 @@ ESM `import` declarations are hoisted to the top of the module regardless of whe
 
 The failure mode is silent: the test still passes — sometimes by coincidence, sometimes because the assertion doesn't actually exercise the path the mock was meant to control — and a real bug in the route can ship under cover of a green test.
 
-**Concrete instance from PR #173:** In `packages/backend/tests/unit/dashboard-api-contract.test.ts`, the 200-success test for `POST /projects/select` called `mock.module('../../src/services/projects.js', ...)` inside the `it()` body to override `getProjectById` and `findProjectMembership`. The route's handler had already been loaded via the top-of-file `import { app }`, so `findProjectMembership` was captured at the original implementation. The inline mock had no effect. CodeRabbit caught this on the second review round; the test had been "passing" but not for the reason its author believed.
+**Concrete instance from PR #173:** In `dashboard-api-contract.test.ts`, the 200-success test for `POST /projects/select` called `mock.module('../../src/services/projects.js', ...)` inside the `it()` body to override `getProjectById` and `findProjectMembership`. The route's handler had already been loaded via the top-of-file `import { app }`, so `findProjectMembership` was captured at the original implementation. The inline mock had no effect. CodeRabbit caught this on the second review round; the test had been "passing" but not for the reason its author believed. (That file was later deleted in PR #188 when the dashboard-api YAML was retired; the `/projects/select` coverage now lives in `packages/backend/tests/unit/routes/projects-select-preference.test.ts`, using the corrected Pattern A below — it mocks once at the top before importing a single route module rather than the whole `app`.)
 
 This is a recurring trap. The same hoisting interaction has surfaced multiple times in this codebase: the isolated-phase pattern in `agent-heartbeat.test.ts`, `tasks.test.ts`, `queue-manager.test.ts`, `control-routes-rbac.test.ts`, and `redis-degradation.test.ts` was developed specifically to work around it (session history). An earlier frontend encounter in `campaign-dag-view.test.tsx` had the same shape (session history). The two patterns below name and codify the existing resolutions so future test authors pick the right one deliberately.
 
@@ -53,7 +53,7 @@ Gate the test body behind an env var (e.g., `WS_AUTH_TEST_ISOLATED=1`). When set
 Use when:
 - The test file sets `process.env` values the route reads at module load (config flags, timeout overrides, feature gates).
 - You mock broad surfaces (auth, DB clients, BetterAuth, Drizzle) and don't want those mocks leaking into other test files sharing the bun-test process.
-- The SUT uses top-level await, which requires the dynamic import refinement noted in `GOTCHAS.md` line 82.
+- The SUT uses top-level await, which requires the dynamic import refinement noted in `GOTCHAS.md`'s Backend Testing (bun:test) section.
 
 ### Decision rule
 

--- a/docs/solutions/conventions/dashboard-read-endpoint-contract.md
+++ b/docs/solutions/conventions/dashboard-read-endpoint-contract.md
@@ -87,7 +87,7 @@ const projectInvalidationKeys = {
 }
 ```
 
-The brainstorm that produced this convention initially proposed a new `dashboard_stats_changed` event. Doc review found that `event-routing.ts:73-84` already invalidates `['dashboard-stats']` on `agent_status`, `campaign_status`, `task_update`, and `crack_result` — adding a new event type would have produced redundant double-invalidations at every publisher site with no behavioral payoff. Future endpoint authors must not repeat this mistake. If the publisher-coupling concern grows enough that the routing map becomes hard to maintain, take it as a separate refactor — not as a per-endpoint pattern.
+The brainstorm that produced this convention initially proposed a new `dashboard_stats_changed` event. Doc review found that the `projectInvalidationKeys` map in `event-routing.ts` already invalidates `['dashboard-stats']` on `agent_status`, `campaign_status`, `task_update`, and `crack_result` — adding a new event type would have produced redundant double-invalidations at every publisher site with no behavioral payoff. Future endpoint authors must not repeat this mistake. If the publisher-coupling concern grows enough that the routing map becomes hard to maintain, take it as a separate refactor — not as a per-endpoint pattern.
 
 ## Compile-time vs. runtime enforcement boundary
 
@@ -142,4 +142,4 @@ The same opportunistic-backfill rule applies to inline-declared response interfa
 - **AGENTS.md** — "Wire shapes live in `@hashhive/shared` as `z.infer` from Zod schemas" and "All three surfaces are route-as-spec via `@hono/zod-openapi`."
 - [`docs/solutions/conventions/shared-zod-openapi-wire-contract-mirror-2026-05-25.md`](./shared-zod-openapi-wire-contract-mirror-2026-05-25.md) — the parent triple-sync convention, now superseded by the route-as-spec migration.
 - **Issue #161 / PR landing this convention** — closes the original DoD gaps on `/stats` and ships `/stats` as the worked example.
-- **`packages/frontend/src/lib/event-routing.ts:73-84`** — the central invalidation map. Read this before proposing any new event type for a dashboard freshness story.
+- **`packages/frontend/src/lib/event-routing.ts`** (the `projectInvalidationKeys` map) — the central invalidation map. Read this before proposing any new event type for a dashboard freshness story.

--- a/docs/solutions/conventions/dashboard-read-endpoint-contract.md
+++ b/docs/solutions/conventions/dashboard-read-endpoint-contract.md
@@ -115,7 +115,7 @@ This convention applies **strictly to `/api/v1/dashboard/*`** GET endpoints. The
 | Shared inferred type | `packages/shared/src/types/index.ts` (`DashboardStats`, `CampaignStatus`) |
 | Route (binds shared schema in `createRoute(...)` → published in `/api/v1/dashboard/openapi.json`) | `packages/backend/src/routes/dashboard/stats.ts` |
 | Integration test | `packages/backend/tests/unit/dashboard-stats-routes.test.ts` |
-| Frontend consumer | `packages/frontend/src/hooks/use-dashboard.ts` (`useDashboardStats`); freshness via `packages/frontend/src/lib/event-routing.ts:73-84` |
+| Frontend consumer | `packages/frontend/src/hooks/use-dashboard.ts` (`useDashboardStats`); freshness via the `projectInvalidationKeys` map in `packages/frontend/src/lib/event-routing.ts` |
 
 ## Existing endpoints predating this contract
 

--- a/docs/solutions/conventions/dashboard-read-endpoint-contract.md
+++ b/docs/solutions/conventions/dashboard-read-endpoint-contract.md
@@ -87,7 +87,7 @@ const projectInvalidationKeys = {
 }
 ```
 
-The brainstorm that produced this convention initially proposed a new `dashboard_stats_changed` event. Doc review found that the `projectInvalidationKeys` map in `event-routing.ts` already invalidates `['dashboard-stats']` on `agent_status`, `campaign_status`, `task_update`, and `crack_result` — adding a new event type would have produced redundant double-invalidations at every publisher site with no behavioral payoff. Future endpoint authors must not repeat this mistake. If the publisher-coupling concern grows enough that the routing map becomes hard to maintain, take it as a separate refactor — not as a per-endpoint pattern.
+The brainstorm that produced this convention initially proposed a new `dashboard_stats_changed` event. Doc review found that the `projectInvalidationKeys` map in `packages/frontend/src/lib/event-routing.ts` already invalidates `['dashboard-stats']` on `agent_status`, `campaign_status`, `task_update`, and `crack_result` — adding a new event type would have produced redundant double-invalidations at every publisher site with no behavioral payoff. Future endpoint authors must not repeat this mistake. If the publisher-coupling concern grows enough that the routing map becomes hard to maintain, take it as a separate refactor — not as a per-endpoint pattern.
 
 ## Compile-time vs. runtime enforcement boundary
 

--- a/docs/solutions/conventions/pre-prod-wire-rename-and-schema-version-bump.md
+++ b/docs/solutions/conventions/pre-prod-wire-rename-and-schema-version-bump.md
@@ -68,8 +68,10 @@ The rename touches every corner of the contract atomically. (As of 2026-06-01 th
 export const HEALTH_VERSION = '2.0.0'
 ```
 
+> **Historical note (route-as-spec migration, ADR-0013):** the `packages/openapi/` directory and its hand-maintained `*-api.yaml` files no longer exist. The changelog snippet below reflects PR #171's pre-migration state — today the equivalent changelog lives in the TS JSDoc above the version constant (see the `HEALTH_VERSION` block above) and, when surfaced on the wire, in the route's `createRoute(...)` `description`.
+
 ```yaml
-# packages/openapi/control-api.yaml
+# packages/openapi/control-api.yaml (retired — see historical note above)
 info:
   description: |
     ## Changelog
@@ -169,4 +171,4 @@ Audit your "everything has the old name" intuition. Some literals — opaque cre
 - [`shared-zod-openapi-wire-contract-mirror-2026-05-25.md`](shared-zod-openapi-wire-contract-mirror-2026-05-25.md) — the triple-sync pattern this rename followed (Zod schema + OpenAPI spec + route handler + contract test).
 - **PR #153** — first half of the swap; preserved `minio` as wire identifier defensively.
 - **PR #171** — second half; dropped the placeholder, bumped `HEALTH_VERSION` to 2.0.0.
-- **AGENTS.md** — "Wire shapes live in `@hashhive/shared`" and "Keep the OpenAPI spec in sync with shared types."
+- **AGENTS.md** — "Wire shapes live in `@hashhive/shared` as `z.infer` from Zod schemas" and "All three surfaces are route-as-spec via `@hono/zod-openapi` ... there is no separate YAML to keep in sync, and there is no `packages/openapi/` directory."

--- a/docs/solutions/conventions/shared-zod-openapi-wire-contract-mirror-2026-05-25.md
+++ b/docs/solutions/conventions/shared-zod-openapi-wire-contract-mirror-2026-05-25.md
@@ -164,7 +164,7 @@ The matrix lives in the PR's `docs/issues/<n>-ac-traceability-matrix.md` so revi
 
 ## Related
 
-- **AGENTS.md** — "Wire shapes live in `@hashhive/shared` as `z.infer` from Zod schemas" and "Keep the OpenAPI spec in sync with shared types."
+- **AGENTS.md (text as of 2026-05-25, since revised)** — "Wire shapes live in `@hashhive/shared` as `z.infer` from Zod schemas" and "Keep the OpenAPI spec in sync with shared types." The second clause no longer reflects current guidance: post route-as-spec migration (ADR-0013), AGENTS.md states there is no separate YAML to keep in sync. The first clause still holds.
 - **PR #169** — first PR to land this triple-sync pattern; closed issue #155.
 - **Issue #170** — follow-up for the heartbeat error envelope (separate pattern: error-envelope per-surface, not response-shape mirror).
 - `docs/solutions/conventions/form-submit-payload-null-checks-2026-05-19.md` — sibling convention on explicit checks across the wire boundary.

--- a/docs/solutions/integration-issues/bullmq-jobid-dedup-requires-eviction.md
+++ b/docs/solutions/integration-issues/bullmq-jobid-dedup-requires-eviction.md
@@ -47,13 +47,19 @@ await queue.add(queueName, data, {
   ...(opts?.priority ? { priority: opts.priority } : {}),
   // CRITICAL: a deduped job MUST evict its id on terminal, else the first
   // run permanently blocks every future re-add of the same jobId.
-  ...(opts?.jobId ? { jobId: opts.jobId, removeOnComplete: true, removeOnFail: true } : {}),
+  ...(opts?.jobId
+    ? {
+        jobId: opts.jobId,
+        removeOnComplete: opts.removeOnComplete ?? true,
+        removeOnFail: opts.removeOnFail ?? true,
+      }
+    : {}),
   attempts: DEFAULT_JOB_ATTEMPTS,
   backoff: { type: 'exponential', delay: 5_000 },
 })
 ```
 
-Coupling the two (jobId implies eviction) at the manager level means no individual caller can forget it.
+Coupling the two (jobId implies eviction) at the manager level means no individual caller can forget it. The `?? true` default keeps immediate eviction as the safe baseline while leaving an override escape hatch: a caller that needs to read a terminal job's `returnvalue`/`failedReason` before it disappears (e.g. status-polling an outcome that leaves no other row to read, issue #202 SU7) can pass `removeOnComplete: { age: <seconds> }`. See the override test in `packages/backend/tests/unit/queue-manager.test.ts`.
 
 ## Why This Works
 

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -575,7 +575,7 @@ export const agentHeartbeatSchema = z.object({
  * directly into its `createRoute(...)` definition, so the generated
  * OpenAPI document (served at `GET /api/v1/agent/openapi.json`) reflects
  * this shape automatically — there is no separate YAML to keep in sync.
- * The contract test in `tests/unit/agent-api-contract.test.ts` parses real
+ * The contract test in `packages/backend/tests/unit/agent-api-contract.test.ts` parses real
  * route responses through this schema to prove the route response matches
  * the shared shape. `.strict()` rejects unknown keys at parse time (Zod
  * otherwise strips them) and emits an explicitly closed object

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -571,12 +571,14 @@ export const agentHeartbeatSchema = z.object({
  * available — agents must treat absence as "no priority signal" rather
  * than receive an explicit negative.
  *
- * This is the shared wire contract; the OpenAPI spec at
- * `packages/openapi/agent-api.yaml` mirrors this shape, and the contract
- * test in `tests/unit/agent-api-contract.test.ts` parses real route
- * responses through this schema to prove the route ↔ shared ↔ OpenAPI
- * triple stays in sync. `.strict()` matches the OpenAPI default of
- * closed objects — extra fields fail parse rather than slip through.
+ * This is the shared wire contract; the agent route binds this schema
+ * directly into its `createRoute(...)` definition, so the generated
+ * OpenAPI document (served at `GET /api/v1/agent/openapi.json`) reflects
+ * this shape automatically — there is no separate YAML to keep in sync.
+ * The contract test in `tests/unit/agent-api-contract.test.ts` parses real
+ * route responses through this schema to prove the route response matches
+ * the shared shape. `.strict()` matches the OpenAPI default of closed
+ * objects — extra fields fail parse rather than slip through.
  */
 export const agentHeartbeatResponseSchema = z
   .object({

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -577,8 +577,10 @@ export const agentHeartbeatSchema = z.object({
  * this shape automatically — there is no separate YAML to keep in sync.
  * The contract test in `tests/unit/agent-api-contract.test.ts` parses real
  * route responses through this schema to prove the route response matches
- * the shared shape. `.strict()` matches the OpenAPI default of closed
- * objects — extra fields fail parse rather than slip through.
+ * the shared shape. `.strict()` rejects unknown keys at parse time (Zod
+ * otherwise strips them) and emits an explicitly closed object
+ * (`additionalProperties: false`) into the generated spec — OpenAPI
+ * objects are open by default, so this closure is deliberate, not inherited.
  */
 export const agentHeartbeatResponseSchema = z
   .object({


### PR DESCRIPTION
## Summary

A full compound-refresh sweep of `docs/solutions/` (19 learnings reviewed; **14 kept, 5 updated**). No consolidations, replacements, or deletions were warranted — every cross-doc overlap resolved to a valid retrieval-value distinction, and there were no contradictions.

The updates fix reference drift that had made a few docs **actively misleading** after the route-as-spec migration (ADR-0013) removed `packages/openapi/` and the hand-maintained `*-api.yaml` files.

## What changed

- **`pre-prod-wire-rename-and-schema-version-bump.md`** — added a historical caveat before the retired `packages/openapi/control-api.yaml` snippet; corrected a quoted-as-live AGENTS.md directive ("Keep the OpenAPI spec in sync") to the current route-as-spec text.
- **`dashboard-read-endpoint-contract.md`** — de-pinned drifted `event-routing.ts:73-84` line refs to the named `projectInvalidationKeys` map (line numbers there demonstrably re-drift).
- **`bun-test-mock-module-import-order.md`** — its worked-example file `dashboard-api-contract.test.ts` was deleted in #188; noted the deletion and pointed to the successor `routes/projects-select-preference.test.ts`; de-pinned a drifted `GOTCHAS.md` line ref.
- **`barrel-plus-subdir-service-split.md`** — refreshed a stale LOC count and a "Final tree" that listed 4 of the current 8 `tasks/` submodules; reframed as the U9-split snapshot plus an accretion note.
- **`bullmq-jobid-dedup-requires-eviction.md`** — snippet now reflects the `opts.removeOnComplete ?? true` override and the `{ age: <seconds> }` escape hatch (#202 SU7).
- **`shared-zod-openapi-wire-contract-mirror-2026-05-25.md`** (already `superseded`) — marked the same stale AGENTS.md quote as historical rather than delete the heavily cross-linked doc.
- **`packages/shared/src/schemas/index.ts`** — corrected a stale doc comment that still referenced the removed `packages/openapi/agent-api.yaml`.

All claims were verified against current source (`manager.ts`, `event-routing.ts`, the `tasks/` directory, deleted/renamed test files) before editing.

## Test plan

- [x] `just check` passes (format, lint, type-check, build)
- [ ] Docs render correctly on GitHub

Tooling: drafted with Claude Code (Opus 4.8) under human review.